### PR TITLE
feat: allow flexible options for github app secret and metrics

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -41,9 +41,14 @@ func main() {
 		defer metrics.SetupTracer(ctx)()
 	}
 
-	client, err := kms.NewKeyManagementClient(ctx)
-	if err != nil {
-		log.Panicf("could not create kms client: %v", err)
+	var client *kms.KeyManagementClient
+	var err error
+
+	if env.KMSKey != "" {
+		client, err = kms.NewKeyManagementClient(ctx)
+		if err != nil {
+			log.Panicf("could not create kms client: %v", err)
+		}
 	}
 
 	atr, err := ghtransport.New(ctx, env, client)

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -7,45 +7,38 @@ import (
 	"context"
 	"log"
 	"log/slog"
-	"net/http"
 	"os"
 	"os/signal"
 
 	"chainguard.dev/go-grpc-kit/pkg/duplex"
 	pboidc "chainguard.dev/sdk/proto/platform/oidc/v1"
 	kms "cloud.google.com/go/kms/apiv1"
-	"github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/chainguard-dev/clog"
 	metrics "github.com/chainguard-dev/terraform-infra-common/pkg/httpmetrics"
 	mce "github.com/chainguard-dev/terraform-infra-common/pkg/httpmetrics/cloudevents"
 	"github.com/kelseyhightower/envconfig"
-	"github.com/octo-sts/app/pkg/gcpkms"
+	envConfig "github.com/octo-sts/app/pkg/envconfig"
+	"github.com/octo-sts/app/pkg/ghtransport"
 	"github.com/octo-sts/app/pkg/octosts"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
-
-type envConfig struct {
-	Port            int    `envconfig:"PORT" required:"true"`
-	Domain          string `envconfig:"STS_DOMAIN" required:"true"`
-	KMSKey          string `envconfig:"KMS_KEY" required:"true"`
-	AppID           int64  `envconfig:"GITHUB_APP_ID" required:"true"`
-	EventingIngress string `envconfig:"EVENT_INGRESS_URI" required:"true"`
-}
 
 func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 	ctx = clog.WithLogger(ctx, clog.New(slog.Default().Handler()))
 
-	go metrics.ServeMetrics()
-
-	// Setup tracing.
-	defer metrics.SetupTracer(ctx)()
-
-	var env envConfig
+	var env envConfig.EnvConfig
 	if err := envconfig.Process("", &env); err != nil {
 		log.Panicf("failed to process env var: %s", err)
+	}
+
+	if env.Metrics == "default" {
+		go metrics.ServeMetrics()
+
+		// Setup tracing.
+		defer metrics.SetupTracer(ctx)()
 	}
 
 	client, err := kms.NewKeyManagementClient(ctx)
@@ -53,12 +46,7 @@ func main() {
 		log.Panicf("could not create kms client: %v", err)
 	}
 
-	signer, err := gcpkms.New(ctx, client, env.KMSKey)
-	if err != nil {
-		log.Panicf("error creating signer: %v", err)
-	}
-
-	atr, err := ghinstallation.NewAppsTransportWithOptions(http.DefaultTransport, env.AppID, ghinstallation.WithSigner(signer))
+	atr, err := ghtransport.New(ctx, env, client)
 	if err != nil {
 		log.Panicf("error creating GitHub App transport: %v", err)
 	}
@@ -76,7 +64,7 @@ func main() {
 		log.Panicf("failed to create cloudevents client: %v", err)
 	}
 
-	pboidc.RegisterSecurityTokenServiceServer(d.Server, octosts.NewSecurityTokenServiceServer(atr, ceclient, env.Domain))
+	pboidc.RegisterSecurityTokenServiceServer(d.Server, octosts.NewSecurityTokenServiceServer(atr, ceclient, env.Domain, env.Metrics))
 	if err := d.RegisterHandler(ctx, pboidc.RegisterSecurityTokenServiceHandlerFromEndpoint); err != nil {
 		log.Panicf("failed to register gateway endpoint: %v", err)
 	}

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -34,7 +34,7 @@ func main() {
 		log.Panicf("failed to process env var: %s", err)
 	}
 
-	if env.Metrics == "default" {
+	if env.Metrics {
 		go metrics.ServeMetrics()
 
 		// Setup tracing.

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -16,7 +16,6 @@ import (
 	"github.com/chainguard-dev/clog"
 	metrics "github.com/chainguard-dev/terraform-infra-common/pkg/httpmetrics"
 	mce "github.com/chainguard-dev/terraform-infra-common/pkg/httpmetrics/cloudevents"
-	"github.com/kelseyhightower/envconfig"
 	envConfig "github.com/octo-sts/app/pkg/envconfig"
 	"github.com/octo-sts/app/pkg/ghtransport"
 	"github.com/octo-sts/app/pkg/octosts"
@@ -29,8 +28,8 @@ func main() {
 	defer cancel()
 	ctx = clog.WithLogger(ctx, clog.New(slog.Default().Handler()))
 
-	var env envConfig.EnvConfig
-	if err := envconfig.Process("", &env); err != nil {
+	env, err := envConfig.Process()
+	if err != nil {
 		log.Panicf("failed to process env var: %s", err)
 	}
 
@@ -42,7 +41,6 @@ func main() {
 	}
 
 	var client *kms.KeyManagementClient
-	var err error
 
 	if env.KMSKey != "" {
 		client, err = kms.NewKeyManagementClient(ctx)

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,12 @@ require (
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)
+
+require (
 	cloud.google.com/go/auth v0.2.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.0 // indirect
 	cloud.google.com/go/compute/metadata v0.3.0 // indirect
@@ -56,6 +62,7 @@ require (
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
+	github.com/stretchr/testify v1.9.0
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.50.0 // indirect

--- a/pkg/envconfig/envconfig.go
+++ b/pkg/envconfig/envconfig.go
@@ -8,5 +8,5 @@ type EnvConfig struct {
 	EventingIngress            string `envconfig:"EVENT_INGRESS_URI" required:"true"`
 	AppSecretCertificateFile   string `envconfig:"APP_SECRET_CERTIFICATE_FILE" required:"false"`
 	AppSecretCertificateEnvVar string `envconfig:"APP_SECRET_CERTIFICATE_ENV_VAR" required:"false"`
-	Metrics                    string `envconfig:"METRICS" required:"false" default:"default"`
+	Metrics                    bool   `envconfig:"METRICS" required:"false" default:"true"`
 }

--- a/pkg/envconfig/envconfig.go
+++ b/pkg/envconfig/envconfig.go
@@ -1,0 +1,12 @@
+package envconfig
+
+type EnvConfig struct {
+	Port                       int    `envconfig:"PORT" required:"true"`
+	Domain                     string `envconfig:"STS_DOMAIN" required:"true"`
+	KMSKey                     string `envconfig:"KMS_KEY" required:"false"`
+	AppID                      int64  `envconfig:"GITHUB_APP_ID" required:"true"`
+	EventingIngress            string `envconfig:"EVENT_INGRESS_URI" required:"true"`
+	AppSecretCertificateFile   string `envconfig:"APP_SECRET_CERTIFICATE_FILE" required:"false"`
+	AppSecretCertificateEnvVar string `envconfig:"APP_SECRET_CERTIFICATE_ENV_VAR" required:"false"`
+	Metrics                    string `envconfig:"METRICS" required:"false" default:"default"`
+}

--- a/pkg/envconfig/envconfig.go
+++ b/pkg/envconfig/envconfig.go
@@ -1,3 +1,6 @@
+// Copyright 2024 Chainguard, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package envconfig
 
 import (

--- a/pkg/envconfig/envconfig_test.go
+++ b/pkg/envconfig/envconfig_test.go
@@ -1,0 +1,99 @@
+package envconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcess(t *testing.T) {
+	tests := []struct {
+		name    string
+		envVars map[string]string
+		wantErr bool
+	}{
+		{
+			name: "No environment variables set",
+			envVars: map[string]string{
+				"PORT":                          "8080",
+				"STS_DOMAIN":                    "",
+				"GITHUB_APP_ID":                 "1234",
+				"EVENT_INGRESS_URI":             "",
+				"KMS_KEY":                       "",
+				"APP_SECRET_CERTIFICATE_FILE":   "",
+				"APP_SECRET_CERTIFICATE_ENVVAR": "",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Only KMS_KEY set",
+			envVars: map[string]string{
+				"PORT":                          "8080",
+				"STS_DOMAIN":                    "",
+				"GITHUB_APP_ID":                 "1234",
+				"EVENT_INGRESS_URI":             "",
+				"KMS_KEY":                       "some-kms-key",
+				"APP_SECRET_CERTIFICATE_FILE":   "",
+				"APP_SECRET_CERTIFICATE_ENVVAR": "",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Only APP_SECRET_CERTIFICATE_FILE set",
+			envVars: map[string]string{
+				"PORT":                          "8080",
+				"STS_DOMAIN":                    "",
+				"GITHUB_APP_ID":                 "1234",
+				"EVENT_INGRESS_URI":             "",
+				"KMS_KEY":                       "",
+				"APP_SECRET_CERTIFICATE_FILE":   "some-file-path",
+				"APP_SECRET_CERTIFICATE_ENVVAR": "",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Only APP_SECRET_CERTIFICATE_ENVVAR set",
+			envVars: map[string]string{
+				"PORT":                          "8080",
+				"STS_DOMAIN":                    "",
+				"GITHUB_APP_ID":                 "1234",
+				"EVENT_INGRESS_URI":             "",
+				"KMS_KEY":                       "",
+				"APP_SECRET_CERTIFICATE_FILE":   "",
+				"APP_SECRET_CERTIFICATE_ENVVAR": "some-env-var",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Multiple variables set",
+			envVars: map[string]string{
+				"PORT":                          "8080",
+				"STS_DOMAIN":                    "",
+				"GITHUB_APP_ID":                 "1234",
+				"EVENT_INGRESS_URI":             "",
+				"KMS_KEY":                       "some-kms-key",
+				"APP_SECRET_CERTIFICATE_FILE":   "some-file-path",
+				"APP_SECRET_CERTIFICATE_ENVVAR": "",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for key, value := range tt.envVars {
+				t.Setenv(key, value)
+			}
+
+			cfg, err := Process()
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, cfg)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, cfg)
+			}
+		})
+	}
+}

--- a/pkg/envconfig/envconfig_test.go
+++ b/pkg/envconfig/envconfig_test.go
@@ -1,3 +1,6 @@
+// Copyright 2024 Chainguard, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package envconfig
 
 import (

--- a/pkg/ghtransport/ghtransport.go
+++ b/pkg/ghtransport/ghtransport.go
@@ -33,12 +33,12 @@ func New(ctx context.Context, env *envConfig.EnvConfig, kmsClient *kms.KeyManage
 		return atr, nil
 	default:
 		if env.KMSKey == "" {
-			log.Panicf("failed to process env var: %s", env.KMSKey)
+			return nil, fmt.Errorf("failed to process env var: %q", env.KMSKey)
 		}
 
 		signer, err := gcpkms.New(ctx, kmsClient, env.KMSKey)
 		if err != nil {
-			log.Panicf("error creating signer: %v", err)
+			return nil, fmt.Errorf("error creating signer: %w", err)
 		}
 
 		atr, err := ghinstallation.NewAppsTransportWithOptions(http.DefaultTransport, env.AppID, ghinstallation.WithSigner(signer))

--- a/pkg/ghtransport/ghtransport.go
+++ b/pkg/ghtransport/ghtransport.go
@@ -5,7 +5,7 @@ package ghtransport
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"net/http"
 
 	kms "cloud.google.com/go/kms/apiv1"

--- a/pkg/ghtransport/ghtransport.go
+++ b/pkg/ghtransport/ghtransport.go
@@ -12,7 +12,8 @@ import (
 )
 
 func New(ctx context.Context, env *envConfig.EnvConfig, kmsClient *kms.KeyManagementClient) (*ghinstallation.AppsTransport, error) {
-	if env.AppSecretCertificateEnvVar != "" {
+	switch {
+	case env.AppSecretCertificateEnvVar != "":
 		atr, err := ghinstallation.NewAppsTransport(http.DefaultTransport, env.AppID, []byte(env.AppSecretCertificateEnvVar))
 
 		if err != nil {
@@ -20,14 +21,14 @@ func New(ctx context.Context, env *envConfig.EnvConfig, kmsClient *kms.KeyManage
 		}
 		return atr, nil
 
-	} else if env.AppSecretCertificateFile != "" {
+	case env.AppSecretCertificateFile != "":
 		atr, err := ghinstallation.NewAppsTransportKeyFromFile(http.DefaultTransport, env.AppID, env.AppSecretCertificateFile)
 
 		if err != nil {
 			log.Panicf("error creating GitHub App transport: %v", err)
 		}
 		return atr, nil
-	} else {
+	default:
 		if env.KMSKey == "" {
 			log.Panicf("failed to process env var: %s", env.KMSKey)
 		}

--- a/pkg/ghtransport/ghtransport.go
+++ b/pkg/ghtransport/ghtransport.go
@@ -11,7 +11,7 @@ import (
 	"github.com/octo-sts/app/pkg/gcpkms"
 )
 
-func New(ctx context.Context, env envConfig.EnvConfig, kmsClient *kms.KeyManagementClient) (*ghinstallation.AppsTransport, error) {
+func New(ctx context.Context, env *envConfig.EnvConfig, kmsClient *kms.KeyManagementClient) (*ghinstallation.AppsTransport, error) {
 	if env.AppSecretCertificateEnvVar != "" {
 		atr, err := ghinstallation.NewAppsTransport(http.DefaultTransport, env.AppID, []byte(env.AppSecretCertificateEnvVar))
 

--- a/pkg/ghtransport/ghtransport.go
+++ b/pkg/ghtransport/ghtransport.go
@@ -1,3 +1,6 @@
+// Copyright 2024 Chainguard, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package ghtransport
 
 import (

--- a/pkg/ghtransport/ghtransport.go
+++ b/pkg/ghtransport/ghtransport.go
@@ -1,0 +1,47 @@
+package ghtransport
+
+import (
+	"context"
+	"log"
+	"net/http"
+
+	kms "cloud.google.com/go/kms/apiv1"
+	"github.com/bradleyfalzon/ghinstallation/v2"
+	envConfig "github.com/octo-sts/app/pkg/envconfig"
+	"github.com/octo-sts/app/pkg/gcpkms"
+)
+
+func New(ctx context.Context, env envConfig.EnvConfig, kmsClient *kms.KeyManagementClient) (*ghinstallation.AppsTransport, error) {
+	if env.AppSecretCertificateEnvVar != "" {
+		atr, err := ghinstallation.NewAppsTransport(http.DefaultTransport, env.AppID, []byte(env.AppSecretCertificateEnvVar))
+
+		if err != nil {
+			log.Panicf("error creating GitHub App transport: %v", err)
+		}
+		return atr, nil
+
+	} else if env.AppSecretCertificateFile != "" {
+		atr, err := ghinstallation.NewAppsTransportKeyFromFile(http.DefaultTransport, env.AppID, env.AppSecretCertificateFile)
+
+		if err != nil {
+			log.Panicf("error creating GitHub App transport: %v", err)
+		}
+		return atr, nil
+	} else {
+		if env.KMSKey == "" {
+			log.Panicf("failed to process env var: %s", env.KMSKey)
+		}
+
+		signer, err := gcpkms.New(ctx, kmsClient, env.KMSKey)
+		if err != nil {
+			log.Panicf("error creating signer: %v", err)
+		}
+
+		atr, err := ghinstallation.NewAppsTransportWithOptions(http.DefaultTransport, env.AppID, ghinstallation.WithSigner(signer))
+		if err != nil {
+			log.Panicf("error creating GitHub App transport: %v", err)
+		}
+
+		return atr, nil
+	}
+}

--- a/pkg/ghtransport/ghtransport.go
+++ b/pkg/ghtransport/ghtransport.go
@@ -20,7 +20,7 @@ func New(ctx context.Context, env *envConfig.EnvConfig, kmsClient *kms.KeyManage
 		atr, err := ghinstallation.NewAppsTransport(http.DefaultTransport, env.AppID, []byte(env.AppSecretCertificateEnvVar))
 
 		if err != nil {
-			log.Panicf("error creating GitHub App transport: %v", err)
+			return nil, err
 		}
 		return atr, nil
 
@@ -28,7 +28,7 @@ func New(ctx context.Context, env *envConfig.EnvConfig, kmsClient *kms.KeyManage
 		atr, err := ghinstallation.NewAppsTransportKeyFromFile(http.DefaultTransport, env.AppID, env.AppSecretCertificateFile)
 
 		if err != nil {
-			log.Panicf("error creating GitHub App transport: %v", err)
+			return nil, err
 		}
 		return atr, nil
 	default:
@@ -43,7 +43,7 @@ func New(ctx context.Context, env *envConfig.EnvConfig, kmsClient *kms.KeyManage
 
 		atr, err := ghinstallation.NewAppsTransportWithOptions(http.DefaultTransport, env.AppID, ghinstallation.WithSigner(signer))
 		if err != nil {
-			log.Panicf("error creating GitHub App transport: %v", err)
+			return nil, err
 		}
 
 		return atr, nil

--- a/pkg/ghtransport/ghtransport_test.go
+++ b/pkg/ghtransport/ghtransport_test.go
@@ -159,7 +159,6 @@ func generateTestCertificateFile(t *testing.T) string {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer tmpFile.Close()
 
 	if err := pem.Encode(tmpFile, &privateKeyPEM); err != nil {
 		log.Fatal(err)

--- a/pkg/ghtransport/ghtransport_test.go
+++ b/pkg/ghtransport/ghtransport_test.go
@@ -28,8 +28,7 @@ func TestGCPKMS(t *testing.T) {
 
 	defer os.Remove(credsFile)
 
-	os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", credsFile)
-	defer os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", credsFile)
 
 	testConfig := envconfig.EnvConfig{
 		Port:            8080,

--- a/pkg/ghtransport/ghtransport_test.go
+++ b/pkg/ghtransport/ghtransport_test.go
@@ -26,7 +26,7 @@ func TestGCPKMS(t *testing.T) {
 
 	credsFile := createGCPKMSCredsFile(t)
 
-	// defer os.Remove(credsFile)
+	defer os.Remove(credsFile)
 
 	os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", credsFile)
 	defer os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")

--- a/pkg/ghtransport/ghtransport_test.go
+++ b/pkg/ghtransport/ghtransport_test.go
@@ -30,7 +30,7 @@ func TestGCPKMS(t *testing.T) {
 
 	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", credsFile)
 
-	testConfig := envconfig.EnvConfig{
+	testConfig := &envconfig.EnvConfig{
 		Port:            8080,
 		Domain:          "example.com",
 		AppID:           123456,
@@ -49,7 +49,7 @@ func TestGCPKMS(t *testing.T) {
 func TestCertEnvVar(t *testing.T) {
 	ctx := context.Background()
 
-	testConfig := envconfig.EnvConfig{
+	testConfig := &envconfig.EnvConfig{
 		Port:                       8080,
 		Domain:                     "example.com",
 		AppID:                      123456,
@@ -68,7 +68,7 @@ func TestCertEnvVar(t *testing.T) {
 func TestCertFile(t *testing.T) {
 	ctx := context.Background()
 
-	testConfig := envconfig.EnvConfig{
+	testConfig := &envconfig.EnvConfig{
 		Port:                     8080,
 		Domain:                   "example.com",
 		AppID:                    123456,

--- a/pkg/ghtransport/ghtransport_test.go
+++ b/pkg/ghtransport/ghtransport_test.go
@@ -1,3 +1,6 @@
+// Copyright 2024 Chainguard, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package ghtransport
 
 import (

--- a/pkg/ghtransport/ghtransport_test.go
+++ b/pkg/ghtransport/ghtransport_test.go
@@ -106,7 +106,7 @@ func generateKMSClient(ctx context.Context, t *testing.T) *kms.KeyManagementClie
 
 func createGCPKMSCredsFile(t *testing.T) string {
 
-	tmpFile, err := os.CreateTemp("", "creds-")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "creds-")
 	if err != nil {
 		t.Fatalf("Failed to create temporary file: %s", err)
 	}

--- a/pkg/ghtransport/ghtransport_test.go
+++ b/pkg/ghtransport/ghtransport_test.go
@@ -1,0 +1,158 @@
+package ghtransport
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"testing"
+
+	kms "cloud.google.com/go/kms/apiv1"
+	"github.com/octo-sts/app/pkg/envconfig"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+func TestGCPKMS(t *testing.T) {
+	ctx := context.Background()
+
+	credsFile := createGCPKMSCredsFile(t)
+
+	// defer os.Remove(credsFile)
+
+	os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", credsFile)
+	defer os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
+
+	testConfig := envconfig.EnvConfig{
+		Port:            8080,
+		Domain:          "example.com",
+		AppID:           123456,
+		EventingIngress: "https://event.ingress.uri",
+		KMSKey:          "test-kms-key",
+		Metrics:         "enabled",
+	}
+
+	transport, err := New(ctx, testConfig, generateKMSClient(ctx, t))
+
+	assert.NoError(t, err)
+
+	assert.NotNil(t, transport)
+}
+
+func TestCertEnvVar(t *testing.T) {
+	ctx := context.Background()
+
+	testConfig := envconfig.EnvConfig{
+		Port:                       8080,
+		Domain:                     "example.com",
+		AppID:                      123456,
+		EventingIngress:            "https://event.ingress.uri",
+		AppSecretCertificateEnvVar: generateTestCertificate("envvar"),
+		Metrics:                    "enabled",
+	}
+
+	transport, err := New(ctx, testConfig, generateKMSClient(ctx, t))
+
+	assert.NoError(t, err)
+
+	assert.NotNil(t, transport)
+}
+
+func TestCertFile(t *testing.T) {
+	ctx := context.Background()
+
+	testConfig := envconfig.EnvConfig{
+		Port:                     8080,
+		Domain:                   "example.com",
+		AppID:                    123456,
+		EventingIngress:          "https://event.ingress.uri",
+		AppSecretCertificateFile: generateTestCertificate("file"),
+		Metrics:                  "enabled",
+	}
+
+	transport, err := New(ctx, testConfig, generateKMSClient(ctx, t))
+
+	assert.NoError(t, err)
+
+	assert.NotNil(t, transport)
+}
+
+func generateKMSClient(ctx context.Context, t *testing.T) *kms.KeyManagementClient {
+	l, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fakeServerAddr := l.Addr().String()
+
+	client, err := kms.NewKeyManagementClient(ctx,
+		option.WithEndpoint(fakeServerAddr),
+		option.WithoutAuthentication(),
+		option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return client
+}
+
+func createGCPKMSCredsFile(t *testing.T) string {
+
+	tmpFile, err := os.CreateTemp("", "creds-")
+	if err != nil {
+		t.Fatalf("Failed to create temporary file: %s", err)
+	}
+
+	jsonStr := fmt.Sprintf(`{
+        "type": "service_account",
+        "private_key": "%s"
+    }`, generateTestCertificate("envvar"))
+
+	if _, err := tmpFile.Write([]byte(jsonStr)); err != nil {
+		t.Fatalf("Failed to write to temporary file: %s", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		t.Fatalf("Failed to close temporary file: %s", err)
+	}
+	t.Logf(tmpFile.Name())
+	return tmpFile.Name()
+}
+
+func generateTestCertificate(output string) string {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		panic(err)
+	}
+
+	privateKeyBytes := x509.MarshalPKCS1PrivateKey(privateKey)
+
+	privateKeyPEM := pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: privateKeyBytes,
+	}
+	if output == "envvar" {
+		var pemOut bytes.Buffer
+		pem.Encode(&pemOut, &privateKeyPEM)
+		return pemOut.String()
+	} else {
+		tmpFile, err := os.CreateTemp("", "privateKey*.pem")
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer tmpFile.Close()
+
+		if err := pem.Encode(tmpFile, &privateKeyPEM); err != nil {
+			log.Fatal(err)
+		}
+
+		return tmpFile.Name()
+	}
+}

--- a/pkg/ghtransport/ghtransport_test.go
+++ b/pkg/ghtransport/ghtransport_test.go
@@ -104,7 +104,6 @@ func generateKMSClient(ctx context.Context, t *testing.T) *kms.KeyManagementClie
 }
 
 func createGCPKMSCredsFile(t *testing.T) string {
-
 	tmpFile, err := os.CreateTemp(t.TempDir(), "creds-")
 	if err != nil {
 		t.Fatalf("Failed to create temporary file: %s", err)
@@ -167,5 +166,4 @@ func generateTestCertificateFile(t *testing.T) string {
 	}
 
 	return tmpFile.Name()
-
 }

--- a/pkg/ghtransport/ghtransport_test.go
+++ b/pkg/ghtransport/ghtransport_test.go
@@ -73,7 +73,7 @@ func TestCertFile(t *testing.T) {
 		Domain:                   "example.com",
 		AppID:                    123456,
 		EventingIngress:          "https://event.ingress.uri",
-		AppSecretCertificateFile: generateTestCertificateFile(),
+		AppSecretCertificateFile: generateTestCertificateFile(t),
 		Metrics:                  true,
 	}
 
@@ -143,7 +143,7 @@ func generateTestCertificateString() string {
 	return pemOut.String()
 }
 
-func generateTestCertificateFile() string {
+func generateTestCertificateFile(t *testing.T) string {
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		panic(err)

--- a/pkg/ghtransport/ghtransport_test.go
+++ b/pkg/ghtransport/ghtransport_test.go
@@ -157,7 +157,7 @@ func generateTestCertificateFile() string {
 		Bytes: privateKeyBytes,
 	}
 
-	tmpFile, err := os.CreateTemp("", "privateKey*.pem")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "privateKey*.pem")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/octosts/octosts.go
+++ b/pkg/octosts/octosts.go
@@ -39,11 +39,12 @@ const (
 	maxRetry   = 3
 )
 
-func NewSecurityTokenServiceServer(atr *ghinstallation.AppsTransport, ceclient cloudevents.Client, domain string) pboidc.SecurityTokenServiceServer {
+func NewSecurityTokenServiceServer(atr *ghinstallation.AppsTransport, ceclient cloudevents.Client, domain string, metrics string) pboidc.SecurityTokenServiceServer {
 	return &sts{
 		atr:      atr,
 		ceclient: ceclient,
 		domain:   domain,
+		metrics:  metrics,
 	}
 }
 
@@ -59,6 +60,7 @@ type sts struct {
 	atr      *ghinstallation.AppsTransport
 	ceclient cloudevents.Client
 	domain   string
+	metrics  string
 }
 
 type cacheTrustPolicyKey struct {
@@ -75,20 +77,24 @@ func (s *sts) Exchange(ctx context.Context, request *pboidc.ExchangeRequest) (_ 
 		Identity: request.Identity,
 	}
 	defer func() {
-		event := cloudevents.NewEvent()
-		event.SetType("dev.octo-sts.exchange")
-		event.SetSubject(fmt.Sprintf("%s/%s", request.Scope, request.Identity))
-		event.SetSource(fmt.Sprintf("https://%s", s.domain))
-		if err != nil {
-			e.Error = err.Error()
-		}
-		if err := event.SetData(cloudevents.ApplicationJSON, e); err != nil {
-			clog.FromContext(ctx).Infof("Failed to encode event payload: %v", err)
+		if s.metrics == "default" {
+			event := cloudevents.NewEvent()
+			event.SetType("dev.octo-sts.exchange")
+			event.SetSubject(fmt.Sprintf("%s/%s", request.Scope, request.Identity))
+			event.SetSource(fmt.Sprintf("https://%s", s.domain))
+			if err != nil {
+				e.Error = err.Error()
+			}
+			if err := event.SetData(cloudevents.ApplicationJSON, e); err != nil {
+				clog.FromContext(ctx).Infof("Failed to encode event payload: %v", err)
+				return
+			}
+			rctx := cloudevents.ContextWithRetriesExponentialBackoff(context.WithoutCancel(ctx), retryDelay, maxRetry)
+			if ceresult := s.ceclient.Send(rctx, event); cloudevents.IsUndelivered(ceresult) || cloudevents.IsNACK(ceresult) {
+				clog.FromContext(ctx).Errorf("Failed to deliver event: %v", ceresult)
+			}
+		} else {
 			return
-		}
-		rctx := cloudevents.ContextWithRetriesExponentialBackoff(context.WithoutCancel(ctx), retryDelay, maxRetry)
-		if ceresult := s.ceclient.Send(rctx, event); cloudevents.IsUndelivered(ceresult) || cloudevents.IsNACK(ceresult) {
-			clog.FromContext(ctx).Errorf("Failed to deliver event: %v", ceresult)
 		}
 	}()
 


### PR DESCRIPTION
feat: allow flexible options for github app secret and metrics

allows for the GitHub app secret to be loaded from GCPKMS as the default, but also now allows envvars and files to be utilized. Vaulting mechanisms are used in our case, however they're loaded a bit differently.

allows for the metrics specific to chainguard to be optionally disabled. the default is to allow the chainguard default metrics.