### PR TITLE
Add token revocation several places.

### DIFF
--- a/pkg/octosts/octosts.go
+++ b/pkg/octosts/octosts.go
@@ -230,6 +230,18 @@ func (s *sts) lookupTrustPolicy(ctx context.Context, install int64, owner, repo,
 			Contents: ptr("read"),
 		},
 	}
+	// Once we have looked up the trust policy we should revoke the token.
+	defer func() {
+		tok, err := atr.Token(ctx)
+		if err != nil {
+			clog.WarnContextf(ctx, "failed to get token for revocation: %v", err)
+			return
+		}
+		if err := Revoke(ctx, tok); err != nil {
+			clog.WarnContextf(ctx, "failed to revoke token: %v", err)
+			return
+		}
+	}()
 
 	client := github.NewClient(&http.Client{
 		Transport: atr,

--- a/pkg/octosts/revoke.go
+++ b/pkg/octosts/revoke.go
@@ -1,0 +1,32 @@
+// Copyright 2024 Chainguard, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package octosts
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// Revoke revokes a security token.
+func Revoke(ctx context.Context, tok string) error {
+	req, err := http.NewRequest(http.MethodDelete, "https://api.github.com/installation/token", nil)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	req = req.WithContext(ctx)
+	req.Header.Add("Authorization", "Bearer "+tok)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("making request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	// The token was revoked!
+	return nil
+}

--- a/pkg/prober/prober.go
+++ b/pkg/prober/prober.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 
 	"chainguard.dev/sdk/sts"
+	"github.com/chainguard-dev/clog"
+	"github.com/chainguard-dev/octo-sts/pkg/octosts"
 	"github.com/google/go-github/v58/github"
 	"golang.org/x/oauth2"
 	"google.golang.org/api/idtoken"
@@ -37,6 +39,11 @@ func Func(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("exchange failed: %w", err)
 	}
+	defer func() {
+		if err := octosts.Revoke(ctx, res); err != nil {
+			clog.WarnContextf(ctx, "failed to revoke token: %v", err)
+		}
+	}()
 
 	ghc := github.NewClient(
 		oauth2.NewClient(ctx,


### PR DESCRIPTION
This adds a method to perform token revocation mirroring what Jason did in the action.

This calls that method from the new prober, and in Octo STS itself where it creates a token for looking up the trust policy (not what it hands back to the user).

Fixes: https://github.com/chainguard-dev/octo-sts/issues/61