### PR TITLE
Reflect the repo transfer in federation rules.

### DIFF
--- a/iac/bootstrap/main.tf
+++ b/iac/bootstrap/main.tf
@@ -54,7 +54,7 @@ resource "google_service_account_iam_binding" "allow_github_impersonation" {
   role               = "roles/iam.workloadIdentityUser"
 
   members = [
-    "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github_pool.name}/attribute.sub/repo:mattmoor/octo-sts:ref:refs/heads/main",
+    "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github_pool.name}/attribute.sub/repo:chainguard-dev/octo-sts:ref:refs/heads/main",
   ]
 }
 


### PR DESCRIPTION
This is already applied.

Fixes: https://github.com/chainguard-dev/octo-sts/issues/26