### PR TITLE
Switch to using regional-service as a precursor to broader refactoring

### DIFF
--- a/iac/backend.tf
+++ b/iac/backend.tf
@@ -4,6 +4,7 @@ terraform {
     prefix = "/octo-sts"
   }
   required_providers {
-    ko = { source = "ko-build/ko" }
+    ko     = { source = "ko-build/ko" }
+    cosign = { source = "chainguard-dev/cosign" }
   }
 }


### PR DESCRIPTION
After this, I plan to push most of the logic into a module that we invoke from the iac directory, which takes an image (and defaults to `chainguard/octo-sts:latest`.