### PR TITLE
Remove webhook filter from deployed config

### DIFF
--- a/iac/main.tf
+++ b/iac/main.tf
@@ -66,6 +66,4 @@ module "app" {
   github_app_id          = var.github_app_id
   github_app_key_version = 1
   notification_channels  = local.notification_channels
-  // Testing out behavior, will remove once we confirm things are working.
-  github_webhook_organization_filter = "octo-sts,chainguard-dev"
 }


### PR DESCRIPTION
Allow webhook to respond to all orgs.

Keeps code in place in case we want to roll this back and/or stand up a limited staging variant later on.