### PR TITLE
Add a missing call to audit alert policy

### DIFF
--- a/iac/main.tf
+++ b/iac/main.tf
@@ -156,7 +156,7 @@ resource "google_monitoring_alert_policy" "anomalous-kms-access" {
       -- Github IaC should only reconcile the keyring and keys.
       -(
         protoPayload.authenticationInfo.principalEmail="${data.google_client_openid_userinfo.me.email}" AND
-        protoPayload.methodName=("CreateKeyRing" OR "CreateCryptoKey" OR "SetIamPolicy")
+        protoPayload.methodName=("CreateKeyRing" OR "CreateCryptoKey" OR "GetCryptoKey" OR "SetIamPolicy")
       )
 
       -- If we were to filter out import events they would look like


### PR DESCRIPTION
The alert policy is currently firing: https://console.cloud.google.com/monitoring/alerting/policies/3908022799698009840?project=octo-sts