### PR TITLE
Compute the SHA256 of the resulting token and record in event.

### DIFF
--- a/iac/sts_exchange.schema.json
+++ b/iac/sts_exchange.schema.json
@@ -295,6 +295,11 @@
         "mode": "NULLABLE"
     },
     {
+        "name": "token_sha256",
+        "type": "STRING",
+        "mode": "NULLABLE"
+    },
+    {
         "name": "error",
         "type": "STRING",
         "mode": "NULLABLE"

--- a/pkg/octosts/event.go
+++ b/pkg/octosts/event.go
@@ -9,6 +9,7 @@ type Event struct {
 	InstallationID int64           `json:"installation_id"`
 	Scope          string          `json:"scope"`
 	Identity       string          `json:"identity"`
+	TokenSHA256    string          `json:"token_sha256"`
 	Error          string          `json:"error,omitempty"`
 }
 

--- a/pkg/octosts/octosts.go
+++ b/pkg/octosts/octosts.go
@@ -5,6 +5,8 @@ package octosts
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -168,6 +170,11 @@ func (s *sts) Exchange(ctx context.Context, request *pboidc.ExchangeRequest) (_ 
 		}
 		return nil, status.Errorf(codes.Internal, "failed to get token: %v", err)
 	}
+
+	// Compute the SHA256 hash of the token and store the hex-encoded value into e.TokenSHA256
+	hash := sha256.Sum256([]byte(token))
+	e.TokenSHA256 = hex.EncodeToString(hash[:])
+
 	return &pboidc.RawToken{
 		Token: token,
 	}, nil


### PR DESCRIPTION
This computes the SHA256 of the issued token, which will then be recorded into BigQuery.

I plan to make an analogous change to `octo-sts-action` (compute and log the sha256) which will let us associate STS exchanges with particular actions runs.