### PR TITLE
Add org filter to webhook.

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -81,10 +81,18 @@ func main() {
 		webhookSecrets = [][]byte{[]byte(webhookConfig.WebhookSecret)}
 	}
 
+	var orgs []string
+	for _, s := range strings.Split(webhookConfig.OrganizationFilter, ",") {
+		if o := strings.TrimSpace(s); o != "" {
+			orgs = append(orgs, o)
+		}
+	}
+
 	mux := http.NewServeMux()
 	mux.Handle("/", &webhook.Validator{
 		Transport:     atr,
 		WebhookSecret: webhookSecrets,
+		Organizations: orgs,
 	})
 	srv := &http.Server{
 		Addr:              fmt.Sprintf(":%d", baseCfg.Port),

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -66,4 +66,6 @@ module "app" {
   github_app_id          = var.github_app_id
   github_app_key_version = 1
   notification_channels  = local.notification_channels
+  // Testing out behavior, will remove once we confirm things are working.
+  github_webhook_organization_filter = "octo-sts,chainguard-dev"
 }

--- a/modules/app/variables.tf
+++ b/modules/app/variables.tf
@@ -55,3 +55,9 @@ variable "notification_channels" {
   description = "List of notification channels to alert."
   type        = list(string)
 }
+
+variable "github_webhook_organization_filter" {
+  description = "The organizations to filter webhook events on (comma separated)."
+  type        = string
+  default     = ""
+}

--- a/modules/app/webhook.tf
+++ b/modules/app/webhook.tf
@@ -46,6 +46,10 @@ module "webhook" {
           value = module.webhook-secret.secret_version_id
         },
         {
+          name  = "GITHUB_WEBHOOK_ORGANIZATION_FILTER"
+          value = var.github_webhook_organization_filter
+        },
+        {
           name  = "KMS_KEY"
           value = local.kms_key
         }

--- a/pkg/envconfig/envconfig.go
+++ b/pkg/envconfig/envconfig.go
@@ -25,6 +25,8 @@ type EnvConfigApp struct {
 
 type EnvConfigWebhook struct {
 	WebhookSecret string `envconfig:"WEBHOOK_SECRET" required:"true"`
+	// If set, only process events from these organizations (comma separated).
+	OrganizationFilter string `envconfig:"GITHUB_ORGANIZATION_FILTER"`
 }
 
 func AppConfig() (*EnvConfigApp, error) {

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -41,6 +41,8 @@ type Validator struct {
 	// Store multiple secrets to allow for rolling updates.
 	// Only one needs to match for the event to be considered valid.
 	WebhookSecret [][]byte
+
+	Organizations []string
 }
 
 func (e *Validator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -217,6 +219,12 @@ func (e *Validator) handlePush(ctx context.Context, event *github.PushEvent) (*g
 	sha := event.GetAfter()
 	installationID := event.GetInstallation().GetID()
 
+	// Skip if the organization is not in the list of organizations to validate.
+	if e.shouldSkipOrganization(owner) {
+		log.Infof("skipping organization %s", owner)
+		return nil, nil
+	}
+
 	client := github.NewClient(&http.Client{
 		Transport: ghinstallation.NewFromAppsTransport(e.Transport, installationID),
 	})
@@ -255,6 +263,12 @@ func (e *Validator) handlePullRequest(ctx context.Context, pr *github.PullReques
 	repo := pr.GetRepo().GetName()
 	sha := pr.GetPullRequest().GetHead().GetSHA()
 	installationID := pr.GetInstallation().GetID()
+
+	// Skip if the organization is not in the list of organizations to validate.
+	if e.shouldSkipOrganization(owner) {
+		log.Infof("skipping organization %s", owner)
+		return nil, nil
+	}
 
 	client := github.NewClient(&http.Client{
 		Transport: ghinstallation.NewFromAppsTransport(e.Transport, installationID),
@@ -303,6 +317,12 @@ func (e *Validator) handleCheckSuite(ctx context.Context, cs checkSuite) (*githu
 	sha := cs.GetCheckSuite().GetHeadSHA()
 	installationID := cs.GetInstallation().GetID()
 
+	// Skip if the organization is not in the list of organizations to validate.
+	if e.shouldSkipOrganization(owner) {
+		log.Infof("skipping organization %s", owner)
+		return nil, nil
+	}
+
 	client := github.NewClient(&http.Client{
 		Transport: ghinstallation.NewFromAppsTransport(e.Transport, installationID),
 	})
@@ -343,4 +363,16 @@ var _ checkSuite = (*fauxCheckSuite)(nil)
 
 func (f *fauxCheckSuite) GetCheckSuite() *github.CheckSuite {
 	return f.GetCheckRun().GetCheckSuite()
+}
+
+func (e *Validator) shouldSkipOrganization(org string) bool {
+	if len(e.Organizations) == 0 {
+		return false
+	}
+	for _, o := range e.Organizations {
+		if o == org {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -12,6 +12,7 @@ import (
 	"mime"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
@@ -370,7 +371,7 @@ func (e *Validator) shouldSkipOrganization(org string) bool {
 		return false
 	}
 	for _, o := range e.Organizations {
-		if o == org {
+		if strings.EqualFold(o, org) {
 			return false
 		}
 	}


### PR DESCRIPTION
We need to test out behavior in the webhook, but we're not 100% confident it's working as intended as is. This adds a configurable filter to enable selective responses to certain orgs.

For now, have the default deployment only look at octo-sts and chainguard-dev orgs.