### PR TITLE
Fix github webhook secret envvar name.

### DIFF
--- a/pkg/envconfig/envconfig.go
+++ b/pkg/envconfig/envconfig.go
@@ -24,7 +24,7 @@ type EnvConfigApp struct {
 }
 
 type EnvConfigWebhook struct {
-	WebhookSecret string `envconfig:"WEBHOOK_SECRET" required:"true"`
+	WebhookSecret string `envconfig:"GITHUB_WEBHOOK_SECRET" required:"true"`
 	// If set, only process events from these organizations (comma separated).
 	OrganizationFilter string `envconfig:"GITHUB_ORGANIZATION_FILTER"`
 }

--- a/pkg/envconfig/envconfig_test.go
+++ b/pkg/envconfig/envconfig_test.go
@@ -150,14 +150,14 @@ func TestWebhookConfig(t *testing.T) {
 		{
 			name: "No environment variables set",
 			envVars: map[string]string{
-				"WEBHOOK_SECRET": "",
+				"GITHUB_WEBHOOK_SECRET": "",
 			},
 			wantErr: false,
 		},
 		{
 			name: "All environment variables set",
 			envVars: map[string]string{
-				"WEBHOOK_SECRET": "octo-sts-test.local",
+				"GITHUB_WEBHOOK_SECRET": "octo-sts-test.local",
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
Matches https://github.com/octo-sts/app/blob/ccd3cf85e3e800c1acb84854aaf03c05b183a4db/modules/app/webhook.tf#L45 + other github envvar naming conventions.