### PR TITLE
fix: environment variable app secret

### DIFF
--- a/pkg/ghtransport/ghtransport.go
+++ b/pkg/ghtransport/ghtransport.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 
 	kms "cloud.google.com/go/kms/apiv1"
 	"github.com/bradleyfalzon/ghinstallation/v2"
@@ -17,7 +18,7 @@ import (
 func New(ctx context.Context, env *envConfig.EnvConfig, kmsClient *kms.KeyManagementClient) (*ghinstallation.AppsTransport, error) {
 	switch {
 	case env.AppSecretCertificateEnvVar != "":
-		atr, err := ghinstallation.NewAppsTransport(http.DefaultTransport, env.AppID, []byte(env.AppSecretCertificateEnvVar))
+		atr, err := ghinstallation.NewAppsTransport(http.DefaultTransport, env.AppID, []byte(os.Getenv(env.AppSecretCertificateEnvVar)))
 
 		if err != nil {
 			return nil, err

--- a/pkg/ghtransport/ghtransport_test.go
+++ b/pkg/ghtransport/ghtransport_test.go
@@ -52,12 +52,14 @@ func TestGCPKMS(t *testing.T) {
 func TestCertEnvVar(t *testing.T) {
 	ctx := context.Background()
 
+	t.Setenv("GITHUB_APP_SECRET", generateTestCertificateString())
+
 	testConfig := &envconfig.EnvConfig{
 		Port:                       8080,
 		Domain:                     "example.com",
 		AppID:                      123456,
 		EventingIngress:            "https://event.ingress.uri",
-		AppSecretCertificateEnvVar: generateTestCertificateString(),
+		AppSecretCertificateEnvVar: "GITHUB_APP_SECRET",
 		Metrics:                    true,
 	}
 


### PR DESCRIPTION
fix: environment variable app secret

when testing locally the cert file option was used. When using this in Kubernetes, I realized this wasn't working as expected.

New tests were added to ensure that this is working properly. This was tested Kubernetes and works as expected.