### PR TITLE
add rate limit for requests

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -12,13 +12,8 @@ import (
 	"os/signal"
 	"strings"
 
-	"chainguard.dev/go-grpc-kit/pkg/duplex"
-	pboidc "chainguard.dev/sdk/proto/platform/oidc/v1"
 	kms "cloud.google.com/go/kms/apiv1"
 	"github.com/bradleyfalzon/ghinstallation/v2"
-	"github.com/chainguard-dev/clog"
-	"github.com/chainguard-dev/octo-sts/pkg/gcpkms"
-	"github.com/chainguard-dev/octo-sts/pkg/octosts"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
 	"github.com/kelseyhightower/envconfig"
@@ -26,6 +21,12 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"knative.dev/pkg/logging"
+
+	"chainguard.dev/go-grpc-kit/pkg/duplex"
+	pboidc "chainguard.dev/sdk/proto/platform/oidc/v1"
+	"github.com/chainguard-dev/clog"
+	"github.com/chainguard-dev/octo-sts/pkg/gcpkms"
+	"github.com/chainguard-dev/octo-sts/pkg/octosts"
 )
 
 type envConfig struct {

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/kelseyhightower/envconfig v1.4.0
 	golang.org/x/oauth2 v0.17.0
+	golang.org/x/time v0.5.0
 	google.golang.org/api v0.164.0
 	google.golang.org/grpc v1.61.0
 	knative.dev/pkg v0.0.0-20231101193506-b09d4f2a2845
@@ -71,7 +72,6 @@ require (
 	golang.org/x/sync v0.6.0 // indirect
 	golang.org/x/sys v0.17.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
-	golang.org/x/time v0.5.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto v0.0.0-20240125205218-1f4bbc51befe // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240205150955-31a09d347014 // indirect

--- a/pkg/http/rate.go
+++ b/pkg/http/rate.go
@@ -1,0 +1,72 @@
+// Copyright 2024 Chainguard, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package http
+
+import (
+	"context"
+	"net/http"
+
+	"golang.org/x/time/rate"
+)
+
+// RLHTTPClient Rate Limited HTTP Client
+type RLHTTPClient struct {
+	Client      *http.Client
+	Ratelimiter *rate.Limiter
+}
+
+// Do dispatches the HTTP request to the network
+func (c *RLHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	// Comment out the below 5 lines to turn off ratelimiting
+	ctx := context.Background()
+	err := c.Ratelimiter.Wait(ctx) // This is a blocking call. Honors the rate limit
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// NewClient return rate_limitted_http client with a ratelimiter
+func NewClient(rl *rate.Limiter) *RLHTTPClient {
+	c := &RLHTTPClient{
+		Client:      http.DefaultClient,
+		Ratelimiter: rl,
+	}
+	return c
+}
+
+// RateLimitingRoundTripper is a custom RoundTripper that enforces rate limits
+type RateLimitingRoundTripper struct {
+	transport http.RoundTripper
+	limiter   *rate.Limiter
+}
+
+// RoundTrip is the method that gets called for each HTTP request
+func (r *RateLimitingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	ctx := req.Context()
+
+	// Wait blocks until limiter allows another event
+	if err := r.limiter.Wait(ctx); err != nil {
+		// handle error: could be context cancellation
+		return nil, err
+	}
+
+	// Proceed with the request
+	return r.transport.RoundTrip(req)
+}
+
+// NewRateLimitingRoundTripper creates a new instance of RateLimitingRoundTripper
+func NewRateLimitingRoundTripper(limiter *rate.Limiter, transport http.RoundTripper) *RateLimitingRoundTripper {
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	return &RateLimitingRoundTripper{
+		transport: transport,
+		limiter:   limiter,
+	}
+}


### PR DESCRIPTION
similar code that we use in https://github.com/chainguard-dev/infra-images/blob/4f3ddec4f10e5b3ec51522276d8c0e89cadc5b58/insights/producers/pkg/version_stream_bot/bot.go#L58


saw in the logs this morning

```
2024/02/09 07:59:59 INFO failed to find trust policy: GET https://api.github.com/repos/chainguard-dev/.github/contents/.github/chainguard/lifecycle-automation.sts.yaml: 403 API rate limit exceeded for installation ID 46439214. If you reach out to GitHub Support for help, please include the request ID A767:732D:A5C3E:1504A4:65C5DB7F. [rate reset in 5m06s]
```

mark as draft for discussion