### PR TITLE
update go version definition in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/chainguard-dev/octo-sts
 
-go 1.21.2
-
-toolchain go1.21.6
+go 1.21.6
 
 require (
 	chainguard.dev/go-grpc-kit v0.17.2


### PR DESCRIPTION
Our ci jobs are using `go-version-file: './go.mod'` to set the go version to use, and that is point to go `1.21.2` which is not the latest.

from on latest ci execution: `Attempting to download 1.21.2...` - https://github.com/chainguard-dev/octo-sts/actions/runs/7623790868/job/20764546026

this will make to the latest available