### PR TITLE
Bump chainguard/tf-common-infra to 0.6.74

### DIFF
--- a/iac/bootstrap/main.tf
+++ b/iac/bootstrap/main.tf
@@ -20,7 +20,7 @@ locals {
 
 module "github-wif" {
   source  = "chainguard-dev/common/infra//modules/github-wif-provider"
-  version = "0.6.60"
+  version = "0.6.74"
 
   project_id = var.project_id
   name       = "github-pool"
@@ -40,7 +40,7 @@ moved {
 
 module "github_identity" {
   source  = "chainguard-dev/common/infra//modules/github-gsa"
-  version = "0.6.60"
+  version = "0.6.74"
 
   project_id = var.project_id
   name       = "github-identity"
@@ -67,7 +67,7 @@ resource "google_project_iam_member" "github_owner" {
 
 module "github_pull_requests" {
   source  = "chainguard-dev/common/infra//modules/github-gsa"
-  version = "0.6.60"
+  version = "0.6.74"
 
   project_id = var.project_id
   name       = "github-pull-requests"

--- a/iac/broker.tf
+++ b/iac/broker.tf
@@ -1,7 +1,7 @@
 // Create the Broker abstraction.
 module "cloudevent-broker" {
   source  = "chainguard-dev/common/infra//modules/cloudevent-broker"
-  version = "0.6.60"
+  version = "0.6.74"
 
   name       = "octo-sts-broker"
   project_id = var.project_id
@@ -14,7 +14,7 @@ data "google_client_openid_userinfo" "me" {}
 
 module "cloudevent-recorder" {
   source  = "chainguard-dev/common/infra//modules/cloudevent-recorder"
-  version = "0.6.60"
+  version = "0.6.74"
 
   name       = "octo-sts-recorder"
   project_id = var.project_id

--- a/iac/gclb.tf
+++ b/iac/gclb.tf
@@ -23,7 +23,7 @@ resource "google_dns_managed_zone" "top-level-zone" {
 // Put the above domain in front of our regional services.
 module "serverless-gclb" {
   source  = "chainguard-dev/common/infra//modules/serverless-gclb"
-  version = "0.6.60"
+  version = "0.6.74"
 
   name       = var.name
   project_id = var.project_id

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -5,7 +5,7 @@ provider "ko" { repo = "gcr.io/${var.project_id}" }
 // Create a network with several regional subnets
 module "networking" {
   source  = "chainguard-dev/common/infra//modules/networking"
-  version = "0.6.60"
+  version = "0.6.74"
 
   name          = var.name
   project_id    = var.project_id

--- a/iac/prober.tf
+++ b/iac/prober.tf
@@ -5,7 +5,7 @@ resource "google_service_account" "prober" {
 
 module "prober" {
   source  = "chainguard-dev/common/infra//modules/prober"
-  version = "0.6.60"
+  version = "0.6.74"
 
   name       = "octo-sts-prober"
   project_id = var.project_id
@@ -32,7 +32,7 @@ resource "google_service_account" "negative_prober" {
 
 module "negative_prober" {
   source  = "chainguard-dev/common/infra//modules/prober"
-  version = "0.6.60"
+  version = "0.6.74"
 
   name       = "octo-sts-negative-prober"
   project_id = var.project_id
@@ -54,7 +54,7 @@ module "negative_prober" {
 
 module "dashboard" {
   source       = "chainguard-dev/common/infra//modules/dashboard/service"
-  version      = "0.6.60"
+  version      = "0.6.74"
   service_name = var.name
   project_id   = var.project_id
 

--- a/modules/app/main.tf
+++ b/modules/app/main.tf
@@ -60,7 +60,7 @@ module "sts-emits-events" {
   for_each = var.regions
 
   source  = "chainguard-dev/common/infra//modules/authorize-private-service"
-  version = "0.6.60"
+  version = "0.6.74"
 
   project_id = var.project_id
   region     = each.key
@@ -71,7 +71,7 @@ module "sts-emits-events" {
 
 module "this" {
   source  = "chainguard-dev/common/infra//modules/regional-service"
-  version = "0.6.60"
+  version = "0.6.74"
 
   project_id = var.project_id
   name       = var.name

--- a/modules/app/webhook.tf
+++ b/modules/app/webhook.tf
@@ -7,7 +7,7 @@ resource "random_password" "webhook-secret" {
 
 module "webhook-secret" {
   source  = "chainguard-dev/common/infra//modules/configmap"
-  version = "0.6.60"
+  version = "0.6.74"
 
   project_id = var.project_id
   name       = "${var.name}-webhook-secret"
@@ -20,7 +20,7 @@ module "webhook-secret" {
 
 module "webhook" {
   source  = "chainguard-dev/common/infra//modules/regional-service"
-  version = "0.6.60"
+  version = "0.6.74"
 
   project_id = var.project_id
   name       = "${var.name}-webhook"


### PR DESCRIPTION
Should fix error:

```
│ Error: Missing required argument
│ 
│   on .terraform/modules/negative_prober/modules/serverless-gclb/main.tf line 75, in resource "google_compute_backend_service" "public-services":
│   75:     content {
│ 
│ The argument "enabled" is required, but no definition was found.
╵
```