### PR TITLE
Add explicit email claim for now

### DIFF
--- a/iac/sts_exchange.schema.json
+++ b/iac/sts_exchange.schema.json
@@ -68,6 +68,11 @@
                 "type": "STRING",
                 "mode": "NULLABLE"
             }
+            {
+                "name": "email",
+                "type": "STRING",
+                "mode": "NULLABLE"
+            }
           ]
         },
         {


### PR DESCRIPTION
The DTS job is failing with this:
```
bq show -j 96355665038:bqts_65c08012-0000-2d17-a0bc-582429af2a14
/Users/mattmoor/google-cloud-sdk/platform/bq/bq.py:18: DeprecationWarning: 'pipes' is deprecated and slated for removal in Python 3.13
  import pipes
Job 96355665038:bqts_65c08012-0000-2d17-a0bc-582429af2a14

  Job Type    State      Start Time         Duration                                    User Email                                  Bytes Processed   Bytes Billed   Billing Tier                       Labels                       
 ---------- --------- ----------------- ---------------- ------------------------------------------------------------------------- ----------------- -------------- -------------- ------------------------------------------------- 
  load       FAILURE   04 Feb 16:37:01   0:00:04.462000   service-96355665038@gcp-sa-bigquerydatatransfer.iam.gserviceaccount.com                                                   dts_run_id:65c42b6a-0000-21e2-a64a-94eb2c05a94c  
                                                                                                                                                                                    data_source_id:google_cloud_storage              

Error encountered during job execution:
Error while reading data, error message: JSON table encountered too many errors, giving up. Rows: 1; errors: 1. Please look into the errors[] collection for more details. File: gs://octo-sts-recorder-us-central1-92d6/dev.octo-sts.exchange/1707083466585176188
Failure details:
 - Error while reading data, error message: JSON processing
   encountered too many errors, giving up. Rows: 1; errors: 1; max
   bad: 0; error percent: 0
 - gs://octo-sts-recorder-us-central1-92d6/dev.octo-
   sts.exchange/1707083466585176188: Error while reading data, error
   message: JSON parsing error in row starting at position 0: No such
   field: trust_policy.claim_pattern.email. File: gs://octo-sts-
   recorder-us-central1-92d6/dev.octo-sts.exchange/1707083466585176188
```

Note this part: `JSON parsing error in row starting at position 0: No such field: trust_policy.claim_pattern.email`