### PR TITLE
feat: parent trust policy at org root

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -37,6 +37,10 @@ func main() {
 		log.Panicf("failed to process env var: %s", err)
 	}
 
+	if baseCfg.OrgTrustPolicy {
+		clog.FromContext(ctx).Infof("Required Org Policy Active")
+	}
+
 	if baseCfg.Metrics {
 		go metrics.ServeMetrics()
 

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -71,7 +71,7 @@ func main() {
 		log.Panicf("failed to create cloudevents client: %v", err)
 	}
 
-	pboidc.RegisterSecurityTokenServiceServer(d.Server, octosts.NewSecurityTokenServiceServer(atr, ceclient, appConfig.Domain, baseCfg.Metrics))
+	pboidc.RegisterSecurityTokenServiceServer(d.Server, octosts.NewSecurityTokenServiceServer(atr, ceclient, appConfig.Domain, baseCfg.Metrics, baseCfg.OrgTrustPolicy))
 	if err := d.RegisterHandler(ctx, pboidc.RegisterSecurityTokenServiceHandlerFromEndpoint); err != nil {
 		log.Panicf("failed to register gateway endpoint: %v", err)
 	}

--- a/pkg/envconfig/envconfig.go
+++ b/pkg/envconfig/envconfig.go
@@ -16,6 +16,7 @@ type EnvConfig struct {
 	AppSecretCertificateFile   string `envconfig:"APP_SECRET_CERTIFICATE_FILE" required:"false"`
 	AppSecretCertificateEnvVar string `envconfig:"APP_SECRET_CERTIFICATE_ENV_VAR" required:"false"`
 	Metrics                    bool   `envconfig:"METRICS" required:"false" default:"true"`
+	OrgTrustPolicy             bool   `envconfig:"ORG_TRUST_POLICY" required:"false" default:"false"`
 }
 
 type EnvConfigApp struct {

--- a/pkg/octosts/octosts.go
+++ b/pkg/octosts/octosts.go
@@ -142,7 +142,7 @@ func (s *sts) Exchange(ctx context.Context, request *pboidc.ExchangeRequest) (_ 
 		err := deepCopy(&request, &orgRequest)
 		createOrgRequest(orgRequest)
 		clog.FromContext(ctx).Infof("org exchange request: %#v", orgRequest)
-		e.InstallationID, e.TrustPolicy, err = s.lookupInstallAndTrustPolicy(ctx, orgRequest.Scope, request.Identity)
+		e.InstallationID, e.TrustPolicy, err = s.lookupInstallAndTrustPolicy(ctx, orgRequest.Scope, orgRequest.Identity)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/octosts/octosts.go
+++ b/pkg/octosts/octosts.go
@@ -42,10 +42,10 @@ const (
 
 func NewSecurityTokenServiceServer(atr *ghinstallation.AppsTransport, ceclient cloudevents.Client, domain string, metrics bool, orgTrustPolicy bool) pboidc.SecurityTokenServiceServer {
 	return &sts{
-		atr:      atr,
-		ceclient: ceclient,
-		domain:   domain,
-		metrics:  metrics,
+		atr:            atr,
+		ceclient:       ceclient,
+		domain:         domain,
+		metrics:        metrics,
 		orgTrustPolicy: orgTrustPolicy,
 	}
 }
@@ -59,11 +59,11 @@ var (
 type sts struct {
 	pboidc.UnimplementedSecurityTokenServiceServer
 
-	atr      *ghinstallation.AppsTransport
-	ceclient cloudevents.Client
-	domain   string
-	metrics  bool
-	orgTrustPolicy  bool
+	atr            *ghinstallation.AppsTransport
+	ceclient       cloudevents.Client
+	domain         string
+	metrics        bool
+	orgTrustPolicy bool
 }
 
 type cacheTrustPolicyKey struct {
@@ -216,17 +216,17 @@ func (s *sts) Exchange(ctx context.Context, request *pboidc.ExchangeRequest) (_ 
 func deepCopy(src **pboidc.ExchangeRequest, dst **pboidc.ExchangeRequest) error {
 	bytes, err := json.Marshal(src)
 	if err != nil {
-	 return err
+		return err
 	}
 	return json.Unmarshal(bytes, dst)
 }
 
 func createOrgRequest(request *pboidc.ExchangeRequest) *pboidc.ExchangeRequest {
-    base := path.Base(request.Scope)
-    newBase := ".github"
+	base := path.Base(request.Scope)
+	newBase := ".github"
 	request.Identity = "org"
-    request.Scope = strings.Replace(request.Scope, base, newBase, 1)
-    return request
+	request.Scope = strings.Replace(request.Scope, base, newBase, 1)
+	return request
 }
 
 func (s *sts) lookupInstallAndTrustPolicy(ctx context.Context, scope, identity string) (int64, *OrgTrustPolicy, error) {

--- a/pkg/octosts/octosts.go
+++ b/pkg/octosts/octosts.go
@@ -140,7 +140,7 @@ func (s *sts) Exchange(ctx context.Context, request *pboidc.ExchangeRequest) (_ 
 	if s.orgTrustPolicy {
 		var orgRequest *pboidc.ExchangeRequest
 		err := deepCopy(&request, &orgRequest)
-		createOrgScope(orgRequest)
+		createOrgRequest(orgRequest)
 		clog.FromContext(ctx).Infof("org exchange request: %#v", orgRequest)
 		e.InstallationID, e.TrustPolicy, err = s.lookupInstallAndTrustPolicy(ctx, orgRequest.Scope, request.Identity)
 		if err != nil {
@@ -218,12 +218,12 @@ func deepCopy(src **pboidc.ExchangeRequest, dst **pboidc.ExchangeRequest) error 
 	return json.Unmarshal(bytes, dst)
 }
 
-func createOrgScope(request *pboidc.ExchangeRequest) *pboidc.ExchangeRequest {
-    orgRequest := request
+func createOrgRequest(request *pboidc.ExchangeRequest) *pboidc.ExchangeRequest {
     base := path.Base(request.Scope)
     newBase := ".github"
-    orgRequest.Scope = strings.Replace(request.Scope, base, newBase, 1)
-    return orgRequest
+	request.Identity = "org"
+    request.Scope = strings.Replace(request.Scope, base, newBase, 1)
+    return request
 }
 
 func (s *sts) lookupInstallAndTrustPolicy(ctx context.Context, scope, identity string) (int64, *OrgTrustPolicy, error) {

--- a/pkg/octosts/octosts.go
+++ b/pkg/octosts/octosts.go
@@ -140,6 +140,9 @@ func (s *sts) Exchange(ctx context.Context, request *pboidc.ExchangeRequest) (_ 
 	if s.orgTrustPolicy {
 		var orgRequest *pboidc.ExchangeRequest
 		err := deepCopy(&request, &orgRequest)
+		if err != nil {
+			return nil, err
+		}
 		createOrgRequest(orgRequest)
 		clog.FromContext(ctx).Infof("org exchange request: %#v", orgRequest)
 		e.InstallationID, e.TrustPolicy, err = s.lookupInstallAndTrustPolicy(ctx, orgRequest.Scope, orgRequest.Identity)


### PR DESCRIPTION
feat: parent trust policy at org root

ensures that users within an org cannot commit unsafe trust files according to enterprise policies.

Another try at https://github.com/octo-sts/app/issues/469.

Similar to org wide trust policies living at https://github.com/chainguard-dev/.github/tree/main/.github/chainguard, this would allow a parent level trust policy at the org root.

`https://github.com/TestOrg/.github/blob/master/.github/chainguard/org.sts.yaml`

Content of `.github/chainguard/org.sts.yaml`

```
issuer: https://token.actions.githubusercontent.com
subject_pattern: repo:TestOrg/.*:ref:refs/.*
```

Logic could be improved to work without the `ORG_TRUST_POLICY` env var. I introduced this to force the `ORG_TRUST_POLICY` behavior.

Simple approach, but happy for feedback either way.