### PR TITLE
Fix yaml tag parsing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	golang.org/x/oauth2 v0.21.0
 	google.golang.org/api v0.190.0
 	google.golang.org/grpc v1.65.0
-	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/apimachinery v0.30.3
 	sigs.k8s.io/yaml v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -329,8 +329,6 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/pkg/webhook/testdata/api/v3/repos/foo/bar/contents/policy.json
+++ b/pkg/webhook/testdata/api/v3/repos/foo/bar/contents/policy.json
@@ -1,0 +1,18 @@
+{
+  "name": "verify-prod.sts.yaml",
+  "path": ".github/chainguard/verify-prod.sts.yaml",
+  "sha": "9f4890d268e2ad02d4171e131018597a7651f61e",
+  "size": 284,
+  "url": "https://api.github.com/repos/octo-sts/app/contents/.github/chainguard/verify-prod.sts.yaml?ref=main",
+  "html_url": "https://github.com/octo-sts/app/blob/main/.github/chainguard/verify-prod.sts.yaml",
+  "git_url": "https://api.github.com/repos/octo-sts/app/git/blobs/9f4890d268e2ad02d4171e131018597a7651f61e",
+  "download_url": "https://raw.githubusercontent.com/octo-sts/app/main/.github/chainguard/verify-prod.sts.yaml",
+  "type": "file",
+  "content": "IyBDb3B5cmlnaHQgMjAyNCBDaGFpbmd1YXJkLCBJbmMuCiMgU1BEWC1MaWNl\nbnNlLUlkZW50aWZpZXI6IEFwYWNoZS0yLjAKCmlzc3VlcjogaHR0cHM6Ly90\nb2tlbi5hY3Rpb25zLmdpdGh1YnVzZXJjb250ZW50LmNvbQpzdWJqZWN0OiBy\nZXBvOm9jdG8tc3RzL2FwcDpwdWxsX3JlcXVlc3QKY2xhaW1fcGF0dGVybjoK\nICB3b3JrZmxvd19yZWY6IG9jdG8tc3RzL2FwcC8uZ2l0aHViL3dvcmtmbG93\ncy92ZXJpZnktcHJvZC55YW1sQC4qCgpwZXJtaXNzaW9uczoKICBwdWxsX3Jl\ncXVlc3RzOiB3cml0ZQo=\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/octo-sts/app/contents/.github/chainguard/verify-prod.sts.yaml?ref=main",
+    "git": "https://api.github.com/repos/octo-sts/app/git/blobs/9f4890d268e2ad02d4171e131018597a7651f61e",
+    "html": "https://github.com/octo-sts/app/blob/main/.github/chainguard/verify-prod.sts.yaml"
+  }
+}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -20,8 +20,8 @@ import (
 	"github.com/google/go-github/v61/github"
 	"github.com/hashicorp/go-multierror"
 	"github.com/octo-sts/app/pkg/octosts"
-	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -132,7 +132,7 @@ func (e *Validator) handleSHA(ctx context.Context, client *github.Client, owner,
 		return nil, nil
 	}
 
-	err := e.validatePolicies(ctx, client, owner, repo, sha, files)
+	err := validatePolicies(ctx, client, owner, repo, sha, files)
 	// Whether or not the commit is verified, we still create a CheckRun.
 	// The only difference is whether it shows up to the user as success or
 	// failure.
@@ -167,7 +167,7 @@ func (e *Validator) handleSHA(ctx context.Context, client *github.Client, owner,
 	return cr, nil
 }
 
-func (e *Validator) validatePolicies(ctx context.Context, client *github.Client, owner, repo string, sha string, files []string) error {
+func validatePolicies(ctx context.Context, client *github.Client, owner, repo string, sha string, files []string) error {
 	var merr error
 	for _, f := range sets.List(sets.New(files...)) {
 		log := clog.FromContext(ctx).With("path", f)

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -1,0 +1,43 @@
+// Copyright 2024 Chainguard, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package webhook
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/chainguard-dev/clog/slogtest"
+	"github.com/google/go-github/v61/github"
+)
+
+func TestValidatePolicy(t *testing.T) {
+	// Use prefetched data.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := filepath.Join("testdata", r.URL.Path)
+		f, err := os.Open(path)
+		if err != nil {
+			t.Logf("%s not found", path)
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		defer f.Close()
+		if _, err := io.Copy(w, f); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}))
+
+	gh, err := github.NewClient(srv.Client()).WithEnterpriseURLs(srv.URL, srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := slogtest.TestContextWithLogger(t)
+	if err := validatePolicies(ctx, gh, "foo", "bar", "deadbeef", []string{"policy.json"}); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Switches yaml parsing library to sigs.k8s.io/yaml which respects json field tags. This fixes yaml parsing for policies, since previously it was not respecting the tags.

Also adds a test!