### PR TITLE
Give the prober some substance.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/google/go-github/v58 v58.0.0
 	github.com/hashicorp/golang-lru v1.0.2
 	github.com/kelseyhightower/envconfig v1.4.0
+	golang.org/x/oauth2 v0.16.0
 	google.golang.org/api v0.161.0
 	google.golang.org/grpc v1.61.0
 	knative.dev/pkg v0.0.0-20231101193506-b09d4f2a2845
@@ -67,7 +68,6 @@ require (
 	go.uber.org/zap v1.26.0 // indirect
 	golang.org/x/crypto v0.18.0 // indirect
 	golang.org/x/net v0.20.0 // indirect
-	golang.org/x/oauth2 v0.16.0 // indirect
 	golang.org/x/sync v0.6.0 // indirect
 	golang.org/x/sys v0.16.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/pkg/prober/prober.go
+++ b/pkg/prober/prober.go
@@ -7,10 +7,62 @@ package prober
 
 import (
 	"context"
-	"log"
+	"fmt"
+
+	"chainguard.dev/sdk/sts"
+	"github.com/google/go-github/v58/github"
+	"golang.org/x/oauth2"
+	"google.golang.org/api/idtoken"
 )
 
 func Func(ctx context.Context) error {
-	log.Print("Got a probe!")
+	xchg := sts.New(
+		"https://octo-sts.dev",
+		"does-not-matter",
+		sts.WithScope("chainguard-dev/octo-sts-prober"),
+		sts.WithIdentity("prober"),
+	)
+
+	ts, err := idtoken.NewTokenSource(ctx, "octo-sts.dev" /* aud */)
+	if err != nil {
+		return fmt.Errorf("failed to get new gcp token source %w", err)
+	}
+
+	token, err := ts.Token()
+	if err != nil {
+		return fmt.Errorf("failed to get new gcp token: %w", err)
+	}
+
+	res, err := xchg.Exchange(ctx, token.AccessToken)
+	if err != nil {
+		return fmt.Errorf("exchange failed: %w", err)
+	}
+
+	ghc := github.NewClient(
+		oauth2.NewClient(ctx,
+			oauth2.StaticTokenSource(&oauth2.Token{
+				AccessToken: res,
+			}),
+		),
+	)
+
+	// Check the `contents: read` permission by reading back the STS policy we
+	// used to federate.
+	file, _, _, err := ghc.Repositories.GetContents(ctx,
+		"chainguard-dev", "octo-sts-prober",
+		".github/chainguard/prober.sts.yaml",
+		&github.RepositoryContentGetOptions{ /* defaults to the default branch */ },
+	)
+	if err != nil {
+		return fmt.Errorf("failed to read back STS policy: %w", err)
+	}
+	if _, err := file.GetContent(); err != nil {
+		return fmt.Errorf("failed to read file contents: %w", err)
+	}
+
+	// TODO(mattmoor): List issues
+
+	// TODO(mattmoor): List pull requests
+
 	return nil
 }


### PR DESCRIPTION
This exercises the `contents: read` permission in the `octo-sts-prober` repo.