### PR TITLE
feat: Add organization-wide trusted token issuers functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,128 +78,146 @@ This will read the `# yaml-language-server: $schema=...` header and provide code
 
 ### Organization Trusted Token Issuers
 
-An organization can restrict which OIDC issuers are allowed to federate with any
-of its repositories by adding `.github/chainguard/trusted-token-issuers.yaml` to
-its `.github` repository. A token whose issuer is not permitted is rejected
-before its trust policy is ever read.
+An organization restricts which OIDC issuers can federate with its repositories.
+Add `.github/chainguard/trusted-token-issuers.yaml` to the organization's `.github`
+repository. octo-sts rejects a token with an issuer that the file does not permit.
+It rejects the token before it reads the trust policy.
 
 ```yaml
 # yaml-language-server: $schema=https://raw.githubusercontent.com/octo-sts/app/refs/heads/main/pkg/octosts/octosts.OrgTrustedIssuers.json
 
-# "enforce" (the default) rejects tokens whose issuer is not permitted.
-# "audit" permits them and records what would have been rejected.
+# "enforce" (the default) rejects a token that the allowlist does not permit.
+# "audit" permits them and records each one the allowlist rejects.
 mode: enforce
 
-# Matched exactly. Note that a trailing slash makes a distinct issuer.
+# octo-sts matches these exactly. A trailing slash makes a different issuer.
 issuers:
   - https://token.actions.githubusercontent.com
   - https://accounts.google.com
 
-# Anchored regular expressions matched against the whole issuer URL.
-# Literal dots must be escaped, and wildcards that can match "/" are rejected.
+# octo-sts matches these as anchored regexps against the whole issuer URL.
+# Escape a literal dot. octo-sts rejects a wildcard that can match "/".
 issuer_patterns:
   - https://oidc\.eks\.[a-z0-9-]+\.amazonaws\.com/id/[A-Z0-9]+
 ```
 
-Entries in `issuers` are matched exactly; entries in `issuer_patterns` are
-anchored regular expressions that must match the entire issuer URL. An issuer is
-permitted if it matches either list. Matching is case-sensitive, so entries must
-be lowercase in their scheme and host.
+octo-sts matches an entry in `issuers` exactly. It matches an entry in
+`issuer_patterns` as an anchored regular expression against the whole issuer URL.
+An issuer passes if it matches either list. Matching is case-sensitive, so write
+the scheme and the host in lowercase.
 
-**Patterns are checked for wildcards that can match `/`.** Anchoring a pattern
-to both ends does not help when it is loose in the middle: `/` separates the host
-from the path, so any atom that can match it lets a pattern reach past the host
-entirely. Each single-character atom in a pattern — a bare `.`, an escaped class
-such as `\S`, or a bracket expression such as `[^\n]` or `[[:ascii:]]` — is
-compiled on its own and tested against `/`, and the pattern is rejected if any of
-them matches. A literal `/` is fine; every issuer with a path has one.
+**octo-sts rejects a pattern that can match `/`.** The `/` character separates the
+host from the path. A pattern that matches `/` can therefore reach past the host.
+Anchors at both ends do not prevent this, because a pattern can stay loose in the
+middle.
 
-This catches the common mistake of writing a pattern that spans into another
-domain. `https://.*.example.com` reads as "any subdomain of example.com" but also
-permits `https://evil.attacker-example.com`, because the unescaped `.` before
-`example` matches `-`, and `https://totally-evil.com/x.example.com`, where the
-host is wholly attacker-controlled. Write literal dots as `\.` and give an
-explicit character class for the part that varies —
-`https://[a-z0-9-]+\.example\.com` expresses "subdomains of example.com" and
-rejects both. A rejected file reports an error naming the pattern.
+octo-sts parses each pattern with the same parser that Go's `regexp` package uses.
+It then applies two rules:
 
-A class that itself contains `/` is rejected for the same reason, so write a
-path one segment at a time with literal separators —
-`https://example\.com/realms/[a-z0-9-]+` rather than
-`https://example\.com/[a-z0-9/-]+`. There is deliberately no way to match a
-path of variable depth.
+- It rejects a character class or a `.` that can match `/`, at any position. This
+  covers `\S`, `[^\n]`, `[[:ascii:]]` and a range such as `[.-9]`.
+- It rejects a literal `/` inside a repetition, an optional group, or an
+  alternation. A group such as `([a-z0-9.-]+/)*` repeats across separators.
 
-**This is a best-effort guard, not a guarantee.** It catches accidents, not a
-determined author — write patterns as narrowly as you can. The file is written
-by an organization owner, who is the principal this control serves, so an
-over-broad pattern is an unwise choice rather than an attack.
+A literal `/` at a fixed position is correct. Every issuer with a path has one.
 
-**No file means no restriction.** Organizations that do not add one see no change
-in behavior.
+These rules catch a common mistake: a pattern that spans into another domain.
+`https://.*.example.com` reads as "any subdomain of example.com". It also permits
+`https://evil.attacker-example.com`, because the unescaped `.` before `example`
+matches `-`. It also permits `https://totally-evil.com/x.example.com`, where an
+attacker controls the whole host.
+
+Write a literal dot as `\.`. Give an explicit character class for the part that
+varies. `https://[a-z0-9-]+\.example\.com` expresses "subdomains of example.com",
+and octo-sts accepts it. The error message names the pattern that failed.
+
+Write a path one segment at a time, with literal separators. Use
+`https://example\.com/realms/[a-z0-9-]+`. Do not use
+`https://example\.com/[a-z0-9/-]+`. octo-sts deliberately gives you no way to match
+a path of variable depth.
+
+**This is a best-effort guard, not a guarantee.** It catches accidents. It does not
+stop a determined author. Write your patterns as narrowly as you can. An
+organization owner writes this file, and the control serves that owner. An
+over-broad pattern is therefore an unwise choice, not an attack.
+
+**No file means no restriction.** An organization that adds no file sees no change.
 
 #### Rolling it out
 
-Commit the file with `mode: audit` first. Nothing is rejected, and every token
-that *would* have been rejected is logged and recorded on the exchange event, so
-you can confirm the list is complete before enforcing. Remove the `mode` line to
-enforce. Note that audit mode does not protect you against a broken file or a
-failed lookup.
+1. Commit the file with `mode: audit`. octo-sts rejects nothing in audit mode.
+2. Read the logs and the exchange events. octo-sts records each token that the
+   allowlist does not permit.
+3. Check that your list is complete.
+4. Remove the `mode` line to enforce.
+
+Audit mode does not protect you against a broken file or a failed lookup.
 
 #### Requirement: the App must be able to read `.github`
 
-The allowlist is read with a short-lived `contents: read` token scoped to the
-`.github` repository. If octo-sts cannot read that repository — most often
-because the App is installed on selected repositories only — **enforcement
-silently does not apply.** GitHub answers a token request for an inaccessible
-repository with a single 422 that cannot distinguish "does not exist" from "not
-granted" from "permissions not granted", so octo-sts cannot report which case it
-hit. Grant the App access to `.github` before relying on this control.
+octo-sts reads the allowlist with a short-lived `contents: read` token. The token
+is scoped to the `.github` repository. **Enforcement silently does not apply if
+octo-sts cannot read that repository.** The most common cause is an App that is
+installed on selected repositories only.
+
+octo-sts cannot report which cause it hit. GitHub answers a token request for an
+inaccessible repository with one 422 status. That status does not separate "the
+repository does not exist" from "you do not have access".
+
+Grant the App access to `.github` before you rely on this control.
 
 #### When the lookup fails
 
 | Situation | Result |
 | --- | --- |
-| File absent | All issuers permitted |
-| No App can read `.github` | All issuers permitted, logged as a warning. Re-checked against GitHub without the local installation cache before concluding — see the propagation note below |
-| Rate limited, or GitHub unavailable | Last known good allowlist; if there is none, the exchange is rejected |
-| File present but invalid | Last known good allowlist; if there is none, every exchange in the organization is rejected |
+| File absent | octo-sts permits all issuers |
+| No App can read `.github` | octo-sts permits all issuers and logs a warning. It first re-reads the installation list from GitHub, without its local cache. See effect 4 below |
+| Rate limited, or GitHub unavailable | octo-sts uses the last known good allowlist. If there is none, it rejects the exchange |
+| File present but invalid | octo-sts uses the last known good allowlist. If there is none, it rejects every exchange in the organization |
 
-This caching has three timing consequences. After *narrowing* the allowlist, the
-previous broader list can still be served for up to an hour whenever GitHub
-errors. After *fixing* an invalid file, rejections can persist for up to five
-minutes while the cached result expires.
+This caching creates four timing effects.
 
-The one to plan for is *enabling* the allowlist. "No file" is itself valid last
-known good state, so an organization adding its **first** allowlist while GitHub
-is degraded can keep permitting all issuers for up to an hour. This is
-deliberate: it is what keeps the organizations that do not use this feature
-working through a GitHub incident. One successful read replaces it. Confirm
-enforcement actually took effect after enabling rather than assuming it did.
-Installing the App is also not instantaneous: before concluding that no
-installation can read `.github`, octo-sts re-enumerates its installations
-without its local cache — but it cannot see an installation GitHub has not yet
-propagated, so enforcement can take a few minutes to begin after an install.
+1. After you *narrow* the allowlist, octo-sts can still serve the previous, broader
+   list for up to one hour. This happens whenever GitHub returns an error.
+2. After you *fix* an invalid file, rejections can continue for up to five minutes.
+   The cached result must expire first.
+3. When you *enable* the allowlist, octo-sts can permit all issuers for up to one
+   hour.
+4. After you install the App, enforcement can take a few minutes to start.
+
+Plan for effect 3. "No file" is itself a valid last known good state. An
+organization that adds its **first** allowlist during a GitHub incident can
+therefore keep permitting all issuers for up to one hour. This behavior is
+deliberate. It keeps the organizations that do not use this feature working through
+the incident. One successful read replaces the state. Check that enforcement
+started. Do not assume it started.
+
+Effect 4 has a different cause. Before octo-sts concludes that no installation can
+read `.github`, it re-reads the installation list from GitHub without its local
+cache. GitHub does not list a new installation at once. octo-sts cannot see an
+installation that GitHub has not yet propagated.
 
 #### Hardening
 
-This control is only as trustworthy as write access to `org/.github`.
+This control is only as strong as write access to `org/.github`.
 
-- **Create `org/.github` before you need it.** The name is not reserved, so in an
-  organization without one, any member who can create a repository can become the
-  sole author of this control. Restrict member repository creation.
+- **Create `org/.github` before you need it.** GitHub does not reserve the name. In
+  an organization without this repository, any member who can create a repository
+  becomes the sole author of this control. Restrict who can create repositories.
 
-- **Protect its default branch**, and make the `Trust Policy Validation` check a
-  **required** status check. It validates this file on every pull request, but it
-  only reports — it blocks nothing unless it is required.
+- **Protect the default branch of `org/.github`.** Make the
+  `Trust Policy Validation` check a **required** status check. The check validates
+  this file on every pull request. It only reports. It blocks nothing until you make
+  it required.
 
 - **Add a CODEOWNERS entry** for the file.
 
 - **Scope organization-level trust policies with `repositories:`.** An
-  organization-level policy granting `contents: write` with no `repositories:`
-  restriction covers every repository the installation can see, `.github`
-  included — so a federated identity could rewrite the very allowlist meant to
-  constrain it. Any permission that can write, rename, or delete `org/.github`
-  defeats this control, and **deleting the file fails open.**
+  organization-level policy that grants `contents: write` without a `repositories:`
+  restriction covers every repository the installation can see. That includes
+  `.github`. A federated identity can then rewrite the allowlist that constrains it.
+  Any permission that writes, renames, or deletes `org/.github` defeats this
+  control. **Deletion of the file fails open.**
 
 - **`.github-private` is not consulted.** The file must live in `.github`.
 

--- a/README.md
+++ b/README.md
@@ -69,11 +69,135 @@ Chainguard email address to federate and read the repo contents.
 
 - [TrustPolicy](./pkg/octosts/octosts.TrustPolicy.json)
 - [OrgTrustPolicy](pkg/octosts/octosts.OrgTrustPolicy.json)
+- [OrgTrustedIssuers](pkg/octosts/octosts.OrgTrustedIssuers.json)
 
 ##### VSCode
 
 We recommend using [vscode-yaml](https://github.com/redhat-developer/vscode-yaml?tab=readme-ov-file).
 This will read the `# yaml-language-server: $schema=...` header and provide code completion.
+
+### Organization Trusted Token Issuers
+
+An organization can restrict which OIDC issuers are allowed to federate with any
+of its repositories by adding `.github/chainguard/trusted-token-issuers.yaml` to
+its `.github` repository. A token whose issuer is not permitted is rejected
+before its trust policy is ever read.
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/octo-sts/app/refs/heads/main/pkg/octosts/octosts.OrgTrustedIssuers.json
+
+# "enforce" (the default) rejects tokens whose issuer is not permitted.
+# "audit" permits them and records what would have been rejected.
+mode: enforce
+
+# Matched exactly. Note that a trailing slash makes a distinct issuer.
+issuers:
+  - https://token.actions.githubusercontent.com
+  - https://accounts.google.com
+
+# Anchored regular expressions matched against the whole issuer URL.
+# Literal dots must be escaped, and wildcards that can match "/" are rejected.
+issuer_patterns:
+  - https://oidc\.eks\.[a-z0-9-]+\.amazonaws\.com/id/[A-Z0-9]+
+```
+
+Entries in `issuers` are matched exactly; entries in `issuer_patterns` are
+anchored regular expressions that must match the entire issuer URL. An issuer is
+permitted if it matches either list. Matching is case-sensitive, so entries must
+be lowercase in their scheme and host.
+
+**Patterns are checked for wildcards that can match `/`.** Anchoring a pattern
+to both ends does not help when it is loose in the middle: `/` separates the host
+from the path, so any atom that can match it lets a pattern reach past the host
+entirely. Each single-character atom in a pattern — a bare `.`, an escaped class
+such as `\S`, or a bracket expression such as `[^\n]` or `[[:ascii:]]` — is
+compiled on its own and tested against `/`, and the pattern is rejected if any of
+them matches. A literal `/` is fine; every issuer with a path has one.
+
+This catches the common mistake of writing a pattern that spans into another
+domain. `https://.*.example.com` reads as "any subdomain of example.com" but also
+permits `https://evil.attacker-example.com`, because the unescaped `.` before
+`example` matches `-`, and `https://totally-evil.com/x.example.com`, where the
+host is wholly attacker-controlled. Write literal dots as `\.` and give an
+explicit character class for the part that varies —
+`https://[a-z0-9-]+\.example\.com` expresses "subdomains of example.com" and
+rejects both. A rejected file reports an error naming the pattern.
+
+A class that itself contains `/` is rejected for the same reason, so write a
+path one segment at a time with literal separators —
+`https://example\.com/realms/[a-z0-9-]+` rather than
+`https://example\.com/[a-z0-9/-]+`. There is deliberately no way to match a
+path of variable depth.
+
+**This is a best-effort guard, not a guarantee.** It catches accidents, not a
+determined author — write patterns as narrowly as you can. The file is written
+by an organization owner, who is the principal this control serves, so an
+over-broad pattern is an unwise choice rather than an attack.
+
+**No file means no restriction.** Organizations that do not add one see no change
+in behavior.
+
+#### Rolling it out
+
+Commit the file with `mode: audit` first. Nothing is rejected, and every token
+that *would* have been rejected is logged and recorded on the exchange event, so
+you can confirm the list is complete before enforcing. Remove the `mode` line to
+enforce. Note that audit mode does not protect you against a broken file or a
+failed lookup.
+
+#### Requirement: the App must be able to read `.github`
+
+The allowlist is read with a short-lived `contents: read` token scoped to the
+`.github` repository. If octo-sts cannot read that repository — most often
+because the App is installed on selected repositories only — **enforcement
+silently does not apply.** GitHub answers a token request for an inaccessible
+repository with a single 422 that cannot distinguish "does not exist" from "not
+granted" from "permissions not granted", so octo-sts cannot report which case it
+hit. Grant the App access to `.github` before relying on this control.
+
+#### When the lookup fails
+
+| Situation | Result |
+| --- | --- |
+| File absent | All issuers permitted |
+| App cannot read `.github` | All issuers permitted, logged as a warning |
+| Rate limited, or GitHub unavailable | Last known good allowlist; if there is none, the exchange is rejected |
+| File present but invalid | Last known good allowlist; if there is none, every exchange in the organization is rejected |
+
+This caching has three timing consequences. After *narrowing* the allowlist, the
+previous broader list can still be served for up to an hour whenever GitHub
+errors. After *fixing* an invalid file, rejections can persist for up to five
+minutes while the cached result expires.
+
+The one to plan for is *enabling* the allowlist. "No file" is itself valid last
+known good state, so an organization adding its **first** allowlist while GitHub
+is degraded can keep permitting all issuers for up to an hour. This is
+deliberate: it is what keeps the organizations that do not use this feature
+working through a GitHub incident. One successful read replaces it. Confirm
+enforcement actually took effect after enabling rather than assuming it did.
+
+#### Hardening
+
+This control is only as trustworthy as write access to `org/.github`.
+
+- **Create `org/.github` before you need it.** The name is not reserved, so in an
+  organization without one, any member who can create a repository can become the
+  sole author of this control. Restrict member repository creation.
+
+- **Protect its default branch**, and make the `Trust Policy Validation` check a
+  **required** status check. It validates this file on every pull request, but it
+  only reports — it blocks nothing unless it is required.
+
+- **Add a CODEOWNERS entry** for the file.
+
+- **Scope organization-level trust policies with `repositories:`.** An
+  organization-level policy granting `contents: write` with no `repositories:`
+  restriction covers every repository the installation can see, `.github`
+  included — so a federated identity could rewrite the very allowlist meant to
+  constrain it. Any permission that can write, rename, or delete `org/.github`
+  defeats this control, and **deleting the file fails open.**
+
+- **`.github-private` is not consulted.** The file must live in `.github`.
 
 ### Federating a token
 
@@ -149,6 +273,8 @@ To ensure secure and effective use of octo-sts, follow these recommended practic
 - **Enable branch protection**: Configure branch protection rules on your main/default branch to prevent direct commits and require pull request reviews before merging changes. This prevents OctoSTS clients from bypassing security controls by directly merging changes to main without review.
 
 - **Restrict who can approve pull requests**: Limit pull request approval permissions to trusted team members or repository administrators.
+
+- **Restrict trusted token issuers**: Use the [organization-wide allowlist](#organization-trusted-token-issuers) so that only approved identity providers can federate with your repositories. Without it, anyone who can write a trust policy can point `issuer:` at a provider they control.
 
 ### Trust Policy Management
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ hit. Grant the App access to `.github` before relying on this control.
 | Situation | Result |
 | --- | --- |
 | File absent | All issuers permitted |
-| App cannot read `.github` | All issuers permitted, logged as a warning |
+| No App can read `.github` | All issuers permitted, logged as a warning. Re-checked against GitHub without the local installation cache before concluding — see the propagation note below |
 | Rate limited, or GitHub unavailable | Last known good allowlist; if there is none, the exchange is rejected |
 | File present but invalid | Last known good allowlist; if there is none, every exchange in the organization is rejected |
 
@@ -175,6 +175,10 @@ is degraded can keep permitting all issuers for up to an hour. This is
 deliberate: it is what keeps the organizations that do not use this feature
 working through a GitHub incident. One successful read replaces it. Confirm
 enforcement actually took effect after enabling rather than assuming it did.
+Installing the App is also not instantaneous: before concluding that no
+installation can read `.github`, octo-sts re-enumerates its installations
+without its local cache — but it cannot see an installation GitHub has not yet
+propagated, so enforcement can take a few minutes to begin after an install.
 
 #### Hardening
 

--- a/cmd/schemagen/main.go
+++ b/cmd/schemagen/main.go
@@ -33,6 +33,7 @@ func main() {
 	for _, t := range []any{
 		octosts.TrustPolicy{},
 		octosts.OrgTrustPolicy{},
+		octosts.OrgTrustedIssuers{},
 	} {
 		path := filepath.Join(*outputFlag, fmt.Sprintf("%T.json", t))
 		out, err := os.Create(path)

--- a/pkg/ghinstall/ghinstall.go
+++ b/pkg/ghinstall/ghinstall.go
@@ -65,11 +65,29 @@ type Manager interface {
 	// installation this process has observed, not every installation that
 	// currently exists. An App uninstalled from an org keeps appearing here
 	// indefinitely; a newly-installed App stays invisible until any negative
-	// cache entry for it expires.
+	// cache entry for it expires. That missing App is reported as a nil error, so
+	// an incomplete enumeration is indistinguishable from a complete one; a caller
+	// whose conclusion becomes UNSAFE when an App is missing must confirm with
+	// GetAllFresh.
 	//
 	// Callers must test len(), not nil-ness: implementations differ in whether
 	// an empty result is a nil or a zero-length slice.
 	GetAll(ctx context.Context, owner string) ([]Installation, error)
+
+	// GetAllFresh enumerates like GetAll but does NOT consult the negative
+	// (not-installed) cache, so an App installed within the last negativeTTL is
+	// visible. The positive cache IS still consulted, so after an
+	// uninstall/reinstall this can report a stale ID; that fails closed, since
+	// the stale ID's token mint fails rather than agreeing. It bypasses this
+	// process's negative cache, not GitHub's replication, so it narrows the
+	// window rather than eliminating it.
+	//
+	// Use it to CONFIRM an absence conclusion GetAll can only support over
+	// observed state. It costs one ListInstallations walk per App with no
+	// positive cache entry, so it does not belong on a hot path. Like GetAll, a
+	// non-nil error means the enumeration is NOT exhaustive even if the returned
+	// slice is non-empty, and callers must test len() rather than nil-ness.
+	GetAllFresh(ctx context.Context, owner string) ([]Installation, error)
 }
 
 const defaultNegativeTTL = 5 * time.Minute
@@ -115,28 +133,21 @@ func NewWithOptions(atr *ghinstallation.AppsTransport, negativeTTL time.Duration
 	}, nil
 }
 
-// Get returns the AppsTransport and installation ID for the given owner.
-// scope and identity are unused by the single-app manager; routing across
-// apps is handled by the roundRobin manager.
-func (m *manager) Get(ctx context.Context, owner, _, _ string) (*ghinstallation.AppsTransport, int64, error) {
-	cacheKey := fmt.Sprintf("%d/%s", m.atr.AppID(), owner)
-	if _, ok := m.negativeCache.Get(cacheKey); ok {
-		clog.InfoContextf(ctx, "negative install cache hit for %s", cacheKey)
-		return nil, 0, status.Errorf(codes.NotFound, "no installation found for %q", owner)
-	}
-	if v, ok := m.cache.Get(cacheKey); ok {
-		clog.InfoContextf(ctx, "found installation in cache for %s", cacheKey)
-		return m.atr, v, nil
-	}
-
+// lookupInstallation walks this App's installations looking for owner.
+//
+// It consults and populates no caches, which lets Get and GetAllFresh share the
+// walk while disagreeing about the negative cache. A false found with a nil error
+// is a complete answer (not installed); a failed walk is not.
+func (m *manager) lookupInstallation(ctx context.Context, owner string) (int64, bool, error) {
 	opts := []github.ClientOptionsFunc{github.WithTransport(m.atr)}
 	if m.baseURL != "" {
 		opts = append(opts, github.WithEnterpriseURLs(m.baseURL, m.baseURL))
 	}
 	client, err := github.NewClient(opts...)
 	if err != nil {
-		return nil, 0, status.Errorf(codes.Internal, "creating GitHub client: %v", err)
+		return 0, false, status.Errorf(codes.Internal, "creating GitHub client: %v", err)
 	}
+
 	// Walk through the pages of installations looking for an organization
 	// matching owner.
 	page := 1
@@ -146,20 +157,72 @@ func (m *manager) Get(ctx context.Context, owner, _, _ string) (*ghinstallation.
 			PerPage: 100,
 		})
 		if err != nil {
-			return nil, 0, status.Errorf(codes.Internal, "listing installations for app %d: %v", m.atr.AppID(), err)
+			return 0, false, status.Errorf(codes.Internal, "listing installations for app %d: %v", m.atr.AppID(), err)
 		}
 
 		for _, install := range installs {
 			if install.Account.GetLogin() == owner {
-				installID := install.GetID()
-				m.cache.Add(cacheKey, installID)
-				return m.atr, installID, nil
+				return install.GetID(), true, nil
 			}
 		}
 		page = resp.NextPage
 	}
+	return 0, false, nil
+}
+
+// cacheKey is the shared key for both of manager's caches. Get and GetAllFresh
+// MUST agree on it: GetAllFresh clears the negative entry Get reads, so a
+// divergence here silently restores the shadowing described on setInstalled.
+func (m *manager) cacheKey(owner string) string {
+	return fmt.Sprintf("%d/%s", m.atr.AppID(), owner)
+}
+
+// setInstalled records that owner IS installed, clearing any negative entry that
+// would shadow it: Get reads the negative cache before the positive one, so a
+// negative entry left alongside a positive one means NotFound for the rest of the
+// negative TTL. Remove precedes Add because manager has no mutex — a concurrent
+// reader landing between the two sees neither entry and does a fresh walk,
+// whereas the other order leaves it reading the stale negative entry.
+//
+// This narrows that window rather than closing it, and establishes no global
+// invariant: a Get whose walk finished before the install can still call
+// setNotInstalled afterwards and re-shadow this entry. The residual fails safe as
+// a spurious NotFound, so routing rejects rather than grants.
+func (m *manager) setInstalled(cacheKey string, id int64) {
+	m.negativeCache.Remove(cacheKey)
+	m.cache.Add(cacheKey, id)
+}
+
+// setNotInstalled records that owner is NOT installed. Only ever called after a
+// completed walk found nothing — a failed walk is ignorance, not absence.
+func (m *manager) setNotInstalled(cacheKey string) {
 	m.negativeCache.Add(cacheKey, true)
-	return nil, 0, status.Errorf(codes.NotFound, "no installation found for %q", owner)
+}
+
+// Get returns the AppsTransport and installation ID for the given owner.
+// scope and identity are unused by the single-app manager; routing across
+// apps is handled by the roundRobin manager.
+func (m *manager) Get(ctx context.Context, owner, _, _ string) (*ghinstallation.AppsTransport, int64, error) {
+	cacheKey := m.cacheKey(owner)
+	if _, ok := m.negativeCache.Get(cacheKey); ok {
+		clog.InfoContextf(ctx, "negative install cache hit for %s", cacheKey)
+		return nil, 0, status.Errorf(codes.NotFound, "no installation found for %q", owner)
+	}
+	if v, ok := m.cache.Get(cacheKey); ok {
+		clog.InfoContextf(ctx, "found installation in cache for %s", cacheKey)
+		return m.atr, v, nil
+	}
+
+	id, found, err := m.lookupInstallation(ctx, owner)
+	if err != nil {
+		return nil, 0, err
+	}
+	if !found {
+		m.setNotInstalled(cacheKey)
+		return nil, 0, status.Errorf(codes.NotFound, "no installation found for %q", owner)
+	}
+	m.setInstalled(cacheKey, id)
+	return m.atr, id, nil
 }
 
 // GetByInstallation returns this app's transport if its installation for
@@ -190,6 +253,31 @@ func (m *manager) GetAll(ctx context.Context, owner string) ([]Installation, err
 		return nil, err
 	}
 	return []Installation{{Transport: atr, ID: id, AppID: m.atr.AppID()}}, nil
+}
+
+// GetAllFresh implements Manager. See the interface for the contract.
+func (m *manager) GetAllFresh(ctx context.Context, owner string) ([]Installation, error) {
+	cacheKey := m.cacheKey(owner)
+	if v, ok := m.cache.Get(cacheKey); ok {
+		// Re-assert rather than read through: otherwise a negative entry armed
+		// after an earlier confirm cleared it is never repaired.
+		m.setInstalled(cacheKey, v)
+		return []Installation{{Transport: m.atr, ID: v, AppID: m.atr.AppID()}}, nil
+	}
+
+	id, found, err := m.lookupInstallation(ctx, owner)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		// A confirmed absence is as cacheable here as in Get; without this every
+		// confirm pays a full walk.
+		m.setNotInstalled(cacheKey)
+		return nil, nil
+	}
+
+	m.setInstalled(cacheKey, id)
+	return []Installation{{Transport: m.atr, ID: id, AppID: m.atr.AppID()}}, nil
 }
 
 // QuotaConfig configures three-tier capacity-aware selection for the
@@ -305,6 +393,23 @@ func (rr *roundRobin) GetByInstallation(ctx context.Context, owner string, insta
 // returned alongside the aggregate error: the list is real but incomplete,
 // and a caller that needs exhaustiveness must not treat it as the whole set.
 func (rr *roundRobin) GetAll(ctx context.Context, owner string) ([]Installation, error) {
+	return rr.enumerate(ctx, owner, "GetAll", Manager.GetAll)
+}
+
+// GetAllFresh implements Manager. See the interface for the contract. It
+// aggregates exactly as GetAll does.
+func (rr *roundRobin) GetAllFresh(ctx context.Context, owner string) ([]Installation, error) {
+	return rr.enumerate(ctx, owner, "GetAllFresh", Manager.GetAllFresh)
+}
+
+// enumerate runs one enumeration method across every manager, concatenating in
+// managers order and deduplicating on installation ID. each takes the Manager
+// before ctx because that is the shape of an interface method expression.
+func (rr *roundRobin) enumerate(
+	ctx context.Context,
+	owner, label string,
+	each func(Manager, context.Context, string) ([]Installation, error),
+) ([]Installation, error) {
 	out := make([]Installation, 0, len(rr.managers))
 	var errs []error
 	seen := make(map[int64]struct{}, len(rr.managers))
@@ -317,7 +422,7 @@ func (rr *roundRobin) GetAll(ctx context.Context, owner string) ([]Installation,
 			break
 		}
 
-		installs, err := m.GetAll(ctx, owner)
+		installs, err := each(m, ctx, owner)
 		if err != nil {
 			errs = append(errs, err)
 			// installs may still be non-empty (a nested roundRobin or future
@@ -335,8 +440,8 @@ func (rr *roundRobin) GetAll(ctx context.Context, owner string) ([]Installation,
 
 	if len(errs) > 0 {
 		err := status.Errorf(codes.Unavailable, "enumerating installations for %q: %v", owner, errors.Join(errs...))
-		clog.WarnContextf(ctx, "ghinstall: GetAll enumeration incomplete for %q: %d of %d managers failed; "+
-			"callers requiring exhaustiveness must treat this as unknown: %v", owner, len(errs), len(rr.managers), err)
+		clog.WarnContextf(ctx, "ghinstall: %s enumeration incomplete for %q: %d of %d managers failed; "+
+			"callers requiring exhaustiveness must treat this as unknown: %v", label, owner, len(errs), len(rr.managers), err)
 		return out, err
 	}
 	return out, nil

--- a/pkg/ghinstall/ghinstall_test.go
+++ b/pkg/ghinstall/ghinstall_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -734,6 +735,15 @@ func TestManagerGetAllPropagatesFailure(t *testing.T) {
 type stubManager struct {
 	installs []Installation
 	err      error
+
+	// freshInstalls / freshErr are what GetAllFresh returns, full stop. They are
+	// deliberately NOT defaulted to installs / err: a test that means "the fresh
+	// enumeration sees nothing" must be able to say so and get nothing, rather
+	// than silently falling back to installs and passing vacuously. Set them to
+	// a superset of installs to model an App that the negative cache hides from
+	// GetAll but not from GetAllFresh.
+	freshInstalls []Installation
+	freshErr      error
 }
 
 func (s *stubManager) Get(_ context.Context, _, _, _ string) (*ghinstallation.AppsTransport, int64, error) {
@@ -754,6 +764,10 @@ func (s *stubManager) GetByInstallation(_ context.Context, _ string, id int64) (
 
 func (s *stubManager) GetAll(_ context.Context, _ string) ([]Installation, error) {
 	return s.installs, s.err
+}
+
+func (s *stubManager) GetAllFresh(_ context.Context, _ string) ([]Installation, error) {
+	return s.freshInstalls, s.freshErr
 }
 
 var _ Manager = (*stubManager)(nil)
@@ -891,5 +905,314 @@ func TestRoundRobinGetAllWithRealManagers(t *testing.T) {
 	}
 	if len(none) != 0 {
 		t.Errorf("GetAll(unserved owner) returned %d installations, want 0", len(none))
+	}
+}
+
+// TestManagerGetAllFreshBypassesNegativeCache is the regression test for the
+// window this whole change exists to close.
+//
+// Sequence: the App is not installed, so a Get arms the negative cache. The App
+// is then installed. GetAll still reports nothing — with a NIL error, because
+// manager.GetAll maps NotFound to (nil, nil) — which is exactly what would let a
+// caller conclude "no installation can see this" and grant allow-all.
+// GetAllFresh must see the truth.
+func TestManagerGetAllFreshBypassesNegativeCache(t *testing.T) {
+	const installID = int64(4321)
+	var installed atomic.Bool
+
+	atr := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/app/installations" {
+			if !installed.Load() {
+				_ = json.NewEncoder(w).Encode([]github.Installation{})
+				return
+			}
+			_ = json.NewEncoder(w).Encode([]github.Installation{{
+				ID:      github.Ptr(installID),
+				Account: &github.User{Login: github.Ptr("org")},
+			}})
+			return
+		}
+		w.WriteHeader(http.StatusNotImplemented)
+	}))
+	m, err := New(atr)
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	// Arm the negative cache the way ordinary routing traffic does.
+	if _, _, err := m.Get(context.Background(), "org", "", ""); err == nil {
+		t.Fatal("Get() = nil error, want NotFound before the App is installed")
+	}
+
+	installed.Store(true)
+
+	// GetAll is still blind, and reports no error while being blind.
+	stale, err := m.GetAll(context.Background(), "org")
+	if err != nil {
+		t.Fatalf("GetAll() = %v, want nil (a negative-cache hit is not an error)", err)
+	}
+	if len(stale) != 0 {
+		t.Fatalf("GetAll() returned %d installations; this test is vacuous unless the negative cache hides the install", len(stale))
+	}
+
+	// GetAllFresh must not be fooled.
+	fresh, err := m.GetAllFresh(context.Background(), "org")
+	if err != nil {
+		t.Fatalf("GetAllFresh() = %v, want nil", err)
+	}
+	if len(fresh) != 1 {
+		t.Fatalf("GetAllFresh() returned %d installations, want 1 — the negative cache must not hide a real install", len(fresh))
+	}
+	if fresh[0].ID != installID {
+		t.Errorf("ID = %d, want %d", fresh[0].ID, installID)
+	}
+	if fresh[0].AppID != atr.AppID() {
+		t.Errorf("AppID = %d, want %d", fresh[0].AppID, atr.AppID())
+	}
+	if fresh[0].Transport == nil {
+		t.Error("Transport = nil, want the app transport")
+	}
+
+	// Get checks the negative cache BEFORE the positive one, so discovering the
+	// installation without clearing the negative entry would fix enforcement
+	// while leaving routing broken for the rest of the TTL.
+	if _, id, err := m.Get(context.Background(), "org", "", ""); err != nil {
+		t.Errorf("Get() = %v, want the installation GetAllFresh just confirmed exists", err)
+	} else if id != installID {
+		t.Errorf("Get() id = %d, want %d", id, installID)
+	}
+}
+
+// TestManagerGetAllFreshUsesPositiveCache pins that the confirm path is cheap
+// once warm: GetAllFresh skips only the NEGATIVE cache. A stale positive entry
+// yields a superset, which is the conservative direction for a caller deciding
+// whether NO installation can see something.
+func TestManagerGetAllFreshUsesPositiveCache(t *testing.T) {
+	const installID = int64(99)
+	var listCalls atomic.Int32
+
+	atr := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/app/installations" {
+			listCalls.Add(1)
+			_ = json.NewEncoder(w).Encode([]github.Installation{{
+				ID:      github.Ptr(installID),
+				Account: &github.User{Login: github.Ptr("org")},
+			}})
+			return
+		}
+		w.WriteHeader(http.StatusNotImplemented)
+	}))
+	m, err := New(atr)
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	if _, _, err := m.Get(context.Background(), "org", "", ""); err != nil {
+		t.Fatalf("Get() = %v", err)
+	}
+	before := listCalls.Load()
+
+	got, err := m.GetAllFresh(context.Background(), "org")
+	if err != nil {
+		t.Fatalf("GetAllFresh() = %v", err)
+	}
+	if len(got) != 1 || got[0].ID != installID {
+		t.Fatalf("GetAllFresh() = %v, want the cached installation %d", got, installID)
+	}
+	if listCalls.Load() != before {
+		t.Errorf("GetAllFresh() made %d extra ListInstallations calls, want 0 — the positive cache must still short-circuit", listCalls.Load()-before)
+	}
+}
+
+// TestManagerGetAllFreshPropagatesFailure: a failed walk must not look like
+// not-installed, or a caller would treat it as a complete answer.
+func TestManagerGetAllFreshPropagatesFailure(t *testing.T) {
+	atr := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/app/installations" {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNotImplemented)
+	}))
+	m, err := New(atr)
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	got, err := m.GetAllFresh(context.Background(), "org")
+	if err == nil {
+		t.Fatal("GetAllFresh() = nil error, want an error when the API call fails")
+	}
+	if st, ok := status.FromError(err); !ok || st.Code() == codes.NotFound {
+		t.Errorf("GetAllFresh() code = %v, want anything but NotFound (that would be indistinguishable from not-installed)", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("GetAllFresh() returned %d installations, want 0", len(got))
+	}
+}
+
+// TestManagerGetAllFreshNotInstalledArmsNegativeCache: a genuine miss must still
+// leave a negative entry, or every confirm would pay a full walk.
+func TestManagerGetAllFreshNotInstalledArmsNegativeCache(t *testing.T) {
+	var listCalls atomic.Int32
+	atr := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/app/installations" {
+			listCalls.Add(1)
+			_ = json.NewEncoder(w).Encode([]github.Installation{})
+			return
+		}
+		w.WriteHeader(http.StatusNotImplemented)
+	}))
+	m, err := New(atr)
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	got, err := m.GetAllFresh(context.Background(), "org")
+	if err != nil {
+		t.Fatalf("GetAllFresh() = %v, want nil for a not-installed owner", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("GetAllFresh() returned %d installations, want 0", len(got))
+	}
+
+	before := listCalls.Load()
+	if _, _, err := m.Get(context.Background(), "org", "", ""); err == nil {
+		t.Fatal("Get() = nil error, want NotFound")
+	}
+	if listCalls.Load() != before {
+		t.Errorf("Get() made %d extra ListInstallations calls, want 0 — GetAllFresh must arm the negative cache on a genuine miss", listCalls.Load()-before)
+	}
+}
+
+func TestRoundRobinGetAllFresh(t *testing.T) {
+	t.Run("concatenates and dedups", func(t *testing.T) {
+		rr := NewRoundRobin([]Manager{
+			&stubManager{freshInstalls: []Installation{{ID: 1, AppID: 10}}},
+			&stubManager{freshInstalls: []Installation{{ID: 2, AppID: 20}, {ID: 1, AppID: 10}}},
+		})
+		got, err := rr.GetAllFresh(context.Background(), "org")
+		if err != nil {
+			t.Fatalf("GetAllFresh() = %v, want nil", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("GetAllFresh() returned %d installations, want 2 (deduped)", len(got))
+		}
+		if got[0].ID != 1 || got[1].ID != 2 {
+			t.Errorf("GetAllFresh() = %v, want stable order [1 2]", []int64{got[0].ID, got[1].ID})
+		}
+	})
+
+	t.Run("one manager failing yields a partial result AND an error", func(t *testing.T) {
+		rr := NewRoundRobin([]Manager{
+			&stubManager{freshInstalls: []Installation{{ID: 1, AppID: 10}}},
+			&stubManager{freshErr: errors.New("boom")},
+		})
+		got, err := rr.GetAllFresh(context.Background(), "org")
+		if err == nil {
+			t.Fatal("GetAllFresh() = nil error, want an error for a partial enumeration")
+		}
+		if len(got) != 1 {
+			t.Errorf("GetAllFresh() returned %d installations, want the 1 that succeeded", len(got))
+		}
+	})
+
+	t.Run("an unserved owner is not an error", func(t *testing.T) {
+		rr := NewRoundRobin([]Manager{&stubManager{}, &stubManager{}})
+		got, err := rr.GetAllFresh(context.Background(), "org")
+		if err != nil {
+			t.Fatalf("GetAllFresh() = %v, want nil", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("GetAllFresh() returned %d installations, want 0", len(got))
+		}
+	})
+
+	// GetAll and GetAllFresh share one aggregation helper, so this covers the
+	// cancellation bail-out for both.
+	t.Run("a cancelled context bails instead of collecting N identical errors", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		rr := NewRoundRobin([]Manager{
+			&stubManager{freshInstalls: []Installation{{ID: 1, AppID: 10}}},
+			&stubManager{freshInstalls: []Installation{{ID: 2, AppID: 20}}},
+		})
+		got, err := rr.GetAllFresh(ctx, "org")
+		if err == nil {
+			t.Fatal("GetAllFresh() = nil error, want the cancellation")
+		}
+		if len(got) != 0 {
+			t.Errorf("GetAllFresh() returned %d installations, want 0 — it must bail before querying any manager", len(got))
+		}
+	})
+}
+
+// TestManagerGetAllFreshRepairsCoexistingCacheEntries pins the invariant that a
+// positive cache entry implies no negative entry, on the positive-cache-HIT path
+// specifically.
+//
+// The two entries can coexist in production: GetAllFresh writes the positive
+// entry, then a concurrent Get whose walk STARTED before the install completes
+// and arms the negative entry afterwards. Because Get checks the negative cache
+// first, routing then returns NotFound for the rest of the TTL — and every later
+// GetAllFresh short-circuits on the positive hit, so without an unconditional
+// Remove there the state never self-heals.
+//
+// Racing to that interleaving would be flaky, so this test seeds the resulting
+// state directly (it is an in-package test) and asserts the repair. It covers
+// the state, not the schedule that produces it.
+func TestManagerGetAllFreshRepairsCoexistingCacheEntries(t *testing.T) {
+	const installID = int64(777)
+	var listCalls atomic.Int32
+
+	atr := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/app/installations" {
+			listCalls.Add(1)
+			_ = json.NewEncoder(w).Encode([]github.Installation{{
+				ID:      github.Ptr(installID),
+				Account: &github.User{Login: github.Ptr("org")},
+			}})
+			return
+		}
+		w.WriteHeader(http.StatusNotImplemented)
+	}))
+	mgr, err := New(atr)
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+	m, ok := mgr.(*manager)
+	if !ok {
+		t.Fatalf("New() returned %T, want *manager", mgr)
+	}
+
+	// Seed the coexistence state a lost race would leave behind.
+	key := m.cacheKey("org")
+	m.cache.Add(key, installID)
+	m.negativeCache.Add(key, true)
+
+	// Sanity: routing really is broken in this state, so the repair below is
+	// load-bearing rather than decorative.
+	if _, _, err := m.Get(context.Background(), "org", "", ""); err == nil {
+		t.Fatal("Get() = nil error; this test is vacuous unless the negative entry shadows the positive one")
+	}
+
+	before := listCalls.Load()
+	got, err := m.GetAllFresh(context.Background(), "org")
+	if err != nil {
+		t.Fatalf("GetAllFresh() = %v, want nil", err)
+	}
+	if len(got) != 1 || got[0].ID != installID {
+		t.Fatalf("GetAllFresh() = %v, want the cached installation %d", got, installID)
+	}
+	if listCalls.Load() != before {
+		t.Errorf("GetAllFresh() made %d extra ListInstallations calls, want 0 — this must be the positive-cache-hit path", listCalls.Load()-before)
+	}
+
+	// The repair: routing recovers immediately instead of at TTL expiry.
+	if _, id, err := m.Get(context.Background(), "org", "", ""); err != nil {
+		t.Errorf("Get() = %v, want the installation — GetAllFresh must clear the negative entry on a positive-cache hit too", err)
+	} else if id != installID {
+		t.Errorf("Get() id = %d, want %d", id, installID)
 	}
 }

--- a/pkg/ghinstall/picker_test.go
+++ b/pkg/ghinstall/picker_test.go
@@ -55,6 +55,15 @@ func (f *fakePickerManager) GetAll(_ context.Context, _ string) ([]Installation,
 	return []Installation{{ID: f.installID}}, nil
 }
 
+// GetAllFresh just delegates: these tests do not distinguish the two
+// enumerations, so this fake cannot model a negative cache hiding an install
+// from GetAll but not GetAllFresh. A test that needs that distinction must use a
+// fake that models the two separately — stubManager here, or enumMgr in
+// pkg/octosts — otherwise it is a regression test that cannot fail.
+func (f *fakePickerManager) GetAllFresh(ctx context.Context, owner string) ([]Installation, error) {
+	return f.GetAll(ctx, owner)
+}
+
 func newFakePickerManagers(installIDs ...int64) []Manager {
 	out := make([]Manager, len(installIDs))
 	for i, id := range installIDs {

--- a/pkg/octosts/event.go
+++ b/pkg/octosts/event.go
@@ -15,6 +15,22 @@ type Event struct {
 	TokenSHA256    string          `json:"token_sha256"`
 	Error          string          `json:"error,omitempty"`
 	Time           time.Time       `json:"time"`
+
+	// IssuerAllowlist records the org trusted-issuer decision: set for audit-mode
+	// pass-throughs and enforce-mode denials, so both are countable without Error.
+	IssuerAllowlist *IssuerDecision `json:"issuer_allowlist,omitempty"`
+}
+
+// IssuerDecision is the outcome of the org trusted-issuer check, recorded only
+// when the issuer was NOT on the allowlist.
+type IssuerDecision struct {
+	Mode Mode `json:"mode"`
+
+	// Allowed is the actual outcome, not the allowlist verdict (always "not
+	// permitted" here): true in audit mode, false in enforce.
+	Allowed bool `json:"allowed"`
+
+	Issuer string `json:"iss"`
 }
 
 type Actor struct {

--- a/pkg/octosts/octosts.OrgTrustPolicy.json
+++ b/pkg/octosts/octosts.OrgTrustPolicy.json
@@ -113,6 +113,9 @@
         "organization_codespaces_settings": {
           "type": "string"
         },
+        "organization_copilot_metrics": {
+          "type": "string"
+        },
         "organization_copilot_seat_management": {
           "type": "string"
         },

--- a/pkg/octosts/octosts.OrgTrustedIssuers.json
+++ b/pkg/octosts/octosts.OrgTrustedIssuers.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/octo-sts/app/pkg/octosts/org-trusted-issuers",
+  "$ref": "#/$defs/OrgTrustedIssuers",
+  "$defs": {
+    "OrgTrustedIssuers": {
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": [
+            "enforce",
+            "audit"
+          ],
+          "description": "Mode selects enforcement behavior. \"enforce\" (the default) rejects\ntokens whose issuer is not permitted. \"audit\" permits them and records\nwhat would have been rejected, for staged rollout."
+        },
+        "issuers": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Issuers is the set of permitted issuer URLs, matched exactly."
+        },
+        "issuer_patterns": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "IssuerPatterns are regular expressions matched against the token\nissuer. Patterns are anchored and must match the entire URL."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "OrgTrustedIssuers is an organization-wide allowlist of OIDC issuers, read from .github/chainguard/trusted-token-issuers.yaml in the organization's .github repository."
+    }
+  }
+}

--- a/pkg/octosts/octosts.TrustPolicy.json
+++ b/pkg/octosts/octosts.TrustPolicy.json
@@ -113,6 +113,9 @@
         "organization_codespaces_settings": {
           "type": "string"
         },
+        "organization_copilot_metrics": {
+          "type": "string"
+        },
         "organization_copilot_seat_management": {
           "type": "string"
         },

--- a/pkg/octosts/octosts.go
+++ b/pkg/octosts/octosts.go
@@ -181,7 +181,7 @@ func (s *sts) Exchange(ctx context.Context, request *pboidc.ExchangeRequest) (_ 
 	}
 
 	var base *ghinstallation.AppsTransport
-	base, e.InstallationID, e.TrustPolicy, err = s.lookupInstallAndTrustPolicy(ctx, requestScope, request.GetIdentity(), tok.Subject)
+	base, e.InstallationID, e.TrustPolicy, e.IssuerAllowlist, err = s.lookupInstallAndTrustPolicy(ctx, requestScope, request.GetIdentity(), tok.Subject, issuer)
 	if err != nil {
 		return nil, err
 	}
@@ -276,7 +276,18 @@ func (s *sts) getExchangeInstall(ctx context.Context, owner, scope, identity, su
 	return atr, id, nil
 }
 
-func (s *sts) lookupInstallAndTrustPolicy(ctx context.Context, scope, identity, subject string) (*ghinstallation.AppsTransport, int64, *OrgTrustPolicy, error) {
+// lookupInstallAndTrustPolicy resolves the installation, enforces the
+// organization trusted-issuer allowlist, and loads the trust policy.
+//
+// issuer must be the value apiauth.ExtractIssuer returned — the same one
+// provider.Get was given — because allowlist entries are always written with a
+// scheme, and ExtractIssuer applies auth.NormalizeIssuer. In practice the two
+// forms coincide for every token that reaches here: the only value
+// NormalizeIssuer rewrites is the schemeless "accounts.google.com", and
+// TrustPolicy.CheckToken rejects that outright because
+// oidcvalidate.IsValidIssuer returns false for it. Passing the normalized value
+// is the conservative choice should either of those change.
+func (s *sts) lookupInstallAndTrustPolicy(ctx context.Context, scope, identity, subject, issuer string) (*ghinstallation.AppsTransport, int64, *OrgTrustPolicy, *IssuerDecision, error) {
 	otp := &OrgTrustPolicy{}
 	var tp trustPolicy = &otp.TrustPolicy
 
@@ -295,27 +306,39 @@ func (s *sts) lookupInstallAndTrustPolicy(ctx context.Context, scope, identity, 
 
 	if cached, ok := trustPolicies.Get(tpKey); ok && cached == negativeCacheConst {
 		clog.InfoContextf(ctx, "negative cache hit for %s", tpKey)
-		return nil, 0, nil, status.Errorf(codes.NotFound, "unable to find trust policy for %q", tpKey.identity)
+		return nil, 0, nil, nil, status.Errorf(codes.NotFound, "unable to find trust policy for %q", tpKey.identity)
 	}
 
 	// Read the trust policy using any available installation.
 	readAtr, readID, err := s.rrm.Get(ctx, owner, scope, identity)
 	if err != nil {
-		return nil, 0, nil, err
+		return nil, 0, nil, nil, err
+	}
+
+	// Enforce the organization trusted-issuer allowlist before spending a policy
+	// read or a second token mint on an issuer we may reject.
+	//
+	// This runs AFTER s.rrm.Get even though it ignores its return values: Get's
+	// negative install cache rejects an owner the App is not installed on before
+	// we do any allowlist work, which bounds the API amplification an arbitrary
+	// caller-supplied scope can drive.
+	decision, err := s.checkOrgTrustedIssuers(ctx, owner, issuer)
+	if err != nil {
+		return nil, 0, nil, decision, err
 	}
 
 	readAtr, readID, err = s.lookupTrustPolicyWithRetry(ctx, readAtr, readID, owner, scope, identity, tpKey, tp)
 	if err != nil {
-		return nil, 0, nil, err
+		return nil, 0, nil, decision, err
 	}
 
 	// Now that we know the permissions, pick the exchange installation.
 	atr, id, err := s.getExchangeInstall(ctx, owner, scope, identity, subject, otp.Permissions, readAtr, readID)
 	if err != nil {
-		return nil, 0, nil, err
+		return nil, 0, nil, decision, err
 	}
 
-	return atr, id, otp, nil
+	return atr, id, otp, decision, nil
 }
 
 // lookupTrustPolicyWithRetry fetches the trust policy, retrying with

--- a/pkg/octosts/octosts_test.go
+++ b/pkg/octosts/octosts_test.go
@@ -63,6 +63,11 @@ func (f *fakeInstallMgr) GetAll(_ context.Context, _ string) ([]ghinstall.Instal
 	return []ghinstall.Installation{{Transport: f.atr, ID: 1234, AppID: f.atr.AppID()}}, nil
 }
 
+// GetAllFresh delegates: these tests exercise routing, not cache freshness.
+func (f *fakeInstallMgr) GetAllFresh(ctx context.Context, owner string) ([]ghinstall.Installation, error) {
+	return f.GetAll(ctx, owner)
+}
+
 var _ ghinstall.Manager = (*fakeInstallMgr)(nil)
 
 type fakeGitHub struct {
@@ -420,6 +425,11 @@ func (f *failInstallMgr) GetAll(_ context.Context, _ string) ([]ghinstall.Instal
 	return nil, fmt.Errorf("kms unavailable")
 }
 
+// GetAllFresh delegates: these tests exercise routing, not cache freshness.
+func (f *failInstallMgr) GetAllFresh(ctx context.Context, owner string) ([]ghinstall.Installation, error) {
+	return f.GetAll(ctx, owner)
+}
+
 var _ ghinstall.Manager = (*failInstallMgr)(nil)
 
 // sequentialInstallMgr returns transports in order on successive Get calls.
@@ -451,6 +461,11 @@ func (s *sequentialInstallMgr) GetAll(_ context.Context, _ string) ([]ghinstall.
 		out = append(out, ghinstall.Installation{Transport: atr, ID: int64(1234 + i), AppID: atr.AppID()})
 	}
 	return out, nil
+}
+
+// GetAllFresh delegates: these tests exercise routing, not cache freshness.
+func (s *sequentialInstallMgr) GetAllFresh(ctx context.Context, owner string) ([]ghinstall.Installation, error) {
+	return s.GetAll(ctx, owner)
 }
 
 var _ ghinstall.Manager = (*sequentialInstallMgr)(nil)

--- a/pkg/octosts/octosts_test.go
+++ b/pkg/octosts/octosts_test.go
@@ -97,16 +97,49 @@ func newFakeGitHub() *fakeGitHub {
 		})
 	})
 	mux.HandleFunc("/repos/{org}/{repo}/contents/.github/chainguard/{identity}", func(w http.ResponseWriter, r *http.Request) {
+		// Sentinel: owner "orgdir" always resolves the trusted-issuers path to
+		// a directory rather than a file. go-github distinguishes the two by
+		// response shape — a single JSON object is a file, a JSON array is a
+		// directory listing — so this is the only way to make GetContents
+		// return a nil *RepositoryContent without an actual directory on disk.
+		// A real testdata directory would hit os.ReadFile's EISDIR below, which
+		// is not os.IsNotExist and would fall into the 500 branch instead.
+		if r.PathValue("org") == "orgdir" && r.PathValue("identity") == "trusted-token-issuers.yaml" {
+			json.NewEncoder(w).Encode([]*github.RepositoryContent{
+				{Type: github.Ptr("file"), Name: github.Ptr("placeholder")},
+			})
+			return
+		}
+
 		b, err := os.ReadFile(filepath.Join("testdata", r.PathValue("org"), r.PathValue("repo"), r.PathValue("identity")))
 		if err != nil {
+			// A missing fixture is a 404, matching real GitHub. The previous
+			// 500 (which also fell through to write a body) made the
+			// file-absent path indistinguishable from a server error.
+			if os.IsNotExist(err) {
+				writeGitHubNotFound(w)
+				return
+			}
 			w.WriteHeader(http.StatusInternalServerError)
 			fmt.Fprintf(io.MultiWriter(w, os.Stdout), "ReadFile failed: %v\n", err)
+			return
 		}
 		json.NewEncoder(w).Encode(github.RepositoryContent{
 			Content:  github.Ptr(base64.StdEncoding.EncodeToString(b)),
 			Type:     github.Ptr("file"),
 			Encoding: github.Ptr("base64"),
 		})
+	})
+	// Revoke() posts to this path, but it does NOT reach this fake. Revoke's URL
+	// follows the configured baseURL, which is empty in these tests, so it
+	// resolves to https://api.github.com/installation/token; and it sends via
+	// http.DefaultClient rather than the injected transport, so every revoke in
+	// tests escapes to real GitHub and 401s. Callers only log that warning, so
+	// nothing fails. This route is here so the fake is already correct if Revoke
+	// is ever pointed at the fake. The same dead route already exists in
+	// newFakeGitHubNotFoundCounter.
+	mux.HandleFunc("/installation/token", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
 	})
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotImplemented)
@@ -116,6 +149,20 @@ func newFakeGitHub() *fakeGitHub {
 	return &fakeGitHub{
 		mux: mux,
 	}
+}
+
+// writeGitHubNotFound writes a 404 shaped like a real GitHub error response, so
+// go-github produces a *github.ErrorResponse whose Response.StatusCode is 404.
+//
+// The status comes from WriteHeader, not from the body: go-github's
+// CheckResponse builds ErrorResponse{Response: r} from the real *http.Response
+// and unmarshals only Message/Errors/Block/DocumentationURL out of the body.
+// ErrorResponse.Response is tagged json:"-", so setting it here would be inert
+// — hence only Message is encoded.
+func writeGitHubNotFound(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusNotFound)
+	json.NewEncoder(w).Encode(github.ErrorResponse{Message: "Not Found"})
 }
 
 func (f *fakeGitHub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -316,6 +363,14 @@ func newFakeGitHubRateLimit(statusCode int) *fakeGitHub {
 		})
 	})
 	mux.HandleFunc("/repos/{org}/{repo}/contents/.github/chainguard/{identity}", func(w http.ResponseWriter, r *http.Request) {
+		// The organization allowlist read must not be rate-limited here, or
+		// these tests stop exercising the *policy* read they were written for.
+		// A later task adds a separate all-paths rate-limit fake for testing
+		// the allowlist read's own rate-limit handling.
+		if r.PathValue("identity") == "trusted-token-issuers.yaml" {
+			writeGitHubNotFound(w)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		// Real GitHub sends this on a primary rate limit, and it is what makes
 		// go-github return a *github.RateLimitError rather than a bare
@@ -329,6 +384,9 @@ func newFakeGitHubRateLimit(statusCode int) *fakeGitHub {
 			Response: &http.Response{StatusCode: statusCode},
 			Message:  "API rate limit exceeded",
 		})
+	})
+	mux.HandleFunc("/installation/token", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
 	})
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotImplemented)
@@ -358,6 +416,12 @@ func TestExchangeRateLimit(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			orgIssuers.Add("org", absentOrgIssuerEntry())
+			t.Cleanup(func() {
+				orgIssuers.Remove("org")
+				staleOrgIssuers.Remove("org")
+			})
+
 			ctx := context.Background()
 			atr := newAppsTransport(t, newFakeGitHubRateLimit(tc.statusCode))
 
@@ -532,6 +596,12 @@ func TestPolicyReadRetriesOnRateLimit(t *testing.T) {
 		staleTrustPolicies.Remove(key)
 	})
 
+	orgIssuers.Add("org", absentOrgIssuerEntry())
+	t.Cleanup(func() {
+		orgIssuers.Remove("org")
+		staleOrgIssuers.Remove("org")
+	})
+
 	ctx := context.Background()
 	rateLimitedAtr := newAppsTransport(t, newFakeGitHubRateLimit(http.StatusForbidden))
 	workingAtr := newAppsTransport(t, newFakeGitHub())
@@ -584,6 +654,12 @@ func TestPolicyReadAllRateLimitedReturnsError(t *testing.T) {
 	t.Cleanup(func() {
 		trustPolicies.Remove(key)
 		staleTrustPolicies.Remove(key)
+	})
+
+	orgIssuers.Add("org", absentOrgIssuerEntry())
+	t.Cleanup(func() {
+		orgIssuers.Remove("org")
+		staleOrgIssuers.Remove("org")
 	})
 
 	ctx := context.Background()
@@ -728,7 +804,7 @@ func TestNegativeCacheSkipsInstallationTokenCreation(t *testing.T) {
 		appCount: 1,
 	}
 
-	_, _, _, err := s.lookupInstallAndTrustPolicy(context.Background(), "org/repo", "cached-missing", "some-subject")
+	_, _, _, _, err := s.lookupInstallAndTrustPolicy(context.Background(), "org/repo", "cached-missing", "some-subject", testGitHubIssuer)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}

--- a/pkg/octosts/octosts_test.go
+++ b/pkg/octosts/octosts_test.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -867,6 +868,17 @@ func TestRateLimitServesStaleCache(t *testing.T) {
 	}
 }
 
+// sharedAppKey returns one RSA key for the whole package. newAppsTransport is called
+// ~50 times across these tests and RSA-2048 generation dominated the suite's runtime;
+// the key only signs App JWTs that the fakes never verify, so one is enough.
+var sharedAppKey = sync.OnceValue(func() *rsa.PrivateKey {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		panic("generating the shared test App key: " + err.Error())
+	}
+	return key
+})
+
 func newAppsTransport(t *testing.T, h http.Handler) *ghinstallation.AppsTransport {
 	t.Helper()
 
@@ -895,11 +907,7 @@ func newAppsTransport(t *testing.T, h http.Handler) *ghinstallation.AppsTranspor
 		},
 	}
 
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		t.Fatalf("GenerateKey failed: %v", err)
-	}
-	ghsigner := ghinstallation.NewRSASigner(jwt.SigningMethodRS256, key)
+	ghsigner := ghinstallation.NewRSASigner(jwt.SigningMethodRS256, sharedAppKey())
 
 	atr, err := ghinstallation.NewAppsTransportWithOptions(transport, 1234, ghinstallation.WithSigner(ghsigner))
 	if err != nil {

--- a/pkg/octosts/org_trusted_issuers.go
+++ b/pkg/octosts/org_trusted_issuers.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"regexp/syntax"
 	"slices"
 	"strings"
 
@@ -103,6 +104,9 @@ func (c *OrgTrustedIssuers) Compile() (*IssuerAllowlist, error) {
 		if err := checkNoSlashMatchingAtom(i, p); err != nil {
 			return nil, err
 		}
+		if err := checkNoSeparatorUnderQuantifier(i, p); err != nil {
+			return nil, err
+		}
 		// Compile p ALONE first: the group below hides an unbalanced ")", so
 		// "token\.example\.com)|(" wraps to "^(?:token\.example\.com)|()$", whose "()$"
 		// alternative matches everything. A legitimate top-level "a|b" still compiles.
@@ -152,10 +156,8 @@ func (a *IssuerAllowlist) Allows(issuer string) bool {
 // "/" without containing ".", and "[.-9]" holds "/" by range. A LITERAL "/" stays allowed;
 // unterminated brackets are left to regexp.Compile.
 //
-// KNOWN LIMITATION, structural rather than a missing case: being per-ATOM, a literal "/"
-// inside a QUANTIFIED group escapes it, so "https://([a-z0-9.-]+/)*trusted\.example\.com"
-// validates yet matches "https://evil.com/x/trusted.example.com". Catching it needs AST
-// analysis; TestCompileKnownLimitationQuantifiedGroupSpansSeparators pins the gap.
+// Being per-ATOM it cannot see a "/" that only spans because of surrounding
+// STRUCTURE; checkNoSeparatorUnderQuantifier covers that half.
 func checkNoSlashMatchingAtom(i int, p string) error {
 	for j := 0; j < len(p); j++ {
 		var atom string
@@ -207,6 +209,73 @@ func checkNoSlashMatchingAtom(i int, p string) error {
 		}
 	}
 	return nil
+}
+
+// checkNoSeparatorUnderQuantifier rejects a pattern where a "/"-matching element sits
+// inside a repetition, an optional, or an alternation. The per-atom scan cannot see
+// this: every atom in "([a-z0-9.-]+/)*" is innocent on its own, yet the group spans
+// separators, so "https://([a-z0-9.-]+/)*trusted\.example\.com" matches
+// "https://evil.com/x/trusted.example.com" — attacker-chosen host, trusted name demoted
+// to a path segment. "?", "{n,m}" and alternation do the same.
+//
+// A literal "/" at a FIXED position stays allowed, so real multi-segment issuers such as
+// "https://host\.example\.com/id/[A-Z0-9]+" still validate. An author who wants
+// alternatives writes separate issuer_patterns entries instead of one alternation.
+func checkNoSeparatorUnderQuantifier(i int, p string) error {
+	re, err := syntax.Parse(p, syntax.Perl)
+	if err != nil {
+		// Unparseable: regexp.Compile reports it better than we would.
+		return nil
+	}
+	if found := separatorUnderQuantifier(re, false); found != "" {
+		return fmt.Errorf(`issuer_patterns[%d]: %s can match "/" from inside a `+
+			`repetition, optional or alternation, so the pattern can span past the `+
+			`host — "https://([a-z0-9.-]+/)*trusted\.example\.com" also permits `+
+			`"https://evil.com/x/trusted.example.com". Keep "/" at a fixed position, `+
+			`e.g. https://host\.example\.com/id/[A-Z0-9]+, and write alternatives as `+
+			`separate issuer_patterns entries rather than one alternation`, i, found)
+	}
+	return nil
+}
+
+// separatorUnderQuantifier reports the first "/"-matching element reachable under a
+// variable-length or alternating node, or "" if there is none. variable becomes true
+// once inside such a node and stays true for the whole subtree.
+func separatorUnderQuantifier(re *syntax.Regexp, variable bool) string {
+	switch re.Op {
+	case syntax.OpStar, syntax.OpPlus, syntax.OpQuest, syntax.OpRepeat, syntax.OpAlternate:
+		variable = true
+	}
+	if variable {
+		if what := slashMatchingElement(re); what != "" {
+			return what
+		}
+	}
+	for _, sub := range re.Sub {
+		if found := separatorUnderQuantifier(sub, variable); found != "" {
+			return found
+		}
+	}
+	return ""
+}
+
+// slashMatchingElement names re if it can match "/" on its own, else "".
+func slashMatchingElement(re *syntax.Regexp) string {
+	switch re.Op {
+	case syntax.OpLiteral:
+		if slices.Contains(re.Rune, '/') {
+			return `a literal "/"`
+		}
+	case syntax.OpCharClass:
+		for j := 0; j+1 < len(re.Rune); j += 2 {
+			if re.Rune[j] <= '/' && '/' <= re.Rune[j+1] {
+				return "a character class containing \"/\""
+			}
+		}
+	case syntax.OpAnyChar, syntax.OpAnyCharNotNL:
+		return `"." (which matches "/")`
+	}
+	return ""
 }
 
 // endOfEscape returns the index just past the character-class escape starting at the

--- a/pkg/octosts/org_trusted_issuers.go
+++ b/pkg/octosts/org_trusted_issuers.go
@@ -100,11 +100,7 @@ func (c *OrgTrustedIssuers) Compile() (*IssuerAllowlist, error) {
 		if len(p) > maxPatternLen {
 			return nil, fmt.Errorf("issuer_patterns[%d] too long: %d chars (max %d)", i, len(p), maxPatternLen)
 		}
-		// First, so a loose-and-malformed pattern reports its looseness.
-		if err := checkNoSlashMatchingAtom(i, p); err != nil {
-			return nil, err
-		}
-		if err := checkNoSeparatorUnderQuantifier(i, p); err != nil {
+		if err := checkPatternCannotSpanHost(i, p); err != nil {
 			return nil, err
 		}
 		// Compile p ALONE first: the group below hides an unbalanced ")", so
@@ -146,224 +142,67 @@ func (a *IssuerAllowlist) Allows(issuer string) bool {
 	return false
 }
 
-// checkNoSlashMatchingAtom rejects any single-character atom that can match "/": such an
-// atom lets a pattern span past the host, so "https://.*\.example\.com" would also permit
-// "https://totally-evil.com/x.example.com". BEST-EFFORT FOOTGUN GUARD, NOT A SECURITY
-// BOUNDARY — the author is the org owner.
+// checkPatternCannotSpanHost rejects an issuer_pattern that can match "/" and so span
+// past the host: "https://.*\.example\.com" also permits "https://evil.com/x.example.com".
+// BEST-EFFORT FOOTGUN GUARD, NOT A SECURITY BOUNDARY — the author is the org owner.
 //
-// The test is EMPIRICAL — each atom compiled alone as "^atom$" and asked whether it matches
-// "/" — because banned spellings cannot be enumerated: "\S", "[^\n]" and "[[:ascii:]]" match
-// "/" without containing ".", and "[.-9]" holds "/" by range. A LITERAL "/" stays allowed;
-// unterminated brackets are left to regexp.Compile.
-//
-// Being per-ATOM it cannot see a "/" that only spans because of surrounding
-// STRUCTURE; checkNoSeparatorUnderQuantifier covers that half.
-func checkNoSlashMatchingAtom(i int, p string) error {
-	for j := 0; j < len(p); j++ {
-		var atom string
-
-		switch p[j] {
-		case '.':
-			atom = "."
-
-		case '\\':
-			end := endOfEscape(p, j)
-			if end < 0 {
-				// Skip the escaped byte so "\." is never read as a wildcard.
-				j++
-				continue
-			}
-			atom, j = p[j:end], end-1
-
-		case '[':
-			end := endOfBracketExpression(p, j)
-			if end < 0 {
-				return nil
-			}
-			atom, j = p[j:end], end-1
-
-		default:
-			continue
-		}
-
-		re, err := regexp.Compile("^" + atom + "$")
-		if err != nil {
-			// Fail CLOSED: an atom we cannot analyze is not one we know is safe, and
-			// skipping it would turn every scanner mis-parse into a silent bypass.
-			return fmt.Errorf(`issuer_patterns[%d]: cannot verify that %q cannot `+
-				`match "/" (%v), so the pattern is rejected rather than assumed `+
-				`safe — rewrite it with a plain class such as [a-z0-9-]`, i, atom, err)
-		}
-		if re.MatchString("/") {
-			return fmt.Errorf(`issuer_patterns[%d]: %q can match "/", so the pattern `+
-				`can span past the host into an attacker-controlled domain, as `+
-				`"https://.*\.example\.com" also permits `+
-				`"https://totally-evil.com/x.example.com" — escape literal dots as `+
-				`"\." and bound each varying part, e.g. `+
-				`https://[a-z0-9-]+\.example\.com. Write a path one segment at a `+
-				`time with literal separators, e.g. `+
-				`https://example\.com/realms/[a-z0-9-]+, because a class that `+
-				`itself contains "/" is rejected for the same reason. `+
-				`This is a best-effort check, `+
-				`not a guarantee: write patterns as narrowly as you can`, i, atom)
-		}
-	}
-	return nil
-}
-
-// checkNoSeparatorUnderQuantifier rejects a pattern where a "/"-matching element sits
-// inside a repetition, an optional, or an alternation. The per-atom scan cannot see
-// this: every atom in "([a-z0-9.-]+/)*" is innocent on its own, yet the group spans
-// separators, so "https://([a-z0-9.-]+/)*trusted\.example\.com" matches
-// "https://evil.com/x/trusted.example.com" — attacker-chosen host, trusted name demoted
-// to a path segment. "?", "{n,m}" and alternation do the same.
-//
-// A literal "/" at a FIXED position stays allowed, so real multi-segment issuers such as
-// "https://host\.example\.com/id/[A-Z0-9]+" still validate. An author who wants
-// alternatives writes separate issuer_patterns entries instead of one alternation.
-func checkNoSeparatorUnderQuantifier(i int, p string) error {
+// It inspects the regexp/syntax AST — the same parse regexp.Compile performs — so it
+// cannot disagree with the matcher about tokenization. A hand-written byte scanner did
+// this before and disagreed six times, each a bypass.
+func checkPatternCannotSpanHost(i int, p string) error {
 	re, err := syntax.Parse(p, syntax.Perl)
 	if err != nil {
-		// Unparseable: regexp.Compile reports it better than we would.
+		// Unparseable: the compile below reports it better than we would.
 		return nil
 	}
-	if found := separatorUnderQuantifier(re, false); found != "" {
-		return fmt.Errorf(`issuer_patterns[%d]: %s can match "/" from inside a `+
-			`repetition, optional or alternation, so the pattern can span past the `+
-			`host — "https://([a-z0-9.-]+/)*trusted\.example\.com" also permits `+
-			`"https://evil.com/x/trusted.example.com". Keep "/" at a fixed position, `+
-			`e.g. https://host\.example\.com/id/[A-Z0-9]+, and write alternatives as `+
-			`separate issuer_patterns entries rather than one alternation`, i, found)
+	if what := spanningElement(re, false); what != "" {
+		return fmt.Errorf(`issuer_patterns[%d]: %s, so the pattern can span past the `+
+			`host into an attacker-controlled domain, as "https://.*\.example\.com" also `+
+			`permits "https://totally-evil.com/x.example.com" — escape literal dots as `+
+			`"\." and bound each varying part, e.g. https://[a-z0-9-]+\.example\.com. Keep `+
+			`"/" at a fixed position, writing a path one segment at a time, and give `+
+			`alternatives their own issuer_patterns entries. This is a best-effort check, `+
+			`not a guarantee: write patterns as narrowly as you can`, i, what)
 	}
 	return nil
 }
 
-// separatorUnderQuantifier reports the first "/"-matching element reachable under a
-// variable-length or alternating node, or "" if there is none. variable becomes true
-// once inside such a node and stays true for the whole subtree.
-func separatorUnderQuantifier(re *syntax.Regexp, variable bool) string {
+// spanningElement describes the first element that lets the pattern match "/", or "".
+//
+// A class or "." matching "/" is rejected ANYWHERE: parsing desugars "\S", "[^\n]",
+// "[[:ascii:]]", "\p{P}" and "[.-9]" into rune ranges, so one range test covers every
+// spelling. A literal "/" is rejected only under a repetition, optional or alternation
+// — at a fixed position it is how real multi-segment issuers are written, e.g.
+// https://host\.example\.com/id/[A-Z0-9]+. variable carries that down the subtree.
+func spanningElement(re *syntax.Regexp, variable bool) string {
 	switch re.Op {
 	case syntax.OpStar, syntax.OpPlus, syntax.OpQuest, syntax.OpRepeat, syntax.OpAlternate:
 		variable = true
 	}
-	if variable {
-		if what := slashMatchingElement(re); what != "" {
-			return what
-		}
-	}
-	for _, sub := range re.Sub {
-		if found := separatorUnderQuantifier(sub, variable); found != "" {
-			return found
-		}
-	}
-	return ""
-}
 
-// slashMatchingElement names re if it can match "/" on its own, else "".
-func slashMatchingElement(re *syntax.Regexp) string {
 	switch re.Op {
-	case syntax.OpLiteral:
-		if slices.Contains(re.Rune, '/') {
-			return `a literal "/"`
-		}
+	case syntax.OpAnyChar, syntax.OpAnyCharNotNL:
+		return `"." can match "/"`
+
 	case syntax.OpCharClass:
 		for j := 0; j+1 < len(re.Rune); j += 2 {
 			if re.Rune[j] <= '/' && '/' <= re.Rune[j+1] {
-				return "a character class containing \"/\""
+				return `a character class can match "/"`
 			}
 		}
-	case syntax.OpAnyChar, syntax.OpAnyCharNotNL:
-		return `"." (which matches "/")`
+
+	case syntax.OpLiteral:
+		if variable && slices.Contains(re.Rune, '/') {
+			return `a literal "/" sits inside a repetition, optional or alternation`
+		}
+	}
+
+	for _, sub := range re.Sub {
+		if what := spanningElement(sub, variable); what != "" {
+			return what
+		}
 	}
 	return ""
-}
-
-// endOfEscape returns the index just past the character-class escape starting at the
-// backslash at p[j], or -1 when there is no atom to test (an escaped literal or
-// trailing backslash) and the caller should skip two bytes.
-func endOfEscape(p string, j int) int {
-	if j+1 >= len(p) {
-		return -1
-	}
-	switch p[j+1] {
-	case 'd', 'D', 's', 'S', 'w', 'W':
-		return j + 2
-
-	// Numeric escapes SPELL characters rather than naming classes ("\x2F", "\x{2F}" and
-	// "\057" are all "/"); as escaped literals they would be skipped and never tested.
-	case 'x':
-		if j+2 >= len(p) {
-			return -1
-		}
-		if p[j+2] == '{' {
-			if k := strings.IndexByte(p[j+2:], '}'); k >= 0 {
-				return j + 2 + k + 1
-			}
-			return -1
-		}
-		if j+3 < len(p) && isHexDigit(p[j+2]) && isHexDigit(p[j+3]) {
-			return j + 4
-		}
-		return -1
-	case '0', '1', '2', '3', '4', '5', '6', '7':
-		end := j + 2
-		for end < len(p) && end < j+4 && p[end] >= '0' && p[end] <= '7' {
-			end++
-		}
-		return end
-
-	case 'p', 'P':
-		if j+2 >= len(p) {
-			return -1
-		}
-		if p[j+2] != '{' {
-			return j + 3
-		}
-		if k := strings.IndexByte(p[j+2:], '}'); k >= 0 {
-			return j + 2 + k + 1
-		}
-		return -1
-	default:
-		return -1
-	}
-}
-
-func isHexDigit(b byte) bool {
-	return b >= '0' && b <= '9' || b >= 'a' && b <= 'f' || b >= 'A' && b <= 'F'
-}
-
-// endOfBracketExpression returns the index just past the bracket expression opening at
-// p[j], or -1 if unterminated. More than a search for "]": a backslash escapes the next
-// byte ("[a-z\]]"), a POSIX class carries its own "]" ("[[:alpha:]]"), and a leading "]"
-// is a literal member ("[^]]").
-func endOfBracketExpression(p string, j int) int {
-	k := j + 1
-	if k < len(p) && p[k] == '^' {
-		k++
-	}
-	// RE2 reads a first-position "]" as a literal; stopping there would extract the
-	// uncompilable "[^]" and leave the real class untested.
-	if k < len(p) && p[k] == ']' {
-		k++
-	}
-	for ; k < len(p); k++ {
-		switch p[k] {
-		case '\\':
-			k++
-		case '[':
-			// "[:name:]" is a POSIX class only when a ":]" actually follows; otherwise
-			// RE2 reads this "[" as an ordinary member and the real "]" is still ahead,
-			// so keep scanning: bailing out let "[[:/-~]", holding "/", pass untested.
-			if strings.HasPrefix(p[k:], "[:") {
-				if end := strings.Index(p[k:], ":]"); end >= 0 {
-					k += end + 1
-				}
-			}
-		case ']':
-			return k + 1
-		}
-	}
-	return -1
 }
 
 // checkLowercaseSchemeAndHost rejects uppercase in an issuer's scheme or host: matching

--- a/pkg/octosts/org_trusted_issuers.go
+++ b/pkg/octosts/org_trusted_issuers.go
@@ -1,0 +1,315 @@
+// Copyright 2026 Chainguard, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package octosts
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/octo-sts/app/pkg/oidcvalidate"
+	"sigs.k8s.io/yaml"
+)
+
+// Mode selects how an org's trusted-issuer allowlist is applied.
+type Mode string
+
+const (
+	// ModeEnforce rejects tokens whose issuer is not permitted. Default.
+	ModeEnforce Mode = "enforce"
+	// ModeAudit permits them and records what would have been rejected.
+	ModeAudit Mode = "audit"
+)
+
+// Size caps bound memory and compile time; RE2 cannot backtrack catastrophically.
+const (
+	maxIssuers        = 64
+	maxIssuerPatterns = 16
+	maxPatternLen     = 256
+)
+
+// OrgTrustedIssuers is an org-wide allowlist of OIDC issuers read from
+// OrgTrustedIssuersPath. When present, only issuers it permits may federate.
+type OrgTrustedIssuers struct {
+	Mode Mode `json:"mode,omitempty" jsonschema:"enum=enforce,enum=audit"`
+
+	// Issuers is matched byte-exactly.
+	Issuers []string `json:"issuers,omitempty"`
+
+	// IssuerPatterns are anchored regexps matching the entire issuer URL.
+	IssuerPatterns []string `json:"issuer_patterns,omitempty"`
+}
+
+// ParseOrgTrustedIssuers unmarshals and compiles raw file contents. Both the
+// exchange path and the webhook check call this, so they cannot disagree.
+func ParseOrgTrustedIssuers(raw []byte) (*IssuerAllowlist, error) {
+	var cfg OrgTrustedIssuers
+	if err := yaml.UnmarshalStrict(raw, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing organization trusted issuers: %w", err)
+	}
+	return cfg.Compile()
+}
+
+// IssuerAllowlist is a compiled OrgTrustedIssuers, immutable and concurrent-safe.
+type IssuerAllowlist struct {
+	mode     Mode
+	issuers  []string
+	patterns []*regexp.Regexp
+}
+
+// Compile validates the configuration and prepares it for matching. It returns a
+// new value, unlike TrustPolicy.Compile, so a cached allowlist cannot be
+// invalidated by a concurrent recompile.
+func (c *OrgTrustedIssuers) Compile() (*IssuerAllowlist, error) {
+	mode := c.Mode
+	switch mode {
+	case "":
+		mode = ModeEnforce
+	case ModeEnforce, ModeAudit:
+	default:
+		return nil, fmt.Errorf("unknown mode %q (want %q or %q)", c.Mode, ModeEnforce, ModeAudit)
+	}
+
+	// An empty file would deny all federation in the org: a silent outage.
+	if len(c.Issuers) == 0 && len(c.IssuerPatterns) == 0 {
+		return nil, errors.New("must list at least one entry in issuers or issuer_patterns")
+	}
+
+	if len(c.Issuers) > maxIssuers {
+		return nil, fmt.Errorf("too many issuers: %d (max %d)", len(c.Issuers), maxIssuers)
+	}
+	if len(c.IssuerPatterns) > maxIssuerPatterns {
+		return nil, fmt.Errorf("too many issuer_patterns: %d (max %d)", len(c.IssuerPatterns), maxIssuerPatterns)
+	}
+
+	for _, iss := range c.Issuers {
+		if !oidcvalidate.IsValidIssuer(iss) {
+			return nil, fmt.Errorf("invalid issuer %q", iss)
+		}
+		if err := checkLowercaseSchemeAndHost(iss); err != nil {
+			return nil, err
+		}
+	}
+
+	patterns := make([]*regexp.Regexp, 0, len(c.IssuerPatterns))
+	for i, p := range c.IssuerPatterns {
+		if len(p) > maxPatternLen {
+			return nil, fmt.Errorf("issuer_patterns[%d] too long: %d chars (max %d)", i, len(p), maxPatternLen)
+		}
+		// Before compiling: a loose-and-malformed pattern should report looseness.
+		if err := checkNoSlashMatchingAtom(i, p); err != nil {
+			return nil, err
+		}
+		// Compile p ALONE first: the group below hides an unbalanced ")", so
+		// "token\.example\.com)|(" wraps to "^(?:token\.example\.com)|()$", whose
+		// "()$" alternative matches everything — allow-all, reported Valid by the
+		// webhook. A legitimate top-level "a|b" still compiles alone.
+		if _, err := regexp.Compile(p); err != nil {
+			return nil, fmt.Errorf("invalid issuer_pattern %q: %w", p, err)
+		}
+		// Non-capturing group required: "|" binds looser than the anchors, so
+		// "^"+p+"$" parses as "(^A)|(B$)", leaving an alternation unanchored.
+		re, err := regexp.Compile("^(?:" + p + ")$")
+		if err != nil {
+			return nil, fmt.Errorf("invalid issuer_pattern %q: %w", p, err)
+		}
+		patterns = append(patterns, re)
+	}
+
+	return &IssuerAllowlist{
+		mode:     mode,
+		issuers:  slices.Clone(c.Issuers),
+		patterns: patterns,
+	}, nil
+}
+
+func (a *IssuerAllowlist) Mode() Mode { return a.mode }
+
+// Allows reports whether issuer is permitted. The two lists are a union,
+// deliberately unlike TrustPolicy where they are mutually exclusive. Patterns
+// honour inline flags such as (?i), so matching is only as strict as the pattern.
+func (a *IssuerAllowlist) Allows(issuer string) bool {
+	if slices.Contains(a.issuers, issuer) {
+		return true
+	}
+	for _, re := range a.patterns {
+		if re.MatchString(issuer) {
+			return true
+		}
+	}
+	return false
+}
+
+// checkNoSlashMatchingAtom rejects an issuer_pattern containing any
+// single-character atom that can match "/". BEST-EFFORT FOOTGUN GUARD, NOT A
+// SECURITY BOUNDARY — the author is the org owner. The accident it catches: an
+// atom matching "/" lets a pattern span past the host, so
+// "https://.*\.example\.com" also permits "https://totally-evil.com/x.example.com".
+//
+// The test is EMPIRICAL — each atom compiled alone as "^atom$", asked whether it
+// matches "/" — because banned spellings cannot be enumerated: "\S", "[^\n]" and
+// "[[:ascii:]]" match "/" without containing ".", and "[.-9]" holds "/" by range.
+// A LITERAL "/" stays allowed. Unterminated brackets are left to regexp.Compile.
+func checkNoSlashMatchingAtom(i int, p string) error {
+	for j := 0; j < len(p); j++ {
+		var atom string
+
+		switch p[j] {
+		case '.':
+			atom = "."
+
+		case '\\':
+			end := endOfEscape(p, j)
+			if end < 0 {
+				// Skip the escaped byte so "\." is never read as a wildcard.
+				j++
+				continue
+			}
+			atom, j = p[j:end], end-1
+
+		case '[':
+			end := endOfBracketExpression(p, j)
+			if end < 0 {
+				return nil
+			}
+			atom, j = p[j:end], end-1
+
+		default:
+			continue
+		}
+
+		re, err := regexp.Compile("^" + atom + "$")
+		if err != nil {
+			// Fail CLOSED: an atom we cannot analyze is not an atom we know is safe.
+			// Skipping it would turn every scanner mis-parse into a silent bypass.
+			return fmt.Errorf(`issuer_patterns[%d]: cannot verify that %q cannot `+
+				`match "/" (%v), so the pattern is rejected rather than assumed `+
+				`safe — rewrite it with a plain class such as [a-z0-9-]`, i, atom, err)
+		}
+		if re.MatchString("/") {
+			return fmt.Errorf(`issuer_patterns[%d]: %q can match "/", so the pattern `+
+				`can span past the host into an attacker-controlled domain, as `+
+				`"https://.*\.example\.com" also permits `+
+				`"https://totally-evil.com/x.example.com" — escape literal dots as `+
+				`"\." and bound each varying part, e.g. `+
+				`https://[a-z0-9-]+\.example\.com. Write a path one segment at a `+
+				`time with literal separators, e.g. `+
+				`https://example\.com/realms/[a-z0-9-]+, because a class that `+
+				`itself contains "/" is rejected for the same reason. `+
+				`This is a best-effort check, `+
+				`not a guarantee: write patterns as narrowly as you can`, i, atom)
+		}
+	}
+	return nil
+}
+
+// endOfEscape returns the index just past the character-class escape starting at
+// the backslash at p[j], or -1 when there is no atom to test (an escaped literal
+// or trailing backslash), meaning the caller should skip two bytes.
+func endOfEscape(p string, j int) int {
+	if j+1 >= len(p) {
+		return -1
+	}
+	switch p[j+1] {
+	case 'd', 'D', 's', 'S', 'w', 'W':
+		return j + 2
+
+	// Numeric escapes SPELL characters rather than naming classes: "\x2F",
+	// "\x{2F}" and "\057" are all "/". Treated as escaped literals they would be
+	// skipped and the slash they encode would never be tested.
+	case 'x':
+		if j+2 >= len(p) {
+			return -1
+		}
+		if p[j+2] == '{' {
+			if k := strings.IndexByte(p[j+2:], '}'); k >= 0 {
+				return j + 2 + k + 1
+			}
+			return -1
+		}
+		if j+3 < len(p) && isHexDigit(p[j+2]) && isHexDigit(p[j+3]) {
+			return j + 4
+		}
+		return -1
+	case '0', '1', '2', '3', '4', '5', '6', '7':
+		end := j + 2
+		for end < len(p) && end < j+4 && p[end] >= '0' && p[end] <= '7' {
+			end++
+		}
+		return end
+
+	case 'p', 'P':
+		if j+2 >= len(p) {
+			return -1
+		}
+		if p[j+2] != '{' {
+			return j + 3
+		}
+		if k := strings.IndexByte(p[j+2:], '}'); k >= 0 {
+			return j + 2 + k + 1
+		}
+		return -1
+	default:
+		return -1
+	}
+}
+
+func isHexDigit(b byte) bool {
+	return b >= '0' && b <= '9' || b >= 'a' && b <= 'f' || b >= 'A' && b <= 'F'
+}
+
+// endOfBracketExpression returns the index just past the bracket expression
+// opening at p[j], or -1 if unterminated. More than a search for "]": a
+// backslash escapes the next byte ("[a-z\]]"), a POSIX class carries its own "]"
+// ("[[:alpha:]]"), and a leading "]" is a literal member ("[^]]").
+func endOfBracketExpression(p string, j int) int {
+	k := j + 1
+	if k < len(p) && p[k] == '^' {
+		k++
+	}
+	// RE2 reads a first-position "]" as a literal. Stopping on it would extract
+	// the uncompilable "[^]" and leave the real class untested.
+	if k < len(p) && p[k] == ']' {
+		k++
+	}
+	for ; k < len(p); k++ {
+		switch p[k] {
+		case '\\':
+			k++
+		case '[':
+			// "[:name:]" is a POSIX class only when a ":]" actually follows;
+			// otherwise RE2 reads this "[" as an ordinary member and the real "]"
+			// is still ahead, so keep scanning rather than bailing out — bailing
+			// let "[[:/-~]", a class holding "/", pass untested.
+			if strings.HasPrefix(p[k:], "[:") {
+				if end := strings.Index(p[k:], ":]"); end >= 0 {
+					k += end + 1
+				}
+			}
+		case ']':
+			return k + 1
+		}
+	}
+	return -1
+}
+
+// checkLowercaseSchemeAndHost rejects uppercase in an issuer's scheme or host:
+// matching is byte-exact, so those would never match a real "iss" claim — a
+// silent org-wide outage in enforce mode. It inspects the RAW string because
+// url.Parse lowercases the scheme, hiding the problem. Paths are legitimately
+// mixed-case (e.g. AWS EKS /id/ABCDEF123456) and excluded.
+func checkLowercaseSchemeAndHost(iss string) error {
+	schemeAndHost := iss
+	if i := strings.Index(iss, "://"); i >= 0 {
+		if j := strings.Index(iss[i+3:], "/"); j >= 0 {
+			schemeAndHost = iss[:i+3+j]
+		}
+	}
+	if schemeAndHost != strings.ToLower(schemeAndHost) {
+		return fmt.Errorf("issuer %q must be lowercase in scheme and host", iss)
+	}
+	return nil
+}

--- a/pkg/octosts/org_trusted_issuers.go
+++ b/pkg/octosts/org_trusted_issuers.go
@@ -32,7 +32,7 @@ const (
 )
 
 // OrgTrustedIssuers is an org-wide allowlist of OIDC issuers read from
-// OrgTrustedIssuersPath. When present, only issuers it permits may federate.
+// OrgTrustedIssuersPath; when present, only issuers it permits may federate.
 type OrgTrustedIssuers struct {
 	Mode Mode `json:"mode,omitempty" jsonschema:"enum=enforce,enum=audit"`
 
@@ -60,8 +60,8 @@ type IssuerAllowlist struct {
 	patterns []*regexp.Regexp
 }
 
-// Compile validates the configuration and prepares it for matching. It returns a
-// new value, unlike TrustPolicy.Compile, so a cached allowlist cannot be
+// Compile validates the configuration and prepares it for matching. Unlike
+// TrustPolicy.Compile it returns a NEW value, so a cached allowlist cannot be
 // invalidated by a concurrent recompile.
 func (c *OrgTrustedIssuers) Compile() (*IssuerAllowlist, error) {
 	mode := c.Mode
@@ -99,14 +99,13 @@ func (c *OrgTrustedIssuers) Compile() (*IssuerAllowlist, error) {
 		if len(p) > maxPatternLen {
 			return nil, fmt.Errorf("issuer_patterns[%d] too long: %d chars (max %d)", i, len(p), maxPatternLen)
 		}
-		// Before compiling: a loose-and-malformed pattern should report looseness.
+		// First, so a loose-and-malformed pattern reports its looseness.
 		if err := checkNoSlashMatchingAtom(i, p); err != nil {
 			return nil, err
 		}
 		// Compile p ALONE first: the group below hides an unbalanced ")", so
-		// "token\.example\.com)|(" wraps to "^(?:token\.example\.com)|()$", whose
-		// "()$" alternative matches everything — allow-all, reported Valid by the
-		// webhook. A legitimate top-level "a|b" still compiles alone.
+		// "token\.example\.com)|(" wraps to "^(?:token\.example\.com)|()$", whose "()$"
+		// alternative matches everything. A legitimate top-level "a|b" still compiles.
 		if _, err := regexp.Compile(p); err != nil {
 			return nil, fmt.Errorf("invalid issuer_pattern %q: %w", p, err)
 		}
@@ -128,9 +127,9 @@ func (c *OrgTrustedIssuers) Compile() (*IssuerAllowlist, error) {
 
 func (a *IssuerAllowlist) Mode() Mode { return a.mode }
 
-// Allows reports whether issuer is permitted. The two lists are a union,
-// deliberately unlike TrustPolicy where they are mutually exclusive. Patterns
-// honour inline flags such as (?i), so matching is only as strict as the pattern.
+// Allows reports whether issuer is permitted. The two lists are a union, deliberately
+// unlike TrustPolicy where they are mutually exclusive. Patterns honour inline flags
+// such as (?i), so matching is only as strict as the pattern.
 func (a *IssuerAllowlist) Allows(issuer string) bool {
 	if slices.Contains(a.issuers, issuer) {
 		return true
@@ -143,16 +142,20 @@ func (a *IssuerAllowlist) Allows(issuer string) bool {
 	return false
 }
 
-// checkNoSlashMatchingAtom rejects an issuer_pattern containing any
-// single-character atom that can match "/". BEST-EFFORT FOOTGUN GUARD, NOT A
-// SECURITY BOUNDARY — the author is the org owner. The accident it catches: an
-// atom matching "/" lets a pattern span past the host, so
-// "https://.*\.example\.com" also permits "https://totally-evil.com/x.example.com".
+// checkNoSlashMatchingAtom rejects any single-character atom that can match "/": such an
+// atom lets a pattern span past the host, so "https://.*\.example\.com" would also permit
+// "https://totally-evil.com/x.example.com". BEST-EFFORT FOOTGUN GUARD, NOT A SECURITY
+// BOUNDARY — the author is the org owner.
 //
-// The test is EMPIRICAL — each atom compiled alone as "^atom$", asked whether it
-// matches "/" — because banned spellings cannot be enumerated: "\S", "[^\n]" and
-// "[[:ascii:]]" match "/" without containing ".", and "[.-9]" holds "/" by range.
-// A LITERAL "/" stays allowed. Unterminated brackets are left to regexp.Compile.
+// The test is EMPIRICAL — each atom compiled alone as "^atom$" and asked whether it matches
+// "/" — because banned spellings cannot be enumerated: "\S", "[^\n]" and "[[:ascii:]]" match
+// "/" without containing ".", and "[.-9]" holds "/" by range. A LITERAL "/" stays allowed;
+// unterminated brackets are left to regexp.Compile.
+//
+// KNOWN LIMITATION, structural rather than a missing case: being per-ATOM, a literal "/"
+// inside a QUANTIFIED group escapes it, so "https://([a-z0-9.-]+/)*trusted\.example\.com"
+// validates yet matches "https://evil.com/x/trusted.example.com". Catching it needs AST
+// analysis; TestCompileKnownLimitationQuantifiedGroupSpansSeparators pins the gap.
 func checkNoSlashMatchingAtom(i int, p string) error {
 	for j := 0; j < len(p); j++ {
 		var atom string
@@ -183,8 +186,8 @@ func checkNoSlashMatchingAtom(i int, p string) error {
 
 		re, err := regexp.Compile("^" + atom + "$")
 		if err != nil {
-			// Fail CLOSED: an atom we cannot analyze is not an atom we know is safe.
-			// Skipping it would turn every scanner mis-parse into a silent bypass.
+			// Fail CLOSED: an atom we cannot analyze is not one we know is safe, and
+			// skipping it would turn every scanner mis-parse into a silent bypass.
 			return fmt.Errorf(`issuer_patterns[%d]: cannot verify that %q cannot `+
 				`match "/" (%v), so the pattern is rejected rather than assumed `+
 				`safe — rewrite it with a plain class such as [a-z0-9-]`, i, atom, err)
@@ -206,9 +209,9 @@ func checkNoSlashMatchingAtom(i int, p string) error {
 	return nil
 }
 
-// endOfEscape returns the index just past the character-class escape starting at
-// the backslash at p[j], or -1 when there is no atom to test (an escaped literal
-// or trailing backslash), meaning the caller should skip two bytes.
+// endOfEscape returns the index just past the character-class escape starting at the
+// backslash at p[j], or -1 when there is no atom to test (an escaped literal or
+// trailing backslash) and the caller should skip two bytes.
 func endOfEscape(p string, j int) int {
 	if j+1 >= len(p) {
 		return -1
@@ -217,9 +220,8 @@ func endOfEscape(p string, j int) int {
 	case 'd', 'D', 's', 'S', 'w', 'W':
 		return j + 2
 
-	// Numeric escapes SPELL characters rather than naming classes: "\x2F",
-	// "\x{2F}" and "\057" are all "/". Treated as escaped literals they would be
-	// skipped and the slash they encode would never be tested.
+	// Numeric escapes SPELL characters rather than naming classes ("\x2F", "\x{2F}" and
+	// "\057" are all "/"); as escaped literals they would be skipped and never tested.
 	case 'x':
 		if j+2 >= len(p) {
 			return -1
@@ -261,17 +263,17 @@ func isHexDigit(b byte) bool {
 	return b >= '0' && b <= '9' || b >= 'a' && b <= 'f' || b >= 'A' && b <= 'F'
 }
 
-// endOfBracketExpression returns the index just past the bracket expression
-// opening at p[j], or -1 if unterminated. More than a search for "]": a
-// backslash escapes the next byte ("[a-z\]]"), a POSIX class carries its own "]"
-// ("[[:alpha:]]"), and a leading "]" is a literal member ("[^]]").
+// endOfBracketExpression returns the index just past the bracket expression opening at
+// p[j], or -1 if unterminated. More than a search for "]": a backslash escapes the next
+// byte ("[a-z\]]"), a POSIX class carries its own "]" ("[[:alpha:]]"), and a leading "]"
+// is a literal member ("[^]]").
 func endOfBracketExpression(p string, j int) int {
 	k := j + 1
 	if k < len(p) && p[k] == '^' {
 		k++
 	}
-	// RE2 reads a first-position "]" as a literal. Stopping on it would extract
-	// the uncompilable "[^]" and leave the real class untested.
+	// RE2 reads a first-position "]" as a literal; stopping there would extract the
+	// uncompilable "[^]" and leave the real class untested.
 	if k < len(p) && p[k] == ']' {
 		k++
 	}
@@ -280,10 +282,9 @@ func endOfBracketExpression(p string, j int) int {
 		case '\\':
 			k++
 		case '[':
-			// "[:name:]" is a POSIX class only when a ":]" actually follows;
-			// otherwise RE2 reads this "[" as an ordinary member and the real "]"
-			// is still ahead, so keep scanning rather than bailing out — bailing
-			// let "[[:/-~]", a class holding "/", pass untested.
+			// "[:name:]" is a POSIX class only when a ":]" actually follows; otherwise
+			// RE2 reads this "[" as an ordinary member and the real "]" is still ahead,
+			// so keep scanning: bailing out let "[[:/-~]", holding "/", pass untested.
 			if strings.HasPrefix(p[k:], "[:") {
 				if end := strings.Index(p[k:], ":]"); end >= 0 {
 					k += end + 1
@@ -296,11 +297,10 @@ func endOfBracketExpression(p string, j int) int {
 	return -1
 }
 
-// checkLowercaseSchemeAndHost rejects uppercase in an issuer's scheme or host:
-// matching is byte-exact, so those would never match a real "iss" claim — a
-// silent org-wide outage in enforce mode. It inspects the RAW string because
-// url.Parse lowercases the scheme, hiding the problem. Paths are legitimately
-// mixed-case (e.g. AWS EKS /id/ABCDEF123456) and excluded.
+// checkLowercaseSchemeAndHost rejects uppercase in an issuer's scheme or host: matching
+// is byte-exact, so those never match a real "iss" claim — a silent org-wide outage in
+// enforce mode. It inspects the RAW string because url.Parse lowercases the scheme.
+// Paths are legitimately mixed-case (e.g. AWS EKS /id/ABCDEF123456) and excluded.
 func checkLowercaseSchemeAndHost(iss string) error {
 	schemeAndHost := iss
 	if i := strings.Index(iss, "://"); i >= 0 {

--- a/pkg/octosts/org_trusted_issuers_store.go
+++ b/pkg/octosts/org_trusted_issuers_store.go
@@ -22,10 +22,9 @@ import (
 	"github.com/octo-sts/app/pkg/ghtransport"
 )
 
-// OrgTrustedIssuersPath locates the org allowlist inside the org's .github
-// repository. Exported because pkg/webhook's check run reads it too and both
-// paths must agree. The name avoids the substring "token": gosec's G101 matches
-// identifier names and would flag it as a hardcoded credential.
+// OrgTrustedIssuersPath locates the org allowlist. Exported because pkg/webhook's
+// check run reads it too and both paths must agree. The name avoids the substring
+// "token": gosec's G101 matches identifier names and would flag it as a credential.
 const OrgTrustedIssuersPath = ".github/chainguard/trusted-token-issuers.yaml"
 
 // orgIssuerState is the cached knowledge about one org's allowlist. The zero
@@ -60,8 +59,8 @@ type orgIssuerEntry struct {
 	err   error            // set iff state == orgIssuerInvalid
 }
 
-// These constructors keep the payload invariant (allow only for Present, err only
-// for Invalid) in one place. None for Unknown: the zero value is the only source.
+// These hold the payload invariant (allow only for Present, err only for Invalid) in
+// one place. None for Unknown: the zero value is its only source.
 
 func absentOrgIssuerEntry() orgIssuerEntry {
 	return orgIssuerEntry{state: orgIssuerAbsent}
@@ -81,7 +80,7 @@ var orgIssuers = expirablelru.NewLRU[string, orgIssuerEntry](200, nil, time.Minu
 // staleOrgIssuers holds Absent and Present only: Invalid is never "last known good".
 var staleOrgIssuers = expirablelru.NewLRU[string, orgIssuerEntry](200, nil, time.Hour)
 
-// cacheOrgIssuerEntry routes durable knowledge to the stale cache and logs the
+// cacheOrgIssuerEntry routes durable knowledge to the stale cache, logging the
 // otherwise-invisible enforcing-to-not-enforcing shift.
 func cacheOrgIssuerEntry(ctx context.Context, owner string, e orgIssuerEntry) {
 	if prev, ok := staleOrgIssuers.Get(owner); ok &&
@@ -95,14 +94,14 @@ func cacheOrgIssuerEntry(ctx context.Context, owner string, e orgIssuerEntry) {
 	}
 }
 
-// fetchKind is one installation's answer about an org's allowlist. Retryability
-// is a property of the kind, not something inferred from a gRPC code: inferring
-// it let a rate-limited token mint skip the retry across other installations.
+// fetchKind is one installation's answer about an org's allowlist. Retryability is
+// a property of the kind, never inferred from a gRPC code: inferring it let a
+// rate-limited token mint skip the retry across other installations.
 type fetchKind int
 
 const (
-	// fetchOK means the file was read; entry is Present or Invalid. Invalid rides
-	// fetchOK: "the config is broken" is an answer, not a failure to enumerate.
+	// fetchOK: file read; entry is Present or Invalid. Invalid rides fetchOK because
+	// "the config is broken" is an answer, not a failure to enumerate.
 	fetchOK          fetchKind = iota
 	fetchAbsent                // no allowlist applies; definitive
 	fetchNoAccess              // this installation cannot see .github; try the next
@@ -134,8 +133,8 @@ type fetchResult struct {
 	err   error          // terminal status for fetchRateLimited / fetchFailed
 }
 
-// The kind-to-payload pairing IS the security contract — retryable kinds carry a
-// terminal status, fetchAbsent/fetchNoAccess carry none — so it lives in one place.
+// The kind-to-payload pairing IS the security contract (retryable kinds carry a
+// terminal status, fetchAbsent/fetchNoAccess none), so it lives in one place.
 
 func absentFetch() fetchResult   { return fetchResult{kind: fetchAbsent} }
 func noAccessFetch() fetchResult { return fetchResult{kind: fetchNoAccess} }
@@ -150,9 +149,8 @@ func failedFetch() fetchResult {
 
 func okFetch(e orgIssuerEntry) fetchResult { return fetchResult{kind: fetchOK, entry: e} }
 
-// Fixed messages returned to callers. Org, issuer, mode and the underlying error
-// go to logs and the Event only: echoing them would let any holder of a verified
-// token enumerate an org's identity providers.
+// Fixed messages returned to callers. Org, issuer, mode and cause go to logs and the
+// Event only: echoing them would let any verified-token holder enumerate an org's IdPs.
 const (
 	msgIssuerNotPermitted  = "issuer not permitted by organization policy"
 	msgIssuerConfigInvalid = "organization trusted-issuer configuration is invalid"
@@ -160,11 +158,10 @@ const (
 	msgIssuerRateLimited   = "organization trusted-issuer lookup rate limited"
 )
 
-// isOrgIssuerRateLimit reports whether err is PROVEN to be a rate limit. Stricter
-// than IsGitHubRateLimited: a bare *ErrorResponse 403 is a permanent permission,
-// SAML/IP-allowlist or suspended-installation failure, and calling it a rate limit
-// would deny every exchange in the org indefinitely. Real limits are typed
-// *RateLimitError or *AbuseRateLimitError.
+// isOrgIssuerRateLimit reports whether err is PROVEN to be a rate limit. Stricter than
+// IsGitHubRateLimited: a bare *ErrorResponse 403 is a permanent permission,
+// SAML/IP-allowlist or suspension failure, and calling it a rate limit would deny every
+// exchange in the org indefinitely.
 func isOrgIssuerRateLimit(err error) bool {
 	if err == nil {
 		return false
@@ -180,9 +177,8 @@ func isOrgIssuerRateLimit(err error) bool {
 }
 
 // isMintRateLimit reports whether a mint failure response is a rate limit. Below
-// go-github's CheckResponse there is no typed *RateLimitError: 429 and 403 with
-// X-RateLimit-Remaining: 0 are primary limits; Retry-After catches secondary
-// limits, where Remaining is typically NONZERO.
+// go-github's CheckResponse there is no typed *RateLimitError: X-RateLimit-Remaining
+// 0 is a primary limit, Retry-After a secondary one (Remaining typically NONZERO).
 func isMintRateLimit(resp *http.Response) bool {
 	if resp == nil {
 		return false
@@ -190,20 +186,19 @@ func isMintRateLimit(resp *http.Response) bool {
 	if resp.StatusCode == http.StatusTooManyRequests {
 		return true
 	}
-	if resp.StatusCode != http.StatusForbidden {
-		return false
-	}
+	// Header-driven regardless of status, not just 403: GitHub answers an over-used
+	// installation-token endpoint with 422 too, and the headers are the only way to
+	// tell that from a real validation failure.
 	return resp.Header.Get("X-RateLimit-Remaining") == "0" || resp.Header.Get("Retry-After") != ""
 }
 
 // classifyMintError maps an installation-token mint failure. These are
-// *ghinstallation.HTTPError, not *github.ErrorResponse: RoundTrip returns
-// (nil, err), so CheckResponse never runs. Closes err's response body.
+// *ghinstallation.HTTPError, not *github.ErrorResponse, because RoundTrip returns
+// (nil, err) so CheckResponse never runs. Closes err's response body.
 func classifyMintError(ctx context.Context, owner string, err error) fetchResult {
 	var herr *ghinstallation.HTTPError
 	if errors.As(err, &herr) && herr.Response != nil {
-		// ghinstallation deliberately leaves the body open for inspection, so
-		// closing it is our job.
+		// ghinstallation leaves the body open for inspection, so closing it is ours.
 		if herr.Response.Body != nil {
 			defer herr.Response.Body.Close()
 		}
@@ -213,13 +208,17 @@ func classifyMintError(ctx context.Context, owner string, err error) fetchResult
 			}
 		}
 
+		// Rate limiting FIRST: 422 means both a real validation failure and "endpoint
+		// has been spammed", and 422 is the sole source of AGREEMENT that .github is
+		// unreadable — counting an anti-abuse 422 as agreement would let load flip an
+		// enforcing org to allow-all.
 		switch {
-		case herr.Response.StatusCode == http.StatusUnprocessableEntity:
-			return noAccessFetch()
-
 		case isMintRateLimit(herr.Response):
 			clog.WarnContextf(ctx, "org trusted issuers: mint rate limited for %s", owner)
 			return rateLimitedFetch()
+
+		case herr.Response.StatusCode == http.StatusUnprocessableEntity:
+			return noAccessFetch()
 		}
 	}
 
@@ -241,11 +240,10 @@ func classifyContentsError(ctx context.Context, owner string, err error) fetchRe
 			return absentFetch()
 
 		case http.StatusForbidden:
-			// Ignorance, NOT agreement, so fail CLOSED rather than return NoAccess:
-			// a read-time 403 is often org-wide (IP allowlist, SAML/SSO, ToS lock,
-			// contents-API incident) and would make every installation "agree" that
-			// no allowlist applies. Genuine per-installation blindness fails earlier,
-			// at the MINT with a 422 — the sole source of agreement.
+			// Ignorance, NOT agreement, so fail CLOSED rather than NoAccess: a read-time
+			// 403 is often org-wide (IP allowlist, SAML/SSO, ToS lock, API incident) and
+			// would make every installation "agree" no allowlist applies. Genuine
+			// per-installation blindness fails at the MINT with 422, the sole agreement.
 			clog.WarnContextf(ctx, "org trusted issuers: read forbidden for %s/.github (403, not a rate limit); treating as unknown", owner)
 			return failedFetch()
 		}
@@ -255,9 +253,8 @@ func classifyContentsError(ctx context.Context, owner string, err error) fetchRe
 	return failedFetch()
 }
 
-// fetchOrgIssuersOnce reads and compiles the org allowlist using one installation
-// and reports only what it could determine; deciding the org's actual allowlist is
-// the aggregating caller's job.
+// fetchOrgIssuersOnce reads and compiles the org allowlist through one installation,
+// reporting only what it could determine; the org's verdict is the caller's decision.
 func (s *sts) fetchOrgIssuersOnce(ctx context.Context, base *ghinstallation.AppsTransport, install int64, owner string) fetchResult {
 	// Label rate-limit metrics with the installation consuming the quota.
 	ctx = ghtransport.EnrichContext(ctx, base.AppID(), install)
@@ -270,9 +267,9 @@ func (s *sts) fetchOrgIssuersOnce(ctx context.Context, base *ghinstallation.Apps
 		},
 	}
 
-	// Mint explicitly, not lazily inside the revoke defer: only successful tokens
-	// are cached, so a deferred Token() would issue a SECOND failing mint on the
-	// 422 path, common for orgs installing the App on selected repositories.
+	// Mint explicitly, not lazily inside the revoke defer: only successful tokens are
+	// cached, so a deferred Token() would issue a SECOND failing mint on the 422 path,
+	// common for orgs installing the App on selected repositories.
 	tok, err := atr.Token(ctx)
 	if err != nil {
 		return classifyMintError(ctx, owner, err)
@@ -299,8 +296,7 @@ func (s *sts) fetchOrgIssuersOnce(ctx context.Context, base *ghinstallation.Apps
 		return classifyContentsError(ctx, owner, err)
 	}
 	if file == nil {
-		// A directory: GetContent() dereferences Encoding unguarded and would
-		// panic on the exchange path.
+		// A directory: GetContent() dereferences Encoding unguarded and would panic.
 		clog.ErrorContextf(ctx, "org trusted issuers: path is not a file for %s", owner)
 		return invalidConfigResult()
 	}
@@ -320,9 +316,8 @@ func (s *sts) fetchOrgIssuersOnce(ctx context.Context, base *ghinstallation.Apps
 	return okFetch(presentOrgIssuerEntry(allow))
 }
 
-// invalidConfigResult is the outcome for a config present but unusable. The kind
-// is fetchOK because the installation DID answer; the cause is logged at the call
-// site and the caller-visible message stays fixed.
+// invalidConfigResult is the outcome for a config present but unusable. The kind is
+// fetchOK because the installation DID answer; the cause is logged at the call site.
 func invalidConfigResult() fetchResult {
 	return okFetch(invalidOrgIssuerEntry(status.Error(codes.FailedPrecondition, msgIssuerConfigInvalid)))
 }
@@ -334,20 +329,19 @@ type orgIssuerTally struct {
 	sawRateLimit bool
 }
 
-// exhaustiveNoAccess reports whether every installation considered so far ANSWERED,
-// and every answer was "I cannot see .github". total > 0 is a security guard: with no
-// installations it degenerates to 0 == 0, granting org-wide allow-all off no evidence;
-// an empty enumeration is ignorance and belongs on the stale / fail-closed path.
-// anyFailed is redundant today only because of scanInstalls' and record's counting
-// discipline — an edit that stops counting an unanswered installation in total would
-// silently turn ignorance into allow-all. Do not simplify it away.
+// exhaustiveNoAccess reports whether every installation so far ANSWERED "I cannot see
+// .github". total > 0 is a security guard: with no installations it degenerates to
+// 0 == 0, granting allow-all off no evidence, when an empty enumeration is ignorance
+// and belongs on the stale / fail-closed path. anyFailed is redundant only thanks to
+// scanInstalls' and record's counting discipline: an edit that stops counting an
+// unanswered installation would turn ignorance into allow-all. Do not simplify away.
 func (t *orgIssuerTally) exhaustiveNoAccess() bool {
 	return t.total > 0 && !t.anyFailed && t.noAccess == t.total
 }
 
-// record folds one non-definitive outcome into the tally, holding in one place the
-// invariant exhaustiveNoAccess relies on: every non-definitive answer counts as a
-// no-access agreement or a failure. total belongs to scanInstalls.
+// record folds one non-definitive outcome into the tally, holding the invariant
+// exhaustiveNoAccess relies on: every non-definitive answer counts either as a
+// no-access agreement or as a failure. total belongs to scanInstalls.
 func (t *orgIssuerTally) record(k fetchKind) {
 	switch k {
 	case fetchNoAccess:
@@ -362,10 +356,10 @@ func (t *orgIssuerTally) record(k fetchKind) {
 	}
 }
 
-// scanInstalls returns the first DEFINITIVE answer — fetchOK or fetchAbsent —
-// which ends the lookup; everything else is ignorance and folds into t via record.
-// On a definitive (true) return the tally is PARTIAL, so exhaustiveNoAccess must not
-// be consulted; only a false return leaves a tally worth reading.
+// scanInstalls returns the first DEFINITIVE answer (fetchOK or fetchAbsent), which
+// ends the lookup; everything else is ignorance and folds into t via record. On a
+// definitive return the tally is PARTIAL, so only a false return leaves a tally
+// exhaustiveNoAccess may be consulted on.
 func (s *sts) scanInstalls(ctx context.Context, owner string, installs []ghinstall.Installation, t *orgIssuerTally) (entry orgIssuerEntry, definitive bool) {
 	for _, in := range installs {
 		t.total++
@@ -385,8 +379,8 @@ func (s *sts) scanInstalls(ctx context.Context, owner string, installs []ghinsta
 }
 
 // installsNotIn returns the installations whose IDs are absent from alreadyScanned.
-// Matching is by ID, not transport pointer: GetAllFresh can return a fresh
-// *AppsTransport for an already-scanned installation. May return nil.
+// Matching is by ID, not transport pointer: GetAllFresh can return a fresh transport
+// for an already-scanned installation. May return nil.
 func installsNotIn(installs, alreadyScanned []ghinstall.Installation) []ghinstall.Installation {
 	seen := make(map[int64]struct{}, len(alreadyScanned))
 	for _, in := range alreadyScanned {
@@ -403,15 +397,14 @@ func installsNotIn(installs, alreadyScanned []ghinstall.Installation) []ghinstal
 
 // confirmNoAccess re-enumerates without the negative cache and returns the entry the
 // confirmation EARNED (Present or Invalid, not only Absent), or ok=false to leave the
-// caller on the stale / fail-closed path. GetAll can silently omit a just-installed
-// App (it maps a negative-cache NotFound to (nil, nil)), and allow-all is the one
-// conclusion a missing App flips: without this, installing an App to turn enforcement
-// ON would turn it off. It narrows OUR window, not GitHub's — GetAllFresh cannot
-// surface an installation GitHub has not yet replicated, and that residual is
-// accepted rather than fail closed for every single-App org that cannot read .github.
+// caller on the stale / fail-closed path. GetAll maps a negative-cache NotFound to
+// (nil, nil), silently omitting a just-installed App, and allow-all is the one
+// conclusion that flips: without this, installing an App to turn enforcement ON would
+// turn it off. It narrows only THIS service's window, not GitHub's replication lag,
+// whose residual is accepted rather than fail closed for every single-App org.
 func (s *sts) confirmNoAccess(ctx context.Context, owner string, scanned []ghinstall.Installation, t *orgIssuerTally) (orgIssuerEntry, bool) {
-	// Bounded only on success: a confirm that earns nothing is deliberately not
-	// cached and repeats, which is how an org recovers once the API is healthy.
+	// A confirm that earns nothing is deliberately not cached and repeats, which is
+	// how an org recovers once the API is healthy.
 	fresh, err := s.rrm.GetAllFresh(ctx, owner)
 	if err != nil {
 		clog.WarnContextf(ctx, "confirming the installation set for %s failed: %v", owner, err)
@@ -422,8 +415,8 @@ func (s *sts) confirmNoAccess(ctx context.Context, owner string, scanned []ghins
 		return entry, true
 	}
 
-	// Re-check rather than reuse the earlier verdict: the newly-found installations
-	// may have added a failure, which is fatal to the conclusion.
+	// Re-check rather than reuse the earlier verdict: the newly-found installations may
+	// have added a failure, which is fatal to the conclusion.
 	if t.exhaustiveNoAccess() {
 		clog.WarnContextf(ctx, "no installation can read %s/.github (re-enumerated without the installation cache); org issuer enforcement not applied", owner)
 		return absentOrgIssuerEntry(), true
@@ -432,13 +425,12 @@ func (s *sts) confirmNoAccess(ctx context.Context, owner string, scanned []ghins
 	return orgIssuerEntry{}, false
 }
 
-// orgIssuerLookup returns the effective allowlist entry for owner, enumerating
-// EVERY installation and stopping at the first definitive answer. Not s.rrm.Get:
-// pickByQuota is argmax(remaining) with no rotation, so a Get-based loop could see
-// one blind installation forever and wrongly cache allow-all for the whole org.
-//
-// A non-nil error is a terminal gRPC status; a nil error with an Invalid entry
-// means the config is unusable and the caller surfaces entry.err.
+// orgIssuerLookup returns the effective allowlist entry for owner, enumerating EVERY
+// installation and stopping at the first definitive answer. Not s.rrm.Get: pickByQuota
+// is argmax(remaining) with no rotation, so a Get-based loop could see one blind
+// installation forever and wrongly cache allow-all for the whole org. A non-nil error
+// is a terminal gRPC status; a nil error with an Invalid entry means the config is
+// unusable and the caller surfaces entry.err.
 func (s *sts) orgIssuerLookup(ctx context.Context, owner string) (orgIssuerEntry, error) {
 	if e, ok := orgIssuers.Get(owner); ok {
 		return e, nil
@@ -459,11 +451,13 @@ func (s *sts) orgIssuerLookup(ctx context.Context, owner string) (orgIssuerEntry
 		}
 	}
 
-	// Not exhaustive, or something failed. Serving stale is inherently mode-aware:
-	// an audit-mode allowlist never denies.
+	// Not exhaustive, or something failed. Serving stale is mode-aware for free: an
+	// audit-mode allowlist never denies.
 	if stale, ok := staleOrgIssuers.Get(owner); ok {
+		// Served but NOT reseeded into the primary: a fresh 5-minute TTL on an entry
+		// already up to an hour old would let an Absent survive past its stale bound.
+		// Costs a re-enumeration per exchange for the duration of the outage.
 		clog.InfoContextf(ctx, "org issuer lookup incomplete for %s, serving stale entry", owner)
-		orgIssuers.Add(owner, stale)
 		return stale, nil
 	}
 
@@ -479,7 +473,7 @@ func (s *sts) orgIssuerLookup(ctx context.Context, owner string) (orgIssuerEntry
 }
 
 // settleOrgIssuerEntry caches a definitive entry, substituting the last known good
-// allowlist when the current file is unusable: a typo must not be an org-wide kill
+// allowlist when the current file is unusable so a typo is not an org-wide kill
 // switch. That list may be broader than intended, hence the Error log.
 func (s *sts) settleOrgIssuerEntry(ctx context.Context, owner string, entry orgIssuerEntry) orgIssuerEntry {
 	if entry.state == orgIssuerInvalid {
@@ -493,9 +487,9 @@ func (s *sts) settleOrgIssuerEntry(ctx context.Context, owner string, entry orgI
 	return entry
 }
 
-// checkOrgTrustedIssuers evaluates the org allowlist for owner, returning a
-// decision to record on the Event (nil when no allowlist applied or the issuer was
-// permitted) and a terminal error when the exchange must be denied.
+// checkOrgTrustedIssuers evaluates the org allowlist for owner, returning a decision
+// to record on the Event (nil when no allowlist applied or the issuer was permitted)
+// and a terminal error when the exchange must be denied.
 func (s *sts) checkOrgTrustedIssuers(ctx context.Context, owner, issuer string) (*IssuerDecision, error) {
 	entry, err := s.orgIssuerLookup(ctx, owner)
 	if err != nil {

--- a/pkg/octosts/org_trusted_issuers_store.go
+++ b/pkg/octosts/org_trusted_issuers_store.go
@@ -243,11 +243,9 @@ func classifyContentsError(ctx context.Context, owner string, err error) fetchRe
 		case http.StatusForbidden:
 			// Ignorance, NOT agreement, so fail CLOSED rather than return NoAccess:
 			// a read-time 403 is often org-wide (IP allowlist, SAML/SSO, ToS lock,
-			// contents-API incident), which would make every installation "agree"
-			// that no allowlist applies and fall the org open to allow-all during
-			// the incident. Genuine per-installation blindness does not arrive here
-			// — it fails at the MINT with a 422 — so reaching this means the mint
-			// already proved this installation can see .github.
+			// contents-API incident) and would make every installation "agree" that
+			// no allowlist applies. Genuine per-installation blindness fails earlier,
+			// at the MINT with a 422 — the sole source of agreement.
 			clog.WarnContextf(ctx, "org trusted issuers: read forbidden for %s/.github (403, not a rate limit); treating as unknown", owner)
 			return failedFetch()
 		}
@@ -336,17 +334,13 @@ type orgIssuerTally struct {
 	sawRateLimit bool
 }
 
-// exhaustiveNoAccess reports whether every installation considered so far
-// ANSWERED, and every answer was "I cannot see .github".
-//
-// total > 0 is a security guard: with no installations the comparison degenerates
-// to 0 == 0 and would grant org-wide allow-all off no evidence; an empty
-// enumeration is ignorance and belongs on the stale / fail-closed path.
-//
-// anyFailed is redundant today (only fetchNoAccess increments noAccess) but only
-// because of scanInstalls' and record's counting discipline; an edit that stops
-// counting an unanswered installation in total would silently turn ignorance into
-// allow-all. Do not simplify it away.
+// exhaustiveNoAccess reports whether every installation considered so far ANSWERED,
+// and every answer was "I cannot see .github". total > 0 is a security guard: with no
+// installations it degenerates to 0 == 0, granting org-wide allow-all off no evidence;
+// an empty enumeration is ignorance and belongs on the stale / fail-closed path.
+// anyFailed is redundant today only because of scanInstalls' and record's counting
+// discipline — an edit that stops counting an unanswered installation in total would
+// silently turn ignorance into allow-all. Do not simplify it away.
 func (t *orgIssuerTally) exhaustiveNoAccess() bool {
 	return t.total > 0 && !t.anyFailed && t.noAccess == t.total
 }
@@ -370,10 +364,8 @@ func (t *orgIssuerTally) record(k fetchKind) {
 
 // scanInstalls returns the first DEFINITIVE answer — fetchOK or fetchAbsent —
 // which ends the lookup; everything else is ignorance and folds into t via record.
-//
-// On a definitive (true) return the tally is PARTIAL — the answering installation
-// is counted in total but nowhere else — so exhaustiveNoAccess must not be
-// consulted. Only a false return leaves a tally worth reading.
+// On a definitive (true) return the tally is PARTIAL, so exhaustiveNoAccess must not
+// be consulted; only a false return leaves a tally worth reading.
 func (s *sts) scanInstalls(ctx context.Context, owner string, installs []ghinstall.Installation, t *orgIssuerTally) (entry orgIssuerEntry, definitive bool) {
 	for _, in := range installs {
 		t.total++
@@ -389,6 +381,54 @@ func (s *sts) scanInstalls(ctx context.Context, owner string, installs []ghinsta
 			t.record(res.kind)
 		}
 	}
+	return orgIssuerEntry{}, false
+}
+
+// installsNotIn returns the installations whose IDs are absent from alreadyScanned.
+// Matching is by ID, not transport pointer: GetAllFresh can return a fresh
+// *AppsTransport for an already-scanned installation. May return nil.
+func installsNotIn(installs, alreadyScanned []ghinstall.Installation) []ghinstall.Installation {
+	seen := make(map[int64]struct{}, len(alreadyScanned))
+	for _, in := range alreadyScanned {
+		seen[in.ID] = struct{}{}
+	}
+	var out []ghinstall.Installation
+	for _, in := range installs {
+		if _, ok := seen[in.ID]; !ok {
+			out = append(out, in)
+		}
+	}
+	return out
+}
+
+// confirmNoAccess re-enumerates without the negative cache and returns the entry the
+// confirmation EARNED (Present or Invalid, not only Absent), or ok=false to leave the
+// caller on the stale / fail-closed path. GetAll can silently omit a just-installed
+// App (it maps a negative-cache NotFound to (nil, nil)), and allow-all is the one
+// conclusion a missing App flips: without this, installing an App to turn enforcement
+// ON would turn it off. It narrows OUR window, not GitHub's — GetAllFresh cannot
+// surface an installation GitHub has not yet replicated, and that residual is
+// accepted rather than fail closed for every single-App org that cannot read .github.
+func (s *sts) confirmNoAccess(ctx context.Context, owner string, scanned []ghinstall.Installation, t *orgIssuerTally) (orgIssuerEntry, bool) {
+	// Bounded only on success: a confirm that earns nothing is deliberately not
+	// cached and repeats, which is how an org recovers once the API is healthy.
+	fresh, err := s.rrm.GetAllFresh(ctx, owner)
+	if err != nil {
+		clog.WarnContextf(ctx, "confirming the installation set for %s failed: %v", owner, err)
+		return orgIssuerEntry{}, false
+	}
+
+	if entry, definitive := s.scanInstalls(ctx, owner, installsNotIn(fresh, scanned), t); definitive {
+		return entry, true
+	}
+
+	// Re-check rather than reuse the earlier verdict: the newly-found installations
+	// may have added a failure, which is fatal to the conclusion.
+	if t.exhaustiveNoAccess() {
+		clog.WarnContextf(ctx, "no installation can read %s/.github (re-enumerated without the installation cache); org issuer enforcement not applied", owner)
+		return absentOrgIssuerEntry(), true
+	}
+
 	return orgIssuerEntry{}, false
 }
 
@@ -414,10 +454,9 @@ func (s *sts) orgIssuerLookup(ctx context.Context, owner string) (orgIssuerEntry
 	// Absent requires POSITIVE knowledge: a failed or partial enumeration is not
 	// evidence of absence and is never cached. See exhaustiveNoAccess.
 	if enumErr == nil && t.exhaustiveNoAccess() {
-		clog.WarnContextf(ctx, "no installation can read %s/.github; org issuer enforcement not applied", owner)
-		absent := absentOrgIssuerEntry()
-		cacheOrgIssuerEntry(ctx, owner, absent)
-		return absent, nil
+		if entry, ok := s.confirmNoAccess(ctx, owner, installs, &t); ok {
+			return s.settleOrgIssuerEntry(ctx, owner, entry), nil
+		}
 	}
 
 	// Not exhaustive, or something failed. Serving stale is inherently mode-aware:

--- a/pkg/octosts/org_trusted_issuers_store.go
+++ b/pkg/octosts/org_trusted_issuers_store.go
@@ -201,8 +201,6 @@ func classifyMintError(ctx context.Context, owner string, err error) fetchResult
 		// ghinstallation leaves the body open for inspection, so closing it is ours.
 		if herr.Response.Body != nil {
 			defer herr.Response.Body.Close()
-		}
-		if herr.Response.Body != nil {
 			if body, rerr := io.ReadAll(io.LimitReader(herr.Response.Body, 4096)); rerr == nil && len(body) > 0 {
 				clog.DebugContextf(ctx, "org trusted issuers: mint failure body for %s: %s", owner, body)
 			}
@@ -513,13 +511,13 @@ func (s *sts) checkOrgTrustedIssuers(ctx context.Context, owner, issuer string) 
 		return nil, nil
 	}
 
-	d := &IssuerDecision{Mode: entry.allow.Mode(), Issuer: issuer}
-	if entry.allow.Mode() == ModeAudit {
-		d.Allowed = true
+	// Reached only once Allows has said no, so the outcome follows from the mode.
+	mode := entry.allow.Mode()
+	d := &IssuerDecision{Mode: mode, Issuer: issuer, Allowed: mode == ModeAudit}
+	if mode == ModeAudit {
 		clog.WarnContextf(ctx, "org issuer audit: %s would deny issuer %q", owner, issuer)
 		return d, nil
 	}
-	d.Allowed = false
 	clog.WarnContextf(ctx, "org issuer enforce: %s denied issuer %q", owner, issuer)
 	return d, status.Error(codes.PermissionDenied, msgIssuerNotPermitted)
 }

--- a/pkg/octosts/org_trusted_issuers_store.go
+++ b/pkg/octosts/org_trusted_issuers_store.go
@@ -1,0 +1,492 @@
+// Copyright 2026 Chainguard, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package octosts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/bradleyfalzon/ghinstallation/v2"
+	"github.com/chainguard-dev/clog"
+	"github.com/google/go-github/v88/github"
+	expirablelru "github.com/hashicorp/golang-lru/v2/expirable"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/octo-sts/app/pkg/ghinstall"
+	"github.com/octo-sts/app/pkg/ghtransport"
+)
+
+// OrgTrustedIssuersPath locates the org allowlist inside the org's .github
+// repository. Exported because pkg/webhook's check run reads it too and both
+// paths must agree. The name avoids the substring "token": gosec's G101 matches
+// identifier names and would flag it as a hardcoded credential.
+const OrgTrustedIssuersPath = ".github/chainguard/trusted-token-issuers.yaml"
+
+// orgIssuerState is the cached knowledge about one org's allowlist. The zero
+// value is orgIssuerUnknown, not "no allowlist", so it can never be a pass.
+type orgIssuerState int
+
+const (
+	orgIssuerUnknown orgIssuerState = iota // zero value — never a pass
+	orgIssuerAbsent                        // no allowlist applies; all issuers permitted
+	orgIssuerPresent                       // allow holds a compiled allowlist
+	orgIssuerInvalid                       // file present but unusable; err is set
+)
+
+func (s orgIssuerState) String() string {
+	switch s {
+	case orgIssuerUnknown:
+		return "orgIssuerUnknown"
+	case orgIssuerAbsent:
+		return "orgIssuerAbsent"
+	case orgIssuerPresent:
+		return "orgIssuerPresent"
+	case orgIssuerInvalid:
+		return "orgIssuerInvalid"
+	default:
+		return fmt.Sprintf("orgIssuerState(%d)", int(s))
+	}
+}
+
+type orgIssuerEntry struct {
+	state orgIssuerState
+	allow *IssuerAllowlist // set iff state == orgIssuerPresent
+	err   error            // set iff state == orgIssuerInvalid
+}
+
+// These constructors keep the payload invariant (allow only for Present, err only
+// for Invalid) in one place. None for Unknown: the zero value is the only source.
+
+func absentOrgIssuerEntry() orgIssuerEntry {
+	return orgIssuerEntry{state: orgIssuerAbsent}
+}
+
+func presentOrgIssuerEntry(allow *IssuerAllowlist) orgIssuerEntry {
+	return orgIssuerEntry{state: orgIssuerPresent, allow: allow}
+}
+
+func invalidOrgIssuerEntry(err error) orgIssuerEntry {
+	return orgIssuerEntry{state: orgIssuerInvalid, err: err}
+}
+
+// Keyed on owner alone, so 200 bounds concurrently active *organizations*.
+var orgIssuers = expirablelru.NewLRU[string, orgIssuerEntry](200, nil, time.Minute*5)
+
+// staleOrgIssuers holds Absent and Present only: Invalid is never "last known good".
+var staleOrgIssuers = expirablelru.NewLRU[string, orgIssuerEntry](200, nil, time.Hour)
+
+// cacheOrgIssuerEntry routes durable knowledge to the stale cache and logs the
+// otherwise-invisible enforcing-to-not-enforcing shift.
+func cacheOrgIssuerEntry(ctx context.Context, owner string, e orgIssuerEntry) {
+	if prev, ok := staleOrgIssuers.Get(owner); ok &&
+		prev.state == orgIssuerPresent && e.state == orgIssuerAbsent {
+		clog.WarnContextf(ctx, "org trusted issuers no longer apply for %s; enforcement removed", owner)
+	}
+
+	orgIssuers.Add(owner, e)
+	if e.state == orgIssuerAbsent || e.state == orgIssuerPresent {
+		staleOrgIssuers.Add(owner, e)
+	}
+}
+
+// fetchKind is one installation's answer about an org's allowlist. Retryability
+// is a property of the kind, not something inferred from a gRPC code: inferring
+// it let a rate-limited token mint skip the retry across other installations.
+type fetchKind int
+
+const (
+	// fetchOK means the file was read; entry is Present or Invalid. Invalid rides
+	// fetchOK: "the config is broken" is an answer, not a failure to enumerate.
+	fetchOK          fetchKind = iota
+	fetchAbsent                // no allowlist applies; definitive
+	fetchNoAccess              // this installation cannot see .github; try the next
+	fetchRateLimited           // rate limited at mint or read time; try the next
+	fetchFailed                // anything else; try the next
+)
+
+// String renders fetchKind by name so logs distinguish fail-open from fail-closed.
+func (k fetchKind) String() string {
+	switch k {
+	case fetchOK:
+		return "fetchOK"
+	case fetchAbsent:
+		return "fetchAbsent"
+	case fetchNoAccess:
+		return "fetchNoAccess"
+	case fetchRateLimited:
+		return "fetchRateLimited"
+	case fetchFailed:
+		return "fetchFailed"
+	default:
+		return fmt.Sprintf("fetchKind(%d)", int(k))
+	}
+}
+
+type fetchResult struct {
+	kind  fetchKind
+	entry orgIssuerEntry // valid when kind == fetchOK
+	err   error          // terminal status for fetchRateLimited / fetchFailed
+}
+
+// The kind-to-payload pairing IS the security contract — retryable kinds carry a
+// terminal status, fetchAbsent/fetchNoAccess carry none — so it lives in one place.
+
+func absentFetch() fetchResult   { return fetchResult{kind: fetchAbsent} }
+func noAccessFetch() fetchResult { return fetchResult{kind: fetchNoAccess} }
+
+func rateLimitedFetch() fetchResult {
+	return fetchResult{kind: fetchRateLimited, err: status.Error(codes.ResourceExhausted, msgIssuerRateLimited)}
+}
+
+func failedFetch() fetchResult {
+	return fetchResult{kind: fetchFailed, err: status.Error(codes.Unavailable, msgIssuerUnavailable)}
+}
+
+func okFetch(e orgIssuerEntry) fetchResult { return fetchResult{kind: fetchOK, entry: e} }
+
+// Fixed messages returned to callers. Org, issuer, mode and the underlying error
+// go to logs and the Event only: echoing them would let any holder of a verified
+// token enumerate an org's identity providers.
+const (
+	msgIssuerNotPermitted  = "issuer not permitted by organization policy"
+	msgIssuerConfigInvalid = "organization trusted-issuer configuration is invalid"
+	msgIssuerUnavailable   = "organization trusted-issuer lookup unavailable"
+	msgIssuerRateLimited   = "organization trusted-issuer lookup rate limited"
+)
+
+// isOrgIssuerRateLimit reports whether err is PROVEN to be a rate limit. Stricter
+// than IsGitHubRateLimited: a bare *ErrorResponse 403 is a permanent permission,
+// SAML/IP-allowlist or suspended-installation failure, and calling it a rate limit
+// would deny every exchange in the org indefinitely. Real limits are typed
+// *RateLimitError or *AbuseRateLimitError.
+func isOrgIssuerRateLimit(err error) bool {
+	if err == nil {
+		return false
+	}
+	var rl *github.RateLimitError
+	var abuse *github.AbuseRateLimitError
+	if errors.As(err, &rl) || errors.As(err, &abuse) {
+		return true
+	}
+	var resp *github.ErrorResponse
+	return errors.As(err, &resp) && resp.Response != nil &&
+		resp.Response.StatusCode == http.StatusTooManyRequests
+}
+
+// isMintRateLimit reports whether a mint failure response is a rate limit. Below
+// go-github's CheckResponse there is no typed *RateLimitError: 429 and 403 with
+// X-RateLimit-Remaining: 0 are primary limits; Retry-After catches secondary
+// limits, where Remaining is typically NONZERO.
+func isMintRateLimit(resp *http.Response) bool {
+	if resp == nil {
+		return false
+	}
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return true
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		return false
+	}
+	return resp.Header.Get("X-RateLimit-Remaining") == "0" || resp.Header.Get("Retry-After") != ""
+}
+
+// classifyMintError maps an installation-token mint failure. These are
+// *ghinstallation.HTTPError, not *github.ErrorResponse: RoundTrip returns
+// (nil, err), so CheckResponse never runs. Closes err's response body.
+func classifyMintError(ctx context.Context, owner string, err error) fetchResult {
+	var herr *ghinstallation.HTTPError
+	if errors.As(err, &herr) && herr.Response != nil {
+		// ghinstallation deliberately leaves the body open for inspection, so
+		// closing it is our job.
+		if herr.Response.Body != nil {
+			defer herr.Response.Body.Close()
+		}
+		if herr.Response.Body != nil {
+			if body, rerr := io.ReadAll(io.LimitReader(herr.Response.Body, 4096)); rerr == nil && len(body) > 0 {
+				clog.DebugContextf(ctx, "org trusted issuers: mint failure body for %s: %s", owner, body)
+			}
+		}
+
+		switch {
+		case herr.Response.StatusCode == http.StatusUnprocessableEntity:
+			return noAccessFetch()
+
+		case isMintRateLimit(herr.Response):
+			clog.WarnContextf(ctx, "org trusted issuers: mint rate limited for %s", owner)
+			return rateLimitedFetch()
+		}
+	}
+
+	clog.WarnContextf(ctx, "org trusted issuers: mint failed for %s: %v", owner, err)
+	return failedFetch()
+}
+
+// classifyContentsError maps a GetContents failure.
+func classifyContentsError(ctx context.Context, owner string, err error) fetchResult {
+	if isOrgIssuerRateLimit(err) {
+		clog.WarnContextf(ctx, "org trusted issuers: read rate limited for %s", owner)
+		return rateLimitedFetch()
+	}
+
+	var ghErr *github.ErrorResponse
+	if errors.As(err, &ghErr) && ghErr.Response != nil {
+		switch ghErr.Response.StatusCode {
+		case http.StatusNotFound:
+			return absentFetch()
+
+		case http.StatusForbidden:
+			// Ignorance, NOT agreement, so fail CLOSED rather than return NoAccess:
+			// a read-time 403 is often org-wide (IP allowlist, SAML/SSO, ToS lock,
+			// contents-API incident), which would make every installation "agree"
+			// that no allowlist applies and fall the org open to allow-all during
+			// the incident. Genuine per-installation blindness does not arrive here
+			// — it fails at the MINT with a 422 — so reaching this means the mint
+			// already proved this installation can see .github.
+			clog.WarnContextf(ctx, "org trusted issuers: read forbidden for %s/.github (403, not a rate limit); treating as unknown", owner)
+			return failedFetch()
+		}
+	}
+
+	clog.WarnContextf(ctx, "org trusted issuers: read failed for %s: %v", owner, err)
+	return failedFetch()
+}
+
+// fetchOrgIssuersOnce reads and compiles the org allowlist using one installation
+// and reports only what it could determine; deciding the org's actual allowlist is
+// the aggregating caller's job.
+func (s *sts) fetchOrgIssuersOnce(ctx context.Context, base *ghinstallation.AppsTransport, install int64, owner string) fetchResult {
+	// Label rate-limit metrics with the installation consuming the quota.
+	ctx = ghtransport.EnrichContext(ctx, base.AppID(), install)
+
+	atr := ghinstallation.NewFromAppsTransport(base, install)
+	atr.InstallationTokenOptions = &github.InstallationTokenOptions{
+		Repositories: []string{".github"},
+		Permissions: &github.InstallationPermissions{
+			Contents: ptr("read"),
+		},
+	}
+
+	// Mint explicitly, not lazily inside the revoke defer: only successful tokens
+	// are cached, so a deferred Token() would issue a SECOND failing mint on the
+	// 422 path, common for orgs installing the App on selected repositories.
+	tok, err := atr.Token(ctx)
+	if err != nil {
+		return classifyMintError(ctx, owner, err)
+	}
+	defer func() {
+		if err := Revoke(ctx, tok, s.baseURL); err != nil {
+			clog.WarnContextf(ctx, "org trusted issuers: failed to revoke token: %v", err)
+		}
+	}()
+
+	client, err := newGitHubClient(atr, s.baseURL)
+	if err != nil {
+		return fetchResult{
+			kind: fetchFailed,
+			err:  status.Errorf(codes.Internal, "creating GitHub client: %v", err),
+		}
+	}
+
+	file, _, _, err := client.Repositories.GetContents(ctx,
+		owner, ".github", OrgTrustedIssuersPath,
+		&github.RepositoryContentGetOptions{},
+	)
+	if err != nil {
+		return classifyContentsError(ctx, owner, err)
+	}
+	if file == nil {
+		// A directory: GetContent() dereferences Encoding unguarded and would
+		// panic on the exchange path.
+		clog.ErrorContextf(ctx, "org trusted issuers: path is not a file for %s", owner)
+		return invalidConfigResult()
+	}
+
+	raw, err := file.GetContent()
+	if err != nil {
+		clog.ErrorContextf(ctx, "org trusted issuers: failed to decode for %s: %v", owner, err)
+		return invalidConfigResult()
+	}
+
+	allow, err := ParseOrgTrustedIssuers([]byte(raw))
+	if err != nil {
+		clog.ErrorContextf(ctx, "org trusted issuers: invalid config for %s: %v", owner, err)
+		return invalidConfigResult()
+	}
+
+	return okFetch(presentOrgIssuerEntry(allow))
+}
+
+// invalidConfigResult is the outcome for a config present but unusable. The kind
+// is fetchOK because the installation DID answer; the cause is logged at the call
+// site and the caller-visible message stays fixed.
+func invalidConfigResult() fetchResult {
+	return okFetch(invalidOrgIssuerEntry(status.Error(codes.FailedPrecondition, msgIssuerConfigInvalid)))
+}
+
+type orgIssuerTally struct {
+	total        int
+	noAccess     int
+	anyFailed    bool // a fetchFailed or fetchRateLimited was seen
+	sawRateLimit bool
+}
+
+// exhaustiveNoAccess reports whether every installation considered so far
+// ANSWERED, and every answer was "I cannot see .github".
+//
+// total > 0 is a security guard: with no installations the comparison degenerates
+// to 0 == 0 and would grant org-wide allow-all off no evidence; an empty
+// enumeration is ignorance and belongs on the stale / fail-closed path.
+//
+// anyFailed is redundant today (only fetchNoAccess increments noAccess) but only
+// because of scanInstalls' and record's counting discipline; an edit that stops
+// counting an unanswered installation in total would silently turn ignorance into
+// allow-all. Do not simplify it away.
+func (t *orgIssuerTally) exhaustiveNoAccess() bool {
+	return t.total > 0 && !t.anyFailed && t.noAccess == t.total
+}
+
+// record folds one non-definitive outcome into the tally, holding in one place the
+// invariant exhaustiveNoAccess relies on: every non-definitive answer counts as a
+// no-access agreement or a failure. total belongs to scanInstalls.
+func (t *orgIssuerTally) record(k fetchKind) {
+	switch k {
+	case fetchNoAccess:
+		t.noAccess++
+
+	case fetchRateLimited:
+		t.anyFailed = true
+		t.sawRateLimit = true
+
+	default: // fetchFailed
+		t.anyFailed = true
+	}
+}
+
+// scanInstalls returns the first DEFINITIVE answer — fetchOK or fetchAbsent —
+// which ends the lookup; everything else is ignorance and folds into t via record.
+//
+// On a definitive (true) return the tally is PARTIAL — the answering installation
+// is counted in total but nowhere else — so exhaustiveNoAccess must not be
+// consulted. Only a false return leaves a tally worth reading.
+func (s *sts) scanInstalls(ctx context.Context, owner string, installs []ghinstall.Installation, t *orgIssuerTally) (entry orgIssuerEntry, definitive bool) {
+	for _, in := range installs {
+		t.total++
+		res := s.fetchOrgIssuersOnce(ctx, in.Transport, in.ID, owner)
+		switch res.kind {
+		case fetchOK:
+			return res.entry, true
+
+		case fetchAbsent:
+			return absentOrgIssuerEntry(), true
+
+		default:
+			t.record(res.kind)
+		}
+	}
+	return orgIssuerEntry{}, false
+}
+
+// orgIssuerLookup returns the effective allowlist entry for owner, enumerating
+// EVERY installation and stopping at the first definitive answer. Not s.rrm.Get:
+// pickByQuota is argmax(remaining) with no rotation, so a Get-based loop could see
+// one blind installation forever and wrongly cache allow-all for the whole org.
+//
+// A non-nil error is a terminal gRPC status; a nil error with an Invalid entry
+// means the config is unusable and the caller surfaces entry.err.
+func (s *sts) orgIssuerLookup(ctx context.Context, owner string) (orgIssuerEntry, error) {
+	if e, ok := orgIssuers.Get(owner); ok {
+		return e, nil
+	}
+
+	installs, enumErr := s.rrm.GetAll(ctx, owner)
+
+	var t orgIssuerTally
+	if entry, ok := s.scanInstalls(ctx, owner, installs, &t); ok {
+		return s.settleOrgIssuerEntry(ctx, owner, entry), nil
+	}
+
+	// Absent requires POSITIVE knowledge: a failed or partial enumeration is not
+	// evidence of absence and is never cached. See exhaustiveNoAccess.
+	if enumErr == nil && t.exhaustiveNoAccess() {
+		clog.WarnContextf(ctx, "no installation can read %s/.github; org issuer enforcement not applied", owner)
+		absent := absentOrgIssuerEntry()
+		cacheOrgIssuerEntry(ctx, owner, absent)
+		return absent, nil
+	}
+
+	// Not exhaustive, or something failed. Serving stale is inherently mode-aware:
+	// an audit-mode allowlist never denies.
+	if stale, ok := staleOrgIssuers.Get(owner); ok {
+		clog.InfoContextf(ctx, "org issuer lookup incomplete for %s, serving stale entry", owner)
+		orgIssuers.Add(owner, stale)
+		return stale, nil
+	}
+
+	if enumErr != nil {
+		clog.WarnContextf(ctx, "enumerating installations for %s failed: %v", owner, enumErr)
+	} else if len(installs) == 0 {
+		clog.WarnContextf(ctx, "enumerating installations for %s returned none, but routing found one", owner)
+	}
+	if t.sawRateLimit {
+		return orgIssuerEntry{}, status.Error(codes.ResourceExhausted, msgIssuerRateLimited)
+	}
+	return orgIssuerEntry{}, status.Error(codes.Unavailable, msgIssuerUnavailable)
+}
+
+// settleOrgIssuerEntry caches a definitive entry, substituting the last known good
+// allowlist when the current file is unusable: a typo must not be an org-wide kill
+// switch. That list may be broader than intended, hence the Error log.
+func (s *sts) settleOrgIssuerEntry(ctx context.Context, owner string, entry orgIssuerEntry) orgIssuerEntry {
+	if entry.state == orgIssuerInvalid {
+		if stale, ok := staleOrgIssuers.Get(owner); ok && stale.state == orgIssuerPresent {
+			clog.ErrorContextf(ctx, "org trusted issuers for %s is invalid; serving last known good", owner)
+			orgIssuers.Add(owner, stale)
+			return stale
+		}
+	}
+	cacheOrgIssuerEntry(ctx, owner, entry)
+	return entry
+}
+
+// checkOrgTrustedIssuers evaluates the org allowlist for owner, returning a
+// decision to record on the Event (nil when no allowlist applied or the issuer was
+// permitted) and a terminal error when the exchange must be denied.
+func (s *sts) checkOrgTrustedIssuers(ctx context.Context, owner, issuer string) (*IssuerDecision, error) {
+	entry, err := s.orgIssuerLookup(ctx, owner)
+	if err != nil {
+		// Fail closed: an allowlist we could not establish is not allow-all.
+		return nil, err
+	}
+
+	switch entry.state {
+	case orgIssuerAbsent:
+		return nil, nil
+	case orgIssuerInvalid:
+		return nil, entry.err
+	case orgIssuerPresent:
+	default:
+		// orgIssuerUnknown. A zero value must never be a pass.
+		clog.ErrorContextf(ctx, "org issuer cache returned an unknown state for %s", owner)
+		return nil, status.Error(codes.Internal, msgIssuerUnavailable)
+	}
+
+	if entry.allow.Allows(issuer) {
+		return nil, nil
+	}
+
+	d := &IssuerDecision{Mode: entry.allow.Mode(), Issuer: issuer}
+	if entry.allow.Mode() == ModeAudit {
+		d.Allowed = true
+		clog.WarnContextf(ctx, "org issuer audit: %s would deny issuer %q", owner, issuer)
+		return d, nil
+	}
+	d.Allowed = false
+	clog.WarnContextf(ctx, "org issuer enforce: %s denied issuer %q", owner, issuer)
+	return d, status.Error(codes.PermissionDenied, msgIssuerNotPermitted)
+}

--- a/pkg/octosts/org_trusted_issuers_store_test.go
+++ b/pkg/octosts/org_trusted_issuers_store_test.go
@@ -975,8 +975,13 @@ func TestLookupServesStaleOnRateLimit(t *testing.T) {
 	if entry.state != orgIssuerPresent || entry.allow.Mode() != ModeAudit {
 		t.Fatalf("entry = %+v, want the stale audit-mode allowlist", entry)
 	}
-	if _, ok := orgIssuers.Get("orgallow"); !ok {
-		t.Error("primary cache should be reseeded after serving stale")
+	// Deliberately NOT reseeded. This assertion used to require the opposite, which
+	// encoded a real widening: a fresh 5-minute primary TTL on an entry already up
+	// to an hour old let an Absent admitted at t=0 be served past t=64:59, beyond
+	// the stale bound it is supposed to have. Not reseeding costs a re-enumeration
+	// per exchange for as long as the outage lasts.
+	if _, ok := orgIssuers.Get("orgallow"); ok {
+		t.Error("serving stale must not reseed the primary cache — that extends the window past the stale TTL")
 	}
 }
 
@@ -1832,5 +1837,94 @@ func TestInstallsNotInExcludesByID(t *testing.T) {
 
 	if got := installsNotIn(fresh, fresh); len(got) != 0 {
 		t.Errorf("installsNotIn(x, x) = %v, want empty", got)
+	}
+}
+
+// TestClassifyMintErrorRateLimitedBeforeNoAccess pins the ordering that keeps a
+// transient 422 from becoming AGREEMENT that .github is unreadable.
+//
+// GitHub documents 422 on the installation-token endpoint for both a genuine
+// validation failure and "endpoint has been spammed", and mint-422 is the sole
+// remaining source of agreement — so classifying an anti-abuse 422 as agreement
+// would let concurrent load flip an enforcing org to allow-all. Only a 422 with no
+// rate-limit signal counts.
+func TestClassifyMintErrorRateLimitedBeforeNoAccess(t *testing.T) {
+	mk := func(code int, hdr map[string]string) error {
+		h := http.Header{}
+		for k, v := range hdr {
+			h.Set(k, v)
+		}
+		return &ghinstallation.HTTPError{
+			Response: &http.Response{StatusCode: code, Header: h, Body: http.NoBody},
+		}
+	}
+	for _, tc := range []struct {
+		name     string
+		err      error
+		wantKind fetchKind
+	}{
+		{
+			// The regression: agreement is what falls the org open, so a 422 that
+			// carries a rate-limit signal must not supply it.
+			name:     "422 with Retry-After is a limit, not agreement",
+			err:      mk(http.StatusUnprocessableEntity, map[string]string{"Retry-After": "60"}),
+			wantKind: fetchRateLimited,
+		},
+		{
+			name:     "422 with exhausted quota is a limit, not agreement",
+			err:      mk(http.StatusUnprocessableEntity, map[string]string{"X-RateLimit-Remaining": "0"}),
+			wantKind: fetchRateLimited,
+		},
+		{
+			// Still agreement: a bare 422 is the genuine "no .github in this
+			// installation's repository selection" answer, and the org-wide
+			// fail-open depends on it.
+			name:     "bare 422 remains agreement",
+			err:      mk(http.StatusUnprocessableEntity, nil),
+			wantKind: fetchNoAccess,
+		},
+		{
+			name:     "bare 403 is neither a limit nor agreement",
+			err:      mk(http.StatusForbidden, nil),
+			wantKind: fetchFailed,
+		},
+		{
+			name:     "429 is a limit",
+			err:      mk(http.StatusTooManyRequests, nil),
+			wantKind: fetchRateLimited,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyMintError(t.Context(), "org", tc.err); got.kind != tc.wantKind {
+				t.Errorf("kind = %v, want %v", got.kind, tc.wantKind)
+			}
+		})
+	}
+}
+
+// TestStaleEntryIsNotReseededIntoPrimary pins that serving a stale entry does not
+// grant it a fresh primary TTL. Reseeding let an Absent admitted at t=0 be served
+// past t=64:59 — five minutes beyond the one-hour stale bound it is supposed to
+// have, silently widening a fail-open.
+func TestStaleEntryIsNotReseededIntoPrimary(t *testing.T) {
+	cleanupOrgIssuers(t, "orgallow")
+
+	// A durable Absent, then an enumeration that cannot conclude anything.
+	cacheOrgIssuerEntry(t.Context(), "orgallow", absentOrgIssuerEntry())
+	orgIssuers.Remove("orgallow")
+	if _, ok := staleOrgIssuers.Get("orgallow"); !ok {
+		t.Fatal("stale entry missing; this test needs one to serve")
+	}
+
+	s := &sts{rrm: &enumMgr{err: errors.New("enumeration failed")}, appCount: 1}
+	entry, err := s.orgIssuerLookup(t.Context(), "orgallow")
+	if err != nil {
+		t.Fatalf("orgIssuerLookup() = %v, want the stale entry served", err)
+	}
+	if entry.state != orgIssuerAbsent {
+		t.Fatalf("state = %v, want the stale orgIssuerAbsent", entry.state)
+	}
+	if _, ok := orgIssuers.Get("orgallow"); ok {
+		t.Error("stale entry was reseeded into the primary cache; that extends the fail-open past the stale TTL")
 	}
 }

--- a/pkg/octosts/org_trusted_issuers_store_test.go
+++ b/pkg/octosts/org_trusted_issuers_store_test.go
@@ -774,6 +774,21 @@ type enumMgr struct {
 	installs []ghinstall.Installation
 	err      error
 	getCalls atomic.Int32
+
+	// freshInstalls / freshErr model what GetAllFresh sees. freshInstalls
+	// defaults to installs, so a fake that sets neither describes a manager
+	// whose caches were not hiding anything — and the confirm step agrees with
+	// the cheap enumeration. Set freshInstalls to a superset to model an App
+	// installed within the negative-cache TTL.
+	//
+	// Precedence is freshErr, then freshInstalls, then a fallback that mirrors
+	// GetAll exactly — installs AND err. So a fake that sets only err is a failed
+	// enumeration on BOTH paths rather than one that reports success on the
+	// confirm, while a fake that sets freshInstalls says "the confirm sees this,
+	// successfully" and err stays scoped to GetAll.
+	freshInstalls []ghinstall.Installation
+	freshErr      error
+	freshCalls    atomic.Int32
 }
 
 func (e *enumMgr) Get(_ context.Context, _, _, _ string) (*ghinstallation.AppsTransport, int64, error) {
@@ -797,9 +812,15 @@ func (e *enumMgr) GetAll(_ context.Context, _ string) ([]ghinstall.Installation,
 	return e.installs, e.err
 }
 
-// GetAllFresh delegates: these tests do not distinguish the two enumerations.
-func (e *enumMgr) GetAllFresh(ctx context.Context, owner string) ([]ghinstall.Installation, error) {
-	return e.GetAll(ctx, owner)
+func (e *enumMgr) GetAllFresh(_ context.Context, _ string) ([]ghinstall.Installation, error) {
+	e.freshCalls.Add(1)
+	if e.freshErr != nil {
+		return nil, e.freshErr
+	}
+	if e.freshInstalls != nil {
+		return e.freshInstalls, nil
+	}
+	return e.installs, e.err
 }
 
 var _ ghinstall.Manager = (*enumMgr)(nil)
@@ -832,16 +853,24 @@ func TestLookupSurvivesOneBlindInstallation(t *testing.T) {
 	}
 }
 
+// TestLookupAllInstallationsBlindIsAbsent is the fail-open that must survive:
+// once CONFIRMED, a deployment that genuinely cannot read .github keeps working,
+// which describes most installations. This fake sets neither freshInstalls nor
+// freshErr, so the confirm agrees with the cheap enumeration.
+//
+// It also pins the confirm's cost: exactly one GetAllFresh call, bounded by the
+// orgIssuers entry it writes rather than paid per exchange.
 func TestLookupAllInstallationsBlindIsAbsent(t *testing.T) {
 	cleanupOrgIssuers(t, "orgallow")
 
 	a := newAppsTransport(t, newOrgFakeGitHub(withNoGitHubRepoAccess()))
 	b := newAppsTransport(t, newOrgFakeGitHub(withNoGitHubRepoAccess()))
 
-	s := &sts{rrm: &enumMgr{installs: []ghinstall.Installation{
+	mgr := &enumMgr{installs: []ghinstall.Installation{
 		{Transport: a, ID: 1, AppID: 10},
 		{Transport: b, ID: 2, AppID: 20},
-	}}, appCount: 2}
+	}}
+	s := &sts{rrm: mgr, appCount: 2}
 
 	entry, err := s.orgIssuerLookup(t.Context(), "orgallow")
 	if err != nil {
@@ -853,6 +882,18 @@ func TestLookupAllInstallationsBlindIsAbsent(t *testing.T) {
 	if cached, ok := orgIssuers.Get("orgallow"); !ok || cached.state != orgIssuerAbsent {
 		t.Error("an exhaustive all-blind verdict should be cached as Absent")
 	}
+	if got := mgr.freshCalls.Load(); got != 1 {
+		t.Errorf("GetAllFresh called %d times, want exactly 1", got)
+	}
+
+	// The confirm is bounded by the cache it writes: a second lookup is served
+	// from orgIssuers and pays nothing.
+	if _, err := s.orgIssuerLookup(t.Context(), "orgallow"); err != nil {
+		t.Fatalf("second orgIssuerLookup() = %v, want nil", err)
+	}
+	if got := mgr.freshCalls.Load(); got != 1 {
+		t.Errorf("GetAllFresh called %d times across two lookups, want 1 — the confirm must be bounded by the orgIssuers TTL, not run per exchange", got)
+	}
 }
 
 // TestLookupPartialEnumerationNeverCachesAbsent: a failed enumeration is not
@@ -862,10 +903,21 @@ func TestLookupPartialEnumerationNeverCachesAbsent(t *testing.T) {
 
 	blind := newAppsTransport(t, newOrgFakeGitHub(withNoGitHubRepoAccess()))
 
-	s := &sts{rrm: &enumMgr{
+	// freshInstalls is deliberately set to a would-be-confirming superset. If the
+	// enumErr == nil guard were dropped, the confirm would run, find the extra
+	// installation blind too, and cache Absent off a GetAll that had already
+	// reported itself incomplete. Without this the guard is unpinned: with
+	// freshInstalls unset, GetAllFresh falls back to (installs, err) and the
+	// confirm would fail on its own, so the test would pass either way.
+	mgr := &enumMgr{
 		installs: []ghinstall.Installation{{Transport: blind, ID: 1, AppID: 10}},
 		err:      errors.New("could not list installations for app 20"),
-	}, appCount: 2}
+		freshInstalls: []ghinstall.Installation{
+			{Transport: blind, ID: 1, AppID: 10},
+			{Transport: blind, ID: 2, AppID: 20},
+		},
+	}
+	s := &sts{rrm: mgr, appCount: 2}
 
 	_, err := s.orgIssuerLookup(t.Context(), "orgallow")
 	st, ok := status.FromError(err)
@@ -874,6 +926,9 @@ func TestLookupPartialEnumerationNeverCachesAbsent(t *testing.T) {
 	}
 	if _, ok := orgIssuers.Get("orgallow"); ok {
 		t.Error("nothing may be cached when the enumeration was not exhaustive")
+	}
+	if got := mgr.freshCalls.Load(); got != 0 {
+		t.Errorf("GetAllFresh called %d times, want 0 — a GetAll that reported itself incomplete is not a candidate for confirmation", got)
 	}
 }
 
@@ -1540,5 +1595,242 @@ func TestExchangeUninstalledOwnerReadsNoAllowlist(t *testing.T) {
 	}
 	if _, ok := orgIssuers.Get("orgallow"); ok {
 		t.Error("nothing may be cached for an owner the App is not installed on")
+	}
+}
+
+// TestLookupConfirmsBeforeGrantingAllowAll is the regression test for the
+// negative-cache window.
+//
+// An organization runs App A on selected repositories only, so A cannot read
+// .github. It installs App B to turn enforcement ON. For up to the
+// negative-cache TTL, GetAll cannot see B — and reports a NIL error while not
+// seeing it, because manager.GetAll maps NotFound to (nil, nil). Concluding from
+// the cheap enumeration alone would cache allow-all for the whole organization
+// at exactly the moment enforcement was meant to begin.
+func TestLookupConfirmsBeforeGrantingAllowAll(t *testing.T) {
+	cleanupOrgIssuers(t, "orgallow")
+
+	blind := newAppsTransport(t, newOrgFakeGitHub(withNoGitHubRepoAccess()))
+	hidden := newAppsTransport(t, newFakeGitHub())
+
+	mgr := &enumMgr{
+		installs: []ghinstall.Installation{{Transport: blind, ID: 1, AppID: 10}},
+		freshInstalls: []ghinstall.Installation{
+			{Transport: blind, ID: 1, AppID: 10},
+			{Transport: hidden, ID: 2, AppID: 20},
+		},
+	}
+	s := &sts{rrm: mgr, appCount: 2}
+
+	entry, err := s.orgIssuerLookup(t.Context(), "orgallow")
+	if err != nil {
+		t.Fatalf("orgIssuerLookup() = %v, want nil", err)
+	}
+	if entry.state != orgIssuerPresent {
+		t.Fatalf("state = %v, want orgIssuerPresent — an App hidden by the negative cache must not read as allow-all", entry.state)
+	}
+	if got := mgr.freshCalls.Load(); got != 1 {
+		t.Errorf("GetAllFresh called %d times, want exactly 1", got)
+	}
+	if cached, ok := orgIssuers.Get("orgallow"); !ok || cached.state != orgIssuerPresent {
+		t.Error("the confirmed allowlist should be cached")
+	}
+}
+
+// TestLookupFailedConfirmNeverCachesAbsent: if the confirmation cannot be made,
+// the conclusion has not been earned. That is ignorance, not absence.
+func TestLookupFailedConfirmNeverCachesAbsent(t *testing.T) {
+	cleanupOrgIssuers(t, "orgallow")
+
+	blind := newAppsTransport(t, newOrgFakeGitHub(withNoGitHubRepoAccess()))
+
+	s := &sts{rrm: &enumMgr{
+		installs: []ghinstall.Installation{{Transport: blind, ID: 1, AppID: 10}},
+		freshErr: errors.New("could not list installations for app 20"),
+	}, appCount: 2}
+
+	_, err := s.orgIssuerLookup(t.Context(), "orgallow")
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.Unavailable {
+		t.Fatalf("orgIssuerLookup() = %v, want Unavailable when the confirmation failed", err)
+	}
+	if _, ok := orgIssuers.Get("orgallow"); ok {
+		t.Error("nothing may be cached when the absence conclusion could not be confirmed")
+	}
+}
+
+// TestLookupNewlyFoundInstallationBlindIsAbsent: a confirmation that finds a new
+// App which ALSO cannot see .github earns the conclusion the cheap pass only
+// guessed at.
+func TestLookupNewlyFoundInstallationBlindIsAbsent(t *testing.T) {
+	cleanupOrgIssuers(t, "orgallow")
+
+	a := newAppsTransport(t, newOrgFakeGitHub(withNoGitHubRepoAccess()))
+	b := newAppsTransport(t, newOrgFakeGitHub(withNoGitHubRepoAccess()))
+
+	s := &sts{rrm: &enumMgr{
+		installs: []ghinstall.Installation{{Transport: a, ID: 1, AppID: 10}},
+		freshInstalls: []ghinstall.Installation{
+			{Transport: a, ID: 1, AppID: 10},
+			{Transport: b, ID: 2, AppID: 20},
+		},
+	}, appCount: 2}
+
+	entry, err := s.orgIssuerLookup(t.Context(), "orgallow")
+	if err != nil {
+		t.Fatalf("orgIssuerLookup() = %v, want nil", err)
+	}
+	if entry.state != orgIssuerAbsent {
+		t.Fatalf("state = %v, want orgIssuerAbsent", entry.state)
+	}
+	if cached, ok := orgIssuers.Get("orgallow"); !ok || cached.state != orgIssuerAbsent {
+		t.Error("every installation, including the newly-found one, agreed — that verdict is cacheable")
+	}
+}
+
+// TestLookupNewlyFoundInstallationRateLimitedFailsClosed: a newly-found App that
+// cannot be READ leaves the conclusion unearned, so the exchange must fail
+// closed rather than fall back to allow-all.
+func TestLookupNewlyFoundInstallationRateLimitedFailsClosed(t *testing.T) {
+	cleanupOrgIssuers(t, "orgallow")
+
+	blind := newAppsTransport(t, newOrgFakeGitHub(withNoGitHubRepoAccess()))
+	limited := newAppsTransport(t, newOrgFakeGitHub(withMintRateLimited()))
+
+	s := &sts{rrm: &enumMgr{
+		installs: []ghinstall.Installation{{Transport: blind, ID: 1, AppID: 10}},
+		freshInstalls: []ghinstall.Installation{
+			{Transport: blind, ID: 1, AppID: 10},
+			{Transport: limited, ID: 2, AppID: 20},
+		},
+	}, appCount: 2}
+
+	_, err := s.orgIssuerLookup(t.Context(), "orgallow")
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.ResourceExhausted {
+		t.Fatalf("orgIssuerLookup() = %v, want ResourceExhausted", err)
+	}
+	if _, ok := orgIssuers.Get("orgallow"); ok {
+		t.Error("nothing may be cached when a newly-found installation could not be read")
+	}
+}
+
+// TestLookupConfirmSubsetIsAbsent: a confirmation showing FEWER installations
+// (an App uninstalled since its positive cache entry was written) needs no
+// special handling. The extras already reported no-access, which does not weaken
+// "no installation can read .github".
+func TestLookupConfirmSubsetIsAbsent(t *testing.T) {
+	cleanupOrgIssuers(t, "orgallow")
+
+	a := newAppsTransport(t, newOrgFakeGitHub(withNoGitHubRepoAccess()))
+	b := newAppsTransport(t, newOrgFakeGitHub(withNoGitHubRepoAccess()))
+
+	s := &sts{rrm: &enumMgr{
+		installs: []ghinstall.Installation{
+			{Transport: a, ID: 1, AppID: 10},
+			{Transport: b, ID: 2, AppID: 20},
+		},
+		freshInstalls: []ghinstall.Installation{{Transport: a, ID: 1, AppID: 10}},
+	}, appCount: 2}
+
+	entry, err := s.orgIssuerLookup(t.Context(), "orgallow")
+	if err != nil {
+		t.Fatalf("orgIssuerLookup() = %v, want nil", err)
+	}
+	if entry.state != orgIssuerAbsent {
+		t.Fatalf("state = %v, want orgIssuerAbsent", entry.state)
+	}
+}
+
+// TestTallyAccumulatesAcrossPasses pins the property the confirmation step is
+// built on: a second scanInstalls pass ADDS to the first pass's evidence.
+// Recomputing instead of accumulating would let a failure in the second pass go
+// unnoticed and turn ignorance into org-wide allow-all.
+func TestTallyAccumulatesAcrossPasses(t *testing.T) {
+	blindA := newAppsTransport(t, newOrgFakeGitHub(withNoGitHubRepoAccess()))
+	blindB := newAppsTransport(t, newOrgFakeGitHub(withNoGitHubRepoAccess()))
+	broken := newAppsTransport(t, newOrgFakeGitHub(withContentsServerError()))
+
+	s := &sts{appCount: 2}
+	first := []ghinstall.Installation{{Transport: blindA, ID: 1, AppID: 10}}
+
+	t.Run("a failure in the second pass destroys exhaustiveness", func(t *testing.T) {
+		var tally orgIssuerTally
+		if _, definitive := s.scanInstalls(t.Context(), "orgallow", first, &tally); definitive {
+			t.Fatal("scanInstalls() = definitive, want not definitive for an all-blind pass")
+		}
+		if !tally.exhaustiveNoAccess() {
+			t.Fatal("after pass 1 the evidence should be exhaustive no-access; this test is vacuous otherwise")
+		}
+		second := []ghinstall.Installation{{Transport: broken, ID: 2, AppID: 20}}
+		if _, definitive := s.scanInstalls(t.Context(), "orgallow", second, &tally); definitive {
+			t.Fatal("scanInstalls() = definitive, want not definitive for a failed read")
+		}
+		if tally.exhaustiveNoAccess() {
+			t.Error("a failure in the second pass must destroy exhaustiveness, or ignorance becomes org-wide allow-all")
+		}
+	})
+
+	t.Run("a second pass that also agrees keeps exhaustiveness", func(t *testing.T) {
+		var tally orgIssuerTally
+		s.scanInstalls(t.Context(), "orgallow", first, &tally)
+		second := []ghinstall.Installation{{Transport: blindB, ID: 2, AppID: 20}}
+		s.scanInstalls(t.Context(), "orgallow", second, &tally)
+		if !tally.exhaustiveNoAccess() {
+			t.Error("every installation across both passes agreed; that is exhaustive no-access")
+		}
+	})
+
+	// The common production path: the confirmation found nothing new, so
+	// installsNotIn returns nil and the second pass scans an empty slice. It must
+	// leave the first pass's verdict intact rather than resetting anything.
+	t.Run("an empty second pass leaves the verdict intact", func(t *testing.T) {
+		var tally orgIssuerTally
+		s.scanInstalls(t.Context(), "orgallow", first, &tally)
+		if _, definitive := s.scanInstalls(t.Context(), "orgallow", nil, &tally); definitive {
+			t.Fatal("scanInstalls() over an empty slice = definitive, want not definitive")
+		}
+		if !tally.exhaustiveNoAccess() {
+			t.Error("an empty second pass must not disturb the first pass's verdict")
+		}
+	})
+}
+
+// TestExhaustiveNoAccessZeroTallyIsFalse pins the fail-open guard that no
+// end-to-end test can reach, since orgIssuerLookup is only entered after routing
+// already found an installation. Without total > 0 the comparison is 0 == 0,
+// which would grant allow-all off no evidence at all.
+func TestExhaustiveNoAccessZeroTallyIsFalse(t *testing.T) {
+	var tally orgIssuerTally
+	if tally.exhaustiveNoAccess() {
+		t.Error("a zero tally must not report exhaustive no-access")
+	}
+}
+
+// TestInstallsNotInExcludesByID encodes the GetAllFresh contract: it can hand
+// back a fresh *AppsTransport for an installation the first pass already asked,
+// so exclusion must be by ID. Comparing structs or transport pointers would
+// re-scan every installation and double the API cost of every absence conclusion.
+func TestInstallsNotInExcludesByID(t *testing.T) {
+	one := newAppsTransport(t, newFakeGitHub())
+	two := newAppsTransport(t, newFakeGitHub())
+
+	fresh := []ghinstall.Installation{
+		{Transport: one, ID: 1, AppID: 10},
+		{Transport: two, ID: 2, AppID: 20},
+	}
+	// Same ID as fresh[0], deliberately a DIFFERENT transport pointer.
+	alreadyScanned := []ghinstall.Installation{{Transport: two, ID: 1, AppID: 10}}
+
+	got := installsNotIn(fresh, alreadyScanned)
+	if len(got) != 1 {
+		t.Fatalf("installsNotIn() returned %d installations, want 1", len(got))
+	}
+	if got[0].ID != 2 {
+		t.Errorf("installsNotIn() kept ID %d, want 2", got[0].ID)
+	}
+
+	if got := installsNotIn(fresh, fresh); len(got) != 0 {
+		t.Errorf("installsNotIn(x, x) = %v, want empty", got)
 	}
 }

--- a/pkg/octosts/org_trusted_issuers_store_test.go
+++ b/pkg/octosts/org_trusted_issuers_store_test.go
@@ -1,0 +1,1544 @@
+// Copyright 2026 Chainguard, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package octosts
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	v1 "chainguard.dev/sdk/proto/platform/oidc/v1"
+	"github.com/bradleyfalzon/ghinstallation/v2"
+	"github.com/chainguard-dev/clog"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/go-jose/go-jose/v4"
+	josejwt "github.com/go-jose/go-jose/v4/jwt"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-github/v88/github"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	"github.com/octo-sts/app/pkg/ghinstall"
+	"github.com/octo-sts/app/pkg/provider"
+)
+
+var errTestInvalid = errors.New("test: invalid config")
+
+// cleanupOrgIssuers removes the owner keys a test seeded. The caches are
+// package-level shared state, so leaking entries makes later tests in this
+// package order-dependent. This mirrors the existing convention for
+// trustPolicies/staleTrustPolicies.
+func cleanupOrgIssuers(t *testing.T, owners ...string) {
+	t.Helper()
+	purge := func() {
+		for _, o := range owners {
+			orgIssuers.Remove(o)
+			staleOrgIssuers.Remove(o)
+		}
+	}
+	purge()
+	t.Cleanup(purge)
+}
+
+func TestCacheOrgIssuerEntryStaleRouting(t *testing.T) {
+	cleanupOrgIssuers(t, "o-present", "o-absent", "o-invalid")
+
+	allow, err := (&OrgTrustedIssuers{Issuers: []string{testGitHubIssuer}}).Compile()
+	if err != nil {
+		t.Fatalf("Compile() = %v", err)
+	}
+
+	// Present and Absent are durable knowledge and belong in both caches.
+	cacheOrgIssuerEntry(t.Context(), "o-present", presentOrgIssuerEntry(allow))
+	cacheOrgIssuerEntry(t.Context(), "o-absent", absentOrgIssuerEntry())
+	// Invalid is a transient bad state and must never become "last known good".
+	cacheOrgIssuerEntry(t.Context(), "o-invalid", invalidOrgIssuerEntry(errTestInvalid))
+
+	for _, owner := range []string{"o-present", "o-absent", "o-invalid"} {
+		if _, ok := orgIssuers.Get(owner); !ok {
+			t.Errorf("orgIssuers is missing %q", owner)
+		}
+	}
+	for _, owner := range []string{"o-present", "o-absent"} {
+		if _, ok := staleOrgIssuers.Get(owner); !ok {
+			t.Errorf("staleOrgIssuers is missing %q", owner)
+		}
+	}
+	if _, ok := staleOrgIssuers.Get("o-invalid"); ok {
+		t.Error("staleOrgIssuers must not hold an Invalid entry — it would become last-known-good")
+	}
+}
+
+func TestCacheOrgIssuerEntryWarnsOnEnforcementRemoved(t *testing.T) {
+	cleanupOrgIssuers(t, "o-transition")
+
+	allow, err := (&OrgTrustedIssuers{Issuers: []string{testGitHubIssuer}}).Compile()
+	if err != nil {
+		t.Fatalf("Compile() = %v", err)
+	}
+
+	// Capture the log output via a real slog handler wired through clog, so
+	// the warning itself — not just the state it keys off — is asserted.
+	var logs bytes.Buffer
+	ctx := clog.WithLogger(t.Context(), clog.New(slog.NewTextHandler(&logs, nil)))
+
+	// Present first, so staleOrgIssuers holds an enforcing entry...
+	cacheOrgIssuerEntry(ctx, "o-transition", presentOrgIssuerEntry(allow))
+	if prev, ok := staleOrgIssuers.Get("o-transition"); !ok || prev.state != orgIssuerPresent {
+		t.Fatalf("setup: stale entry = %+v, ok = %v; want a Present entry", prev, ok)
+	}
+	if logs.Len() != 0 {
+		t.Fatalf("unexpected log output after the initial Present write: %q", logs.String())
+	}
+
+	// ...then Absent, which is the enforcement-removed transition.
+	cacheOrgIssuerEntry(ctx, "o-transition", absentOrgIssuerEntry())
+
+	got, ok := staleOrgIssuers.Get("o-transition")
+	if !ok || got.state != orgIssuerAbsent {
+		t.Fatalf("stale entry = %+v, ok = %v; want Absent after the transition", got, ok)
+	}
+	if !bytes.Contains(logs.Bytes(), []byte("enforcement removed")) {
+		t.Fatalf("log output = %q, want it to contain the enforcement-removed warning", logs.String())
+	}
+
+	// A repeat Absent write is not a transition (stale is already Absent), so
+	// it must not warn again.
+	logs.Reset()
+	cacheOrgIssuerEntry(ctx, "o-transition", absentOrgIssuerEntry())
+	if logs.Len() != 0 {
+		t.Fatalf("repeat Absent write logged %q, want no warning — the transition is one-shot", logs.String())
+	}
+}
+
+func TestZeroValueEntryIsNotAPass(t *testing.T) {
+	// The Go zero value of orgIssuerEntry must never mean "allow". A dropped
+	// ok from Get, an eviction, or a future struct-copy bug would otherwise
+	// silently disable the control on the hot path.
+	//
+	// The invariant this actually protects is the CONSTANT ORDER: orgIssuerUnknown
+	// must be the iota zero. Reordering the block so orgIssuerAbsent came first
+	// would make every zero value an allow-all, which is why that is asserted
+	// directly rather than only via the struct.
+	if orgIssuerUnknown != 0 {
+		t.Fatalf("orgIssuerUnknown = %d, want 0 — it must be the iota zero so a zero-value entry is never a pass", orgIssuerUnknown)
+	}
+	if orgIssuerAbsent == 0 {
+		t.Fatal("orgIssuerAbsent must not be the iota zero — a zero-value entry would then permit all issuers")
+	}
+
+	var zero orgIssuerEntry
+	if zero.state != orgIssuerUnknown {
+		t.Fatalf("zero value state = %v, want orgIssuerUnknown", zero.state)
+	}
+}
+
+func TestIsOrgIssuerRateLimit(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "typed primary rate limit",
+			err:  &github.RateLimitError{Response: &http.Response{StatusCode: http.StatusForbidden}},
+			want: true,
+		},
+		{
+			name: "typed secondary rate limit",
+			err:  &github.AbuseRateLimitError{Response: &http.Response{StatusCode: http.StatusForbidden}},
+			want: true,
+		},
+		{
+			name: "bare 429",
+			err:  &github.ErrorResponse{Response: &http.Response{StatusCode: http.StatusTooManyRequests}},
+			want: true,
+		},
+		{
+			// The whole point: a bare 403 is a permission, SAML/IP-allowlist, or
+			// suspended-installation failure. go-github would have returned a
+			// typed error had it been a rate limit.
+			name: "bare 403 is NOT a rate limit",
+			err:  &github.ErrorResponse{Response: &http.Response{StatusCode: http.StatusForbidden}},
+			want: false,
+		},
+		{
+			name: "404",
+			err:  &github.ErrorResponse{Response: &http.Response{StatusCode: http.StatusNotFound}},
+			want: false,
+		},
+		{name: "nil", err: nil, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Wrap only a non-nil error. An earlier revision wrapped
+			// unconditionally and guarded the assertion with `tc.err != nil`,
+			// which silently skipped the nil row entirely — it asserted nothing.
+			err := tc.err
+			if err != nil {
+				err = fmt.Errorf("wrapped: %w", err)
+			}
+			if got := isOrgIssuerRateLimit(err); got != tc.want {
+				t.Errorf("isOrgIssuerRateLimit(%T) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestOrgIssuerRateLimitDivergesFromWebhook pins the deliberate divergence: the
+// webhook's helper treats any 403 as rate limiting, which is right there (it
+// only suppresses a CheckRun) and wrong here (it would deny federation).
+func TestOrgIssuerRateLimitDivergesFromWebhook(t *testing.T) {
+	bare403 := &github.ErrorResponse{Response: &http.Response{StatusCode: http.StatusForbidden}}
+	if isOrgIssuerRateLimit(bare403) {
+		t.Error("isOrgIssuerRateLimit must NOT treat a bare 403 as a rate limit")
+	}
+	if !IsGitHubRateLimited(bare403) {
+		t.Error("IsGitHubRateLimited is expected to treat a bare 403 as a rate limit; if this changed, revisit the divergence comment")
+	}
+}
+
+func TestClassifyMintError(t *testing.T) {
+	mk := func(code int, headers map[string]string) error {
+		h := http.Header{}
+		for k, v := range headers {
+			h.Set(k, v)
+		}
+		return fmt.Errorf("wrapped: %w", &ghinstallation.HTTPError{
+			Message:  "boom",
+			Response: &http.Response{StatusCode: code, Header: h, Body: http.NoBody},
+		})
+	}
+
+	for _, tc := range []struct {
+		name     string
+		err      error
+		wantKind fetchKind
+		wantCode codes.Code
+	}{
+		{
+			// 422 conflates "repo absent", "not granted", and "permissions not
+			// granted" — all mean this installation cannot see .github.
+			name:     "422 unprocessable",
+			err:      mk(http.StatusUnprocessableEntity, nil),
+			wantKind: fetchNoAccess,
+		},
+		{
+			name:     "429 too many requests",
+			err:      mk(http.StatusTooManyRequests, nil),
+			wantKind: fetchRateLimited,
+			wantCode: codes.ResourceExhausted,
+		},
+		{
+			// The installation-token endpoint is rate limited like any other.
+			// Collapsing this into "other" meant one exhausted app denied every
+			// exchange in the org while other apps still had quota.
+			name:     "403 with rate limit marker",
+			err:      mk(http.StatusForbidden, map[string]string{"X-RateLimit-Remaining": "0"}),
+			wantKind: fetchRateLimited,
+			wantCode: codes.ResourceExhausted,
+		},
+		{
+			// Secondary limits carry Retry-After; X-RateLimit-Remaining is
+			// typically nonzero, so the primary-only check would miss this.
+			name:     "403 with only Retry-After (secondary limit)",
+			err:      mk(http.StatusForbidden, map[string]string{"Retry-After": "60"}),
+			wantKind: fetchRateLimited,
+			wantCode: codes.ResourceExhausted,
+		},
+		{
+			// A 429 is always a rate limit regardless of what the remaining
+			// count says.
+			name:     "429 with nonzero X-RateLimit-Remaining",
+			err:      mk(http.StatusTooManyRequests, map[string]string{"X-RateLimit-Remaining": "10"}),
+			wantKind: fetchRateLimited,
+			wantCode: codes.ResourceExhausted,
+		},
+		{
+			// A bare 403 is a suspended or blocked installation. It says nothing
+			// about .github visibility, so it must not be fetchNoAccess.
+			name:     "bare 403",
+			err:      mk(http.StatusForbidden, nil),
+			wantKind: fetchFailed,
+			wantCode: codes.Unavailable,
+		},
+		{name: "401", err: mk(http.StatusUnauthorized, nil), wantKind: fetchFailed, wantCode: codes.Unavailable},
+		{name: "404", err: mk(http.StatusNotFound, nil), wantKind: fetchFailed, wantCode: codes.Unavailable},
+		{name: "500", err: mk(http.StatusInternalServerError, nil), wantKind: fetchFailed, wantCode: codes.Unavailable},
+		{name: "untyped", err: errors.New("dial tcp: connection refused"), wantKind: fetchFailed, wantCode: codes.Unavailable},
+		{
+			// herr.Response != nil is a live guard: without it this row would
+			// nil-dereference at herr.Response.StatusCode. The "untyped" row
+			// above only exercises errors.As failing to match, not this branch.
+			name:     "typed error with nil response",
+			err:      fmt.Errorf("wrapped: %w", &ghinstallation.HTTPError{Message: "boom", Response: nil}),
+			wantKind: fetchFailed,
+			wantCode: codes.Unavailable,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyMintError(t.Context(), "org", tc.err)
+			if got.kind != tc.wantKind {
+				t.Fatalf("kind = %v, want %v", got.kind, tc.wantKind)
+			}
+			// Only fetchOK carries an entry. Every other kind must leave it at
+			// the fail-closed zero — asserted here, against the real classifier,
+			// rather than against a test-local literal where it would be
+			// guaranteed by Go's zero-value semantics and prove nothing.
+			if got.kind != fetchOK && got.entry.state != orgIssuerUnknown {
+				t.Errorf("entry.state = %v, want orgIssuerUnknown for kind %v", got.entry.state, got.kind)
+			}
+			if tc.wantCode == codes.OK {
+				if got.err != nil {
+					t.Errorf("err = %v, want nil — kind %v is an answer, not a failure", got.err, got.kind)
+				}
+				return
+			}
+			st, ok := status.FromError(got.err)
+			if !ok {
+				t.Fatalf("err = %T, want a gRPC status", got.err)
+			}
+			if st.Code() != tc.wantCode {
+				t.Errorf("code = %v, want %v", st.Code(), tc.wantCode)
+			}
+		})
+	}
+}
+
+func TestClassifyContentsError(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		err      error
+		wantKind fetchKind
+		wantCode codes.Code
+	}{
+		{
+			name:     "typed primary rate limit",
+			err:      &github.RateLimitError{Response: &http.Response{StatusCode: http.StatusForbidden}},
+			wantKind: fetchRateLimited,
+			wantCode: codes.ResourceExhausted,
+		},
+		{
+			name:     "typed secondary rate limit",
+			err:      &github.AbuseRateLimitError{Response: &http.Response{StatusCode: http.StatusForbidden}},
+			wantKind: fetchRateLimited,
+			wantCode: codes.ResourceExhausted,
+		},
+		{
+			name:     "404 file absent",
+			err:      &github.ErrorResponse{Response: &http.Response{StatusCode: http.StatusNotFound}},
+			wantKind: fetchAbsent,
+		},
+		{
+			// This is the row that a shared 403-means-rate-limit helper would
+			// have made unreachable. It is ignorance, so fetchFailed.
+			//
+			// It used to assert fetchNoAccess, on the theory that a 403 is one
+			// installation's blindness. That was wrong in a way worth recording,
+			// because NoAccess counts as an installation AGREEING that no allowlist
+			// applies: a read-time 403 is frequently org-wide (IP allow list,
+			// SAML/SSO enforcement, ToS lock, an incident failing the contents API),
+			// which makes every installation "agree" while carrying no information
+			// about whether an allowlist exists — falling the org open to allow-all
+			// precisely during the incident.
+			//
+			// The old rationale also mis-stated the aggregator: scanInstalls records
+			// a failure and CONTINUES, so a 403 never stopped it from asking an
+			// installation that can read the file. All fetchFailed changes is that an
+			// all-403 enumeration fails closed instead of concluding absence.
+			//
+			// The genuinely per-installation case does not arrive here: an App
+			// without .github in its repository selection fails at the mint with a
+			// 422, which is still NoAccess and still falls open.
+			name:     "bare 403 is ignorance, not agreement that no allowlist applies",
+			err:      &github.ErrorResponse{Response: &http.Response{StatusCode: http.StatusForbidden}},
+			wantKind: fetchFailed,
+			wantCode: codes.Unavailable,
+		},
+		{
+			name:     "502",
+			err:      &github.ErrorResponse{Response: &http.Response{StatusCode: http.StatusBadGateway}},
+			wantKind: fetchFailed,
+			wantCode: codes.Unavailable,
+		},
+		{name: "untyped", err: errors.New("dial tcp: connection refused"), wantKind: fetchFailed, wantCode: codes.Unavailable},
+		{
+			// ghErr.Response != nil is a live guard: without it this row would
+			// nil-dereference at ghErr.Response.StatusCode. The "untyped" row
+			// above only exercises errors.As failing to match, not this branch.
+			name:     "typed error with nil response",
+			err:      &github.ErrorResponse{Response: nil},
+			wantKind: fetchFailed,
+			wantCode: codes.Unavailable,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyContentsError(t.Context(), "org", fmt.Errorf("wrapped: %w", tc.err))
+			if got.kind != tc.wantKind {
+				t.Fatalf("kind = %v, want %v", got.kind, tc.wantKind)
+			}
+			// Only fetchOK carries an entry. Every other kind must leave it at
+			// the fail-closed zero — asserted here, against the real classifier,
+			// rather than against a test-local literal where it would be
+			// guaranteed by Go's zero-value semantics and prove nothing.
+			if got.kind != fetchOK && got.entry.state != orgIssuerUnknown {
+				t.Errorf("entry.state = %v, want orgIssuerUnknown for kind %v", got.entry.state, got.kind)
+			}
+			if tc.wantCode == codes.OK {
+				if got.err != nil {
+					t.Errorf("err = %v, want nil — kind %v is an answer, not a failure", got.err, got.kind)
+				}
+				return
+			}
+			st, ok := status.FromError(got.err)
+			if !ok {
+				t.Fatalf("err = %T, want a gRPC status", got.err)
+			}
+			if st.Code() != tc.wantCode {
+				t.Errorf("code = %v, want %v", st.Code(), tc.wantCode)
+			}
+		})
+	}
+}
+
+func TestFetchOrgIssuersOnce(t *testing.T) {
+	cleanupOrgIssuers(t, "orgallow")
+
+	atr := newAppsTransport(t, newFakeGitHub())
+	s := &sts{rrm: &fakeInstallMgr{atr: atr}, appCount: 1}
+
+	res := s.fetchOrgIssuersOnce(t.Context(), atr, 1234, "orgallow")
+	if res.kind != fetchOK {
+		t.Fatalf("kind = %v, want fetchOK", res.kind)
+	}
+	if res.entry.state != orgIssuerPresent {
+		t.Fatalf("state = %v, want orgIssuerPresent", res.entry.state)
+	}
+	if !res.entry.allow.Allows(testGitHubIssuer) {
+		t.Errorf("Allows(%q) = false, want true", testGitHubIssuer)
+	}
+	if res.entry.allow.Mode() != ModeEnforce {
+		t.Errorf("Mode() = %q, want %q", res.entry.allow.Mode(), ModeEnforce)
+	}
+	if res.err != nil {
+		t.Errorf("err = %v, want nil — fetchOK is an answer, not a failure", res.err)
+	}
+}
+
+func TestFetchOrgIssuersOnceAbsent(t *testing.T) {
+	cleanupOrgIssuers(t, "orgnone")
+
+	atr := newAppsTransport(t, newFakeGitHub())
+	s := &sts{rrm: &fakeInstallMgr{atr: atr}, appCount: 1}
+
+	// No fixture for orgnone, so the fake returns a GitHub-shaped 404. A 404 is
+	// definitive: the repo was readable and the file is not there.
+	res := s.fetchOrgIssuersOnce(t.Context(), atr, 1234, "orgnone")
+	if res.kind != fetchAbsent {
+		t.Fatalf("kind = %v, want fetchAbsent", res.kind)
+	}
+	if res.entry.state != orgIssuerUnknown {
+		t.Errorf("entry.state = %v, want orgIssuerUnknown — fetchAbsent carries no entry", res.entry.state)
+	}
+	if res.err != nil {
+		t.Errorf("err = %v, want nil", res.err)
+	}
+}
+
+func TestFetchOrgIssuersOnceInvalid(t *testing.T) {
+	cleanupOrgIssuers(t, "orgbad")
+
+	atr := newAppsTransport(t, newFakeGitHub())
+	s := &sts{rrm: &fakeInstallMgr{atr: atr}, appCount: 1}
+
+	res := s.fetchOrgIssuersOnce(t.Context(), atr, 1234, "orgbad")
+	if res.kind != fetchOK {
+		t.Fatalf("kind = %v, want fetchOK (an invalid config is an answer, not a fetch failure)", res.kind)
+	}
+	if res.entry.state != orgIssuerInvalid {
+		t.Fatalf("state = %v, want orgIssuerInvalid", res.entry.state)
+	}
+	st, ok := status.FromError(res.entry.err)
+	if !ok || st.Code() != codes.FailedPrecondition {
+		t.Fatalf("entry.err = %v, want FailedPrecondition", res.entry.err)
+	}
+	if st.Message() != msgIssuerConfigInvalid {
+		t.Errorf("message = %q, want the fixed %q (no config detail may leak)", st.Message(), msgIssuerConfigInvalid)
+	}
+}
+
+// scopeCapturingHandler wraps another handler and records the Authorization
+// header GitHub received on each request to the contents endpoint. The fake's
+// mint route echoes the InstallationTokenOptions JSON back as the token
+// itself (base64-encoded), and ghinstallation attaches that token as the
+// bearer on every subsequent request — so the header this handler captures
+// IS the scope that was actually minted, recoverable without any new
+// plumbing in the non-test code.
+type scopeCapturingHandler struct {
+	http.Handler
+
+	mu       sync.Mutex
+	lastAuth string
+}
+
+func (c *scopeCapturingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if strings.Contains(r.URL.Path, "/contents/") {
+		c.mu.Lock()
+		c.lastAuth = r.Header.Get("Authorization")
+		c.mu.Unlock()
+	}
+	c.Handler.ServeHTTP(w, r)
+}
+
+func (c *scopeCapturingHandler) mintedOptions(t *testing.T) *github.InstallationTokenOptions {
+	t.Helper()
+	c.mu.Lock()
+	auth := c.lastAuth
+	c.mu.Unlock()
+
+	// ghinstallation sends the installation token as "token <value>", not the
+	// OAuth2 "Bearer <value>" form used elsewhere in this codebase for the
+	// caller's own OIDC token.
+	tokenStr, ok := strings.CutPrefix(auth, "token ")
+	if !ok {
+		t.Fatalf("Authorization header = %q, want a %q-prefixed token", auth, "token ")
+	}
+	b, err := base64.StdEncoding.DecodeString(tokenStr)
+	if err != nil {
+		t.Fatalf("DecodeString(%q) failed: %v", tokenStr, err)
+	}
+	opts := new(github.InstallationTokenOptions)
+	if err := json.Unmarshal(b, opts); err != nil {
+		t.Fatalf("Unmarshal(%s) failed: %v", b, err)
+	}
+	return opts
+}
+
+// TestFetchOrgIssuersOnceMintsLeastPrivilegeToken pins the token scope
+// fetchOrgIssuersOnce requests: exactly the organization's .github repository,
+// with exactly contents:read. This is a security property, not an
+// implementation detail — a token that could read more than .github, or that
+// carried an extra permission, would hand any installation broader access
+// than the org-allowlist lookup needs.
+func TestFetchOrgIssuersOnceMintsLeastPrivilegeToken(t *testing.T) {
+	cleanupOrgIssuers(t, "orgallow")
+
+	capture := &scopeCapturingHandler{Handler: newFakeGitHub()}
+	atr := newAppsTransport(t, capture)
+	s := &sts{rrm: &fakeInstallMgr{atr: atr}, appCount: 1}
+
+	res := s.fetchOrgIssuersOnce(t.Context(), atr, 1234, "orgallow")
+	if res.kind != fetchOK {
+		t.Fatalf("kind = %v, want fetchOK", res.kind)
+	}
+
+	got := capture.mintedOptions(t)
+	want := &github.InstallationTokenOptions{
+		Repositories: []string{".github"},
+		Permissions: &github.InstallationPermissions{
+			Contents: ptr("read"),
+		},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("minted InstallationTokenOptions mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestFetchOrgIssuersOnceDirectory exercises the guard against a path that
+// resolves to a directory rather than a file. GetContents returns a nil
+// *RepositoryContent in that case, and RepositoryContent.GetContent()
+// dereferences its Encoding field with no nil-receiver guard — so without the
+// guard in fetchOrgIssuersOnce, this panics on the token-exchange path
+// instead of reporting a broken config. A directory is a broken config, not
+// a fetch failure: the installation DID answer, the answer is just unusable.
+func TestFetchOrgIssuersOnceDirectory(t *testing.T) {
+	cleanupOrgIssuers(t, "orgdir")
+
+	atr := newAppsTransport(t, newFakeGitHub())
+	s := &sts{rrm: &fakeInstallMgr{atr: atr}, appCount: 1}
+
+	// A different installation ID than the other tests use, so fetchOrgIssuersOnce
+	// keeps this parameter's plumbing (EnrichContext, ghinstallation.NewFromAppsTransport)
+	// exercised with more than one value — the aggregating caller in a later
+	// task will vary it across installations.
+	res := s.fetchOrgIssuersOnce(t.Context(), atr, 5678, "orgdir")
+	if res.kind != fetchOK {
+		t.Fatalf("kind = %v, want fetchOK", res.kind)
+	}
+	if res.entry.state != orgIssuerInvalid {
+		t.Fatalf("state = %v, want orgIssuerInvalid", res.entry.state)
+	}
+}
+
+// newOrgFakeGitHub builds a fake GitHub for the org-allowlist tests. With no
+// options it behaves like newFakeGitHub: installations enumerate, mints echo
+// their own InstallationTokenOptions back as the token, and contents are served
+// from testdata. Each option replaces exactly one route, so a fake that only
+// overrides the mint endpoint still reads testdata exactly as before.
+func newOrgFakeGitHub(opts ...orgFakeGitHubOption) *fakeGitHub {
+	routes := &orgFakeGitHubRoutes{
+		mint:     defaultOrgFakeMint,
+		contents: defaultOrgFakeContents,
+	}
+	for _, opt := range opts {
+		opt(routes)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/app/installations", func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode([]github.Installation{{
+			ID:      github.Ptr(int64(1234)),
+			Account: &github.User{Login: github.Ptr("org")},
+		}})
+	})
+	mux.HandleFunc("/app/installations/{appID}/access_tokens", routes.mint)
+	mux.HandleFunc("/repos/{org}/{repo}/contents/.github/chainguard/{identity}", routes.contents)
+	// Revoke() posts here. It does not reach any fake: its URL follows the
+	// configured baseURL, which is empty in these tests and so resolves to
+	// https://api.github.com/installation/token, and it sends via
+	// http.DefaultClient rather than the injected transport. The route keeps the
+	// fake correct if Revoke is ever pointed at it. Same dead route as in
+	// newFakeGitHub.
+	mux.HandleFunc("/installation/token", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotImplemented)
+		fmt.Fprintf(io.MultiWriter(w, os.Stdout), "%s %s not implemented\n", r.Method, r.URL.Path)
+	})
+	return &fakeGitHub{mux: mux}
+}
+
+// orgFakeGitHubRoutes holds the only two routes any of these fakes needs to
+// vary. The others (installation enumeration, the revoke route, the
+// not-implemented catch-all) are identical everywhere and stay in the builder.
+type orgFakeGitHubRoutes struct {
+	mint     http.HandlerFunc
+	contents http.HandlerFunc
+}
+
+type orgFakeGitHubOption func(*orgFakeGitHubRoutes)
+
+// defaultOrgFakeMint echoes the request body back as the token, base64-encoded.
+// TestFetchOrgIssuersOnceMintsLeastPrivilegeToken depends on that echo to
+// recover the scope that was actually minted.
+func defaultOrgFakeMint(w http.ResponseWriter, r *http.Request) {
+	b, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	json.NewEncoder(w).Encode(github.InstallationToken{
+		Token:     github.Ptr(base64.StdEncoding.EncodeToString(b)),
+		ExpiresAt: &github.Timestamp{Time: time.Now().Add(10 * time.Minute)},
+	})
+}
+
+// defaultOrgFakeContents serves a file out of testdata, mirroring newFakeGitHub.
+func defaultOrgFakeContents(w http.ResponseWriter, r *http.Request) {
+	// Sentinel: owner "orgdir" always resolves the trusted-issuers path to a
+	// directory rather than a file. go-github distinguishes the two by response
+	// shape — a single JSON object is a file, a JSON array is a directory
+	// listing — so this is the only way to make GetContents return a nil
+	// *RepositoryContent without an actual directory on disk. A real testdata
+	// directory would hit os.ReadFile's EISDIR below, which is not
+	// os.IsNotExist and would fall into the 500 branch instead.
+	if r.PathValue("org") == "orgdir" && r.PathValue("identity") == "trusted-token-issuers.yaml" {
+		json.NewEncoder(w).Encode([]*github.RepositoryContent{
+			{Type: github.Ptr("file"), Name: github.Ptr("placeholder")},
+		})
+		return
+	}
+
+	b, err := os.ReadFile(filepath.Join("testdata", r.PathValue("org"), r.PathValue("repo"), r.PathValue("identity")))
+	if err != nil {
+		// A missing fixture is a 404, matching real GitHub.
+		if os.IsNotExist(err) {
+			writeGitHubNotFound(w)
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(io.MultiWriter(w, os.Stdout), "ReadFile failed: %v\n", err)
+		return
+	}
+	json.NewEncoder(w).Encode(github.RepositoryContent{
+		Content:  github.Ptr(base64.StdEncoding.EncodeToString(b)),
+		Type:     github.Ptr("file"),
+		Encoding: github.Ptr("base64"),
+	})
+}
+
+// withNoGitHubRepoAccess rejects a .github-scoped mint with 422 while every
+// other scope succeeds, simulating an App installed on selected repositories.
+func withNoGitHubRepoAccess() orgFakeGitHubOption {
+	return func(routes *orgFakeGitHubRoutes) {
+		routes.mint = func(w http.ResponseWriter, r *http.Request) {
+			b, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			if bytes.Contains(b, []byte(`".github"`)) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnprocessableEntity)
+				json.NewEncoder(w).Encode(github.ErrorResponse{
+					Response: &http.Response{StatusCode: http.StatusUnprocessableEntity},
+					Message:  "There is at least one repository that does not exist or is not accessible to the parent installation.",
+				})
+				return
+			}
+			json.NewEncoder(w).Encode(github.InstallationToken{
+				Token:     github.Ptr(base64.StdEncoding.EncodeToString(b)),
+				ExpiresAt: &github.Timestamp{Time: time.Now().Add(10 * time.Minute)},
+			})
+		}
+	}
+}
+
+// withMintRateLimited rate-limits the installation-token endpoint.
+func withMintRateLimited() orgFakeGitHubOption {
+	return func(routes *orgFakeGitHubRoutes) {
+		routes.mint = func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			// X-RateLimit-Remaining: 0 is what makes go-github return a typed
+			// *github.RateLimitError rather than a bare *github.ErrorResponse.
+			// Without it this fake cannot reproduce the production
+			// classification path at all.
+			w.Header().Set("X-RateLimit-Remaining", "0")
+			w.WriteHeader(http.StatusForbidden)
+			json.NewEncoder(w).Encode(github.ErrorResponse{
+				Response: &http.Response{StatusCode: http.StatusForbidden},
+				Message:  "API rate limit exceeded",
+			})
+		}
+	}
+}
+
+// withContentsRateLimited rate-limits every contents request, including the
+// allowlist. newFakeGitHubRateLimit deliberately exempts the allowlist so the
+// policy-read tests keep testing the policy read.
+func withContentsRateLimited() orgFakeGitHubOption {
+	return func(routes *orgFakeGitHubRoutes) {
+		routes.contents = func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			// See withMintRateLimited: the zero remaining count is what yields a
+			// typed *github.RateLimitError.
+			w.Header().Set("X-RateLimit-Remaining", "0")
+			w.Header().Set("X-RateLimit-Limit", "5000")
+			w.Header().Set("X-RateLimit-Reset", fmt.Sprintf("%d", time.Now().Add(time.Minute).Unix()))
+			w.WriteHeader(http.StatusForbidden)
+			json.NewEncoder(w).Encode(github.ErrorResponse{
+				Response: &http.Response{StatusCode: http.StatusForbidden},
+				Message:  "API rate limit exceeded",
+			})
+		}
+	}
+}
+
+// withContentsServerError fails every contents read with a 502 — a transient
+// server error that is neither a rate limit nor evidence of this installation's
+// blindness, so it classifies as fetchFailed. The mint still succeeds.
+func withContentsServerError() orgFakeGitHubOption {
+	return func(routes *orgFakeGitHubRoutes) {
+		routes.contents = func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadGateway)
+			json.NewEncoder(w).Encode(github.ErrorResponse{Message: "Bad gateway"})
+		}
+	}
+}
+
+// enumMgr is a Manager whose GetAll returns a fixed list, and whose Get always
+// returns the FIRST entry — mimicking roundRobin with warm quota data, which
+// selects argmax(remaining) with no rotation. A retry loop built on Get would
+// see the same installation forever.
+type enumMgr struct {
+	installs []ghinstall.Installation
+	err      error
+	getCalls atomic.Int32
+}
+
+func (e *enumMgr) Get(_ context.Context, _, _, _ string) (*ghinstallation.AppsTransport, int64, error) {
+	e.getCalls.Add(1)
+	if len(e.installs) == 0 {
+		return nil, 0, status.Error(codes.NotFound, "not installed")
+	}
+	return e.installs[0].Transport, e.installs[0].ID, nil
+}
+
+func (e *enumMgr) GetByInstallation(_ context.Context, _ string, id int64) (*ghinstallation.AppsTransport, int64, error) {
+	for _, in := range e.installs {
+		if in.ID == id {
+			return in.Transport, in.ID, nil
+		}
+	}
+	return nil, 0, status.Error(codes.NotFound, "not found")
+}
+
+func (e *enumMgr) GetAll(_ context.Context, _ string) ([]ghinstall.Installation, error) {
+	return e.installs, e.err
+}
+
+// GetAllFresh delegates: these tests do not distinguish the two enumerations.
+func (e *enumMgr) GetAllFresh(ctx context.Context, owner string) ([]ghinstall.Installation, error) {
+	return e.GetAll(ctx, owner)
+}
+
+var _ ghinstall.Manager = (*enumMgr)(nil)
+
+// TestLookupSurvivesOneBlindInstallation is the regression test for the bypass.
+// The FIRST installation cannot read .github; a second can and holds an
+// enforcing allowlist. Because Get always returns the first one, only an
+// enumeration-based lookup finds the second.
+func TestLookupSurvivesOneBlindInstallation(t *testing.T) {
+	cleanupOrgIssuers(t, "orgallow")
+
+	blind := newAppsTransport(t, newOrgFakeGitHub(withNoGitHubRepoAccess()))
+	working := newAppsTransport(t, newFakeGitHub())
+
+	mgr := &enumMgr{installs: []ghinstall.Installation{
+		{Transport: blind, ID: 1, AppID: 10},
+		{Transport: working, ID: 2, AppID: 20},
+	}}
+	s := &sts{rrm: mgr, appCount: 2}
+
+	entry, err := s.orgIssuerLookup(t.Context(), "orgallow")
+	if err != nil {
+		t.Fatalf("orgIssuerLookup() = %v, want nil", err)
+	}
+	if entry.state != orgIssuerPresent {
+		t.Fatalf("state = %v, want orgIssuerPresent — one blind installation must not disable enforcement", entry.state)
+	}
+	if mgr.getCalls.Load() != 0 {
+		t.Errorf("Get was called %d times; the lookup must enumerate via GetAll, not route via Get", mgr.getCalls.Load())
+	}
+}
+
+func TestLookupAllInstallationsBlindIsAbsent(t *testing.T) {
+	cleanupOrgIssuers(t, "orgallow")
+
+	a := newAppsTransport(t, newOrgFakeGitHub(withNoGitHubRepoAccess()))
+	b := newAppsTransport(t, newOrgFakeGitHub(withNoGitHubRepoAccess()))
+
+	s := &sts{rrm: &enumMgr{installs: []ghinstall.Installation{
+		{Transport: a, ID: 1, AppID: 10},
+		{Transport: b, ID: 2, AppID: 20},
+	}}, appCount: 2}
+
+	entry, err := s.orgIssuerLookup(t.Context(), "orgallow")
+	if err != nil {
+		t.Fatalf("orgIssuerLookup() = %v, want nil", err)
+	}
+	if entry.state != orgIssuerAbsent {
+		t.Fatalf("state = %v, want orgIssuerAbsent", entry.state)
+	}
+	if cached, ok := orgIssuers.Get("orgallow"); !ok || cached.state != orgIssuerAbsent {
+		t.Error("an exhaustive all-blind verdict should be cached as Absent")
+	}
+}
+
+// TestLookupPartialEnumerationNeverCachesAbsent: a failed enumeration is not
+// evidence of absence.
+func TestLookupPartialEnumerationNeverCachesAbsent(t *testing.T) {
+	cleanupOrgIssuers(t, "orgallow")
+
+	blind := newAppsTransport(t, newOrgFakeGitHub(withNoGitHubRepoAccess()))
+
+	s := &sts{rrm: &enumMgr{
+		installs: []ghinstall.Installation{{Transport: blind, ID: 1, AppID: 10}},
+		err:      errors.New("could not list installations for app 20"),
+	}, appCount: 2}
+
+	_, err := s.orgIssuerLookup(t.Context(), "orgallow")
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.Unavailable {
+		t.Fatalf("orgIssuerLookup() = %v, want Unavailable for an incomplete enumeration", err)
+	}
+	if _, ok := orgIssuers.Get("orgallow"); ok {
+		t.Error("nothing may be cached when the enumeration was not exhaustive")
+	}
+}
+
+// TestLookupMintRateLimitRetriesNextInstallation: a rate-limited mint must not
+// end the lookup while another installation has quota.
+func TestLookupMintRateLimitRetriesNextInstallation(t *testing.T) {
+	cleanupOrgIssuers(t, "orgallow")
+
+	limited := newAppsTransport(t, newOrgFakeGitHub(withMintRateLimited()))
+	working := newAppsTransport(t, newFakeGitHub())
+
+	s := &sts{rrm: &enumMgr{installs: []ghinstall.Installation{
+		{Transport: limited, ID: 1, AppID: 10},
+		{Transport: working, ID: 2, AppID: 20},
+	}}, appCount: 2}
+
+	entry, err := s.orgIssuerLookup(t.Context(), "orgallow")
+	if err != nil {
+		t.Fatalf("orgIssuerLookup() = %v, want nil — a rate-limited mint must try the next installation", err)
+	}
+	if entry.state != orgIssuerPresent {
+		t.Fatalf("state = %v, want orgIssuerPresent", entry.state)
+	}
+}
+
+// TestLookupServesStaleOnRateLimit also covers the audit escape hatch: a stale
+// audit entry passes through simply by being served.
+func TestLookupServesStaleOnRateLimit(t *testing.T) {
+	cleanupOrgIssuers(t, "orgallow")
+
+	allow, err := (&OrgTrustedIssuers{Mode: ModeAudit, Issuers: []string{testGitHubIssuer}}).Compile()
+	if err != nil {
+		t.Fatalf("Compile() = %v", err)
+	}
+	staleOrgIssuers.Add("orgallow", presentOrgIssuerEntry(allow))
+
+	rl := newAppsTransport(t, newOrgFakeGitHub(withContentsRateLimited()))
+	s := &sts{rrm: &enumMgr{installs: []ghinstall.Installation{{Transport: rl, ID: 1, AppID: 10}}}, appCount: 1}
+
+	entry, err := s.orgIssuerLookup(t.Context(), "orgallow")
+	if err != nil {
+		t.Fatalf("orgIssuerLookup() = %v, want nil (stale should be served)", err)
+	}
+	if entry.state != orgIssuerPresent || entry.allow.Mode() != ModeAudit {
+		t.Fatalf("entry = %+v, want the stale audit-mode allowlist", entry)
+	}
+	if _, ok := orgIssuers.Get("orgallow"); !ok {
+		t.Error("primary cache should be reseeded after serving stale")
+	}
+}
+
+func TestLookupRateLimitedWithoutStaleDenies(t *testing.T) {
+	cleanupOrgIssuers(t, "orgallow")
+
+	rl := newAppsTransport(t, newOrgFakeGitHub(withContentsRateLimited()))
+	s := &sts{rrm: &enumMgr{installs: []ghinstall.Installation{{Transport: rl, ID: 1, AppID: 10}}}, appCount: 1}
+
+	_, err := s.orgIssuerLookup(t.Context(), "orgallow")
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.ResourceExhausted {
+		t.Fatalf("orgIssuerLookup() = %v, want ResourceExhausted", err)
+	}
+	if _, ok := orgIssuers.Get("orgallow"); ok {
+		t.Error("a rate-limited lookup must not be cached")
+	}
+}
+
+func TestLookupInvalidServesLastKnownGood(t *testing.T) {
+	cleanupOrgIssuers(t, "orgbad")
+
+	good, err := (&OrgTrustedIssuers{Issuers: []string{testGitHubIssuer}}).Compile()
+	if err != nil {
+		t.Fatalf("Compile() = %v", err)
+	}
+	staleOrgIssuers.Add("orgbad", presentOrgIssuerEntry(good))
+
+	atr := newAppsTransport(t, newFakeGitHub())
+	s := &sts{rrm: &enumMgr{installs: []ghinstall.Installation{{Transport: atr, ID: 1, AppID: 10}}}, appCount: 1}
+
+	entry, err := s.orgIssuerLookup(t.Context(), "orgbad")
+	if err != nil {
+		t.Fatalf("orgIssuerLookup() = %v, want nil", err)
+	}
+	if entry.state != orgIssuerPresent {
+		t.Fatalf("state = %v, want orgIssuerPresent from the stale entry", entry.state)
+	}
+}
+
+func TestLookupInvalidWithoutStaleReturnsInvalid(t *testing.T) {
+	cleanupOrgIssuers(t, "orgbad")
+
+	atr := newAppsTransport(t, newFakeGitHub())
+	s := &sts{rrm: &enumMgr{installs: []ghinstall.Installation{{Transport: atr, ID: 1, AppID: 10}}}, appCount: 1}
+
+	entry, err := s.orgIssuerLookup(t.Context(), "orgbad")
+	if err != nil {
+		t.Fatalf("orgIssuerLookup() = %v, want nil (Invalid is an answer)", err)
+	}
+	if entry.state != orgIssuerInvalid {
+		t.Fatalf("state = %v, want orgIssuerInvalid", entry.state)
+	}
+}
+
+// TestLookupInvalidIgnoresStaleAbsent pins the security-load-bearing
+// `stale.state == orgIssuerPresent` conjunct in settleOrgIssuerEntry.
+//
+// Last-known-GOOD substitution is only safe when the last known state was an
+// actual allowlist. A stale *Absent* entry is not a fallback allowlist, it is
+// the absence of one — substituting it for a currently-Invalid config would
+// silently convert a broken file into allow-all for the whole organization,
+// which is exactly the outcome the enforcement boundary exists to prevent. So
+// an Invalid config with only a stale Absent entry must stay Invalid.
+func TestLookupInvalidIgnoresStaleAbsent(t *testing.T) {
+	cleanupOrgIssuers(t, "orgbad")
+
+	staleOrgIssuers.Add("orgbad", absentOrgIssuerEntry())
+
+	atr := newAppsTransport(t, newFakeGitHub())
+	s := &sts{rrm: &enumMgr{installs: []ghinstall.Installation{{Transport: atr, ID: 1, AppID: 10}}}, appCount: 1}
+
+	entry, err := s.orgIssuerLookup(t.Context(), "orgbad")
+	if err != nil {
+		t.Fatalf("orgIssuerLookup() = %v, want nil (Invalid is an answer)", err)
+	}
+	if entry.state != orgIssuerInvalid {
+		t.Fatalf("state = %v, want orgIssuerInvalid — a stale Absent entry must never be substituted for an invalid config, that would be org-wide allow-all", entry.state)
+	}
+	if cached, ok := orgIssuers.Get("orgbad"); !ok || cached.state != orgIssuerInvalid {
+		t.Errorf("cached entry = %+v (ok = %v), want the Invalid entry, not the stale Absent one", cached, ok)
+	}
+}
+
+// TestLookupBlindPlusFailedIsNotAbsent pins the exhaustiveness ARITHMETIC:
+// Absent needs noAccess == len(installs), not merely noAccess > 0.
+//
+// Here the enumeration itself succeeded, so enumErr is nil and that guard does
+// not help. One installation is blind and the other simply errored, so the org
+// is only PARTLY surveyed — we never established that no installation can read
+// .github. Relaxing the count to `noAccess > 0` would cache allow-all for the
+// whole organization off the back of one blind installation plus one 502.
+func TestLookupBlindPlusFailedIsNotAbsent(t *testing.T) {
+	cleanupOrgIssuers(t, "orgallow")
+
+	blind := newAppsTransport(t, newOrgFakeGitHub(withNoGitHubRepoAccess()))
+	broken := newAppsTransport(t, newOrgFakeGitHub(withContentsServerError()))
+
+	s := &sts{rrm: &enumMgr{installs: []ghinstall.Installation{
+		{Transport: blind, ID: 1, AppID: 10},
+		{Transport: broken, ID: 2, AppID: 20},
+	}}, appCount: 2}
+
+	_, err := s.orgIssuerLookup(t.Context(), "orgallow")
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.Unavailable {
+		t.Fatalf("orgIssuerLookup() = %v, want Unavailable — a partly-surveyed org is unknown, not absent", err)
+	}
+	if cached, ok := orgIssuers.Get("orgallow"); ok {
+		t.Errorf("cached %+v; a partial survey must never be cached, least of all as Absent", cached)
+	}
+}
+
+// TestLookupEmptyEnumerationIsNotAbsent pins that an empty installation list is
+// ignorance, not positive knowledge of absence.
+//
+// With no installations the loop body never runs, so noAccess stays 0 and
+// enumErr is nil — "0 == len(installs)" would therefore cache allow-all for the
+// whole organization off zero evidence. The lookup is only reached after
+// routing already found an installation for this owner, so an empty enumeration
+// means the two managers disagreed; falling through to the stale / fail-closed
+// path is the correct reading.
+func TestLookupEmptyEnumerationIsNotAbsent(t *testing.T) {
+	cleanupOrgIssuers(t, "orgempty")
+
+	s := &sts{rrm: &enumMgr{installs: nil}, appCount: 1}
+
+	entry, err := s.orgIssuerLookup(t.Context(), "orgempty")
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.Unavailable {
+		t.Fatalf("orgIssuerLookup() = %v, want Unavailable — an empty enumeration is not evidence of absence", err)
+	}
+	if entry.state == orgIssuerAbsent {
+		t.Errorf("state = %v, want anything but orgIssuerAbsent", entry.state)
+	}
+	if cached, ok := orgIssuers.Get("orgempty"); ok {
+		t.Errorf("cached %+v; an empty enumeration must never be cached, least of all as Absent", cached)
+	}
+	if cached, ok := staleOrgIssuers.Get("orgempty"); ok {
+		t.Errorf("stale-cached %+v; an empty enumeration must never become last known good", cached)
+	}
+}
+
+// TestLookupAllBlindWithStaleFallsOpen pins the ORDER of the two terminal
+// branches: the exhaustive all-blind verdict is checked before the stale
+// fallback.
+//
+// "Every installation reports it cannot read .github" is positive knowledge and
+// falls open by design. Consulting the stale cache first would instead keep
+// serving a Present entry forever for an org that has legitimately removed the
+// App's access to .github, and would never re-cache the Absent verdict.
+func TestLookupAllBlindWithStaleFallsOpen(t *testing.T) {
+	cleanupOrgIssuers(t, "orgallow")
+
+	allow, err := (&OrgTrustedIssuers{Issuers: []string{testGitHubIssuer}}).Compile()
+	if err != nil {
+		t.Fatalf("Compile() = %v", err)
+	}
+	staleOrgIssuers.Add("orgallow", presentOrgIssuerEntry(allow))
+
+	blind := newAppsTransport(t, newOrgFakeGitHub(withNoGitHubRepoAccess()))
+	s := &sts{rrm: &enumMgr{installs: []ghinstall.Installation{{Transport: blind, ID: 1, AppID: 10}}}, appCount: 1}
+
+	entry, err := s.orgIssuerLookup(t.Context(), "orgallow")
+	if err != nil {
+		t.Fatalf("orgIssuerLookup() = %v, want nil", err)
+	}
+	if entry.state != orgIssuerAbsent {
+		t.Fatalf("state = %v, want orgIssuerAbsent — the exhaustive all-blind verdict must win over the stale entry", entry.state)
+	}
+}
+
+// TestLookupAbsentFileIsCachedAbsent covers the DEFINITIVE absent path: an
+// installation that can read .github and finds no allowlist file there.
+//
+// This is the default state of every organization that has not adopted the
+// feature, which makes it the most-travelled path in the whole lookup. If it
+// resolved to an error instead of Absent, every token exchange in every such
+// organization would fail closed.
+//
+// The blind-installation tests do not cover it. They reach Absent through the
+// exhaustive-agreement branch (every installation reported fetchNoAccess via a
+// 422 mint); this reaches it through a definitive 404, a separate branch that
+// was otherwise unexercised.
+func TestLookupAbsentFileIsCachedAbsent(t *testing.T) {
+	cleanupOrgIssuers(t, "orgnone")
+
+	atr := newAppsTransport(t, newFakeGitHub())
+	s := &sts{rrm: &enumMgr{installs: []ghinstall.Installation{{Transport: atr, ID: 1, AppID: 10}}}, appCount: 1}
+
+	entry, err := s.orgIssuerLookup(t.Context(), "orgnone")
+	if err != nil {
+		t.Fatalf("orgIssuerLookup() = %v, want nil — a missing allowlist file must not fail the exchange", err)
+	}
+	if entry.state != orgIssuerAbsent {
+		t.Fatalf("state = %v, want orgIssuerAbsent", entry.state)
+	}
+	if cached, ok := orgIssuers.Get("orgnone"); !ok || cached.state != orgIssuerAbsent {
+		t.Errorf("primary cache = %+v (ok = %v), want Absent", cached, ok)
+	}
+	// Absent is durable knowledge, so it belongs in the stale cache too.
+	if cached, ok := staleOrgIssuers.Get("orgnone"); !ok || cached.state != orgIssuerAbsent {
+		t.Errorf("stale cache = %+v (ok = %v), want Absent", cached, ok)
+	}
+}
+
+func TestCheckOrgTrustedIssuers(t *testing.T) {
+	enforce, err := (&OrgTrustedIssuers{Issuers: []string{testGitHubIssuer}}).Compile()
+	if err != nil {
+		t.Fatalf("Compile() = %v", err)
+	}
+	audit, err := (&OrgTrustedIssuers{Mode: ModeAudit, Issuers: []string{testGitHubIssuer}}).Compile()
+	if err != nil {
+		t.Fatalf("Compile() = %v", err)
+	}
+
+	for _, tc := range []struct {
+		name         string
+		entry        orgIssuerEntry
+		issuer       string
+		wantCode     codes.Code // OK means the exchange proceeds
+		wantDecision bool
+		wantAllowed  bool
+	}{
+		{
+			name:     "absent permits anything",
+			entry:    absentOrgIssuerEntry(),
+			issuer:   "https://whatever.example.com",
+			wantCode: codes.OK,
+		},
+		{
+			name:     "enforce permits a listed issuer",
+			entry:    presentOrgIssuerEntry(enforce),
+			issuer:   testGitHubIssuer,
+			wantCode: codes.OK,
+		},
+		{
+			name:         "enforce denies an unlisted issuer",
+			entry:        presentOrgIssuerEntry(enforce),
+			issuer:       "https://evil.example.com",
+			wantCode:     codes.PermissionDenied,
+			wantDecision: true,
+			wantAllowed:  false,
+		},
+		{
+			name:         "audit permits an unlisted issuer but records it",
+			entry:        presentOrgIssuerEntry(audit),
+			issuer:       "https://evil.example.com",
+			wantCode:     codes.OK,
+			wantDecision: true,
+			wantAllowed:  true,
+		},
+		{
+			name:     "invalid denies",
+			entry:    invalidOrgIssuerEntry(status.Error(codes.FailedPrecondition, msgIssuerConfigInvalid)),
+			issuer:   testGitHubIssuer,
+			wantCode: codes.FailedPrecondition,
+		},
+		{
+			// A zero value reaching the check must be an internal error, never a pass.
+			name:     "unknown state is internal, not a pass",
+			entry:    orgIssuerEntry{},
+			issuer:   testGitHubIssuer,
+			wantCode: codes.Internal,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			owner := "owner-" + tc.name
+			cleanupOrgIssuers(t, owner)
+			orgIssuers.Add(owner, tc.entry)
+
+			// rrm is deliberately nil: every row pre-seeds the primary cache, so
+			// orgIssuerLookup must return on its cache hit without enumerating.
+			// A nil-pointer panic here means the check is doing more than it should.
+			s := &sts{appCount: 1}
+			decision, err := s.checkOrgTrustedIssuers(t.Context(), owner, tc.issuer)
+
+			if tc.wantCode == codes.OK {
+				if err != nil {
+					t.Fatalf("checkOrgTrustedIssuers() = %v, want nil", err)
+				}
+			} else {
+				st, ok := status.FromError(err)
+				if !ok {
+					t.Fatalf("checkOrgTrustedIssuers() = %T, want a gRPC status", err)
+				}
+				if st.Code() != tc.wantCode {
+					t.Fatalf("code = %v, want %v", st.Code(), tc.wantCode)
+				}
+			}
+
+			if tc.wantDecision {
+				if decision == nil {
+					t.Fatal("decision = nil, want it recorded for the Event")
+				}
+				if decision.Issuer != tc.issuer {
+					t.Errorf("decision.Issuer = %q, want %q", decision.Issuer, tc.issuer)
+				}
+				if decision.Allowed != tc.wantAllowed {
+					t.Errorf("decision.Allowed = %v, want %v", decision.Allowed, tc.wantAllowed)
+				}
+			} else if decision != nil {
+				t.Errorf("decision = %+v, want nil", decision)
+			}
+		})
+	}
+}
+
+// TestCheckOrgTrustedIssuersPropagatesLookupError is the fail-closed guard. If
+// the lookup cannot establish the org's allowlist, the exchange must be denied.
+// Swallowing that error would return (nil, nil) — indistinguishable from
+// "permitted" — and would silently disable the control for any org whose
+// lookup is failing.
+func TestCheckOrgTrustedIssuersPropagatesLookupError(t *testing.T) {
+	cleanupOrgIssuers(t, "orgallow")
+
+	rl := newAppsTransport(t, newOrgFakeGitHub(withContentsRateLimited()))
+	s := &sts{rrm: &enumMgr{installs: []ghinstall.Installation{{Transport: rl, ID: 1, AppID: 10}}}, appCount: 1}
+
+	decision, err := s.checkOrgTrustedIssuers(t.Context(), "orgallow", testGitHubIssuer)
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.ResourceExhausted {
+		t.Fatalf("checkOrgTrustedIssuers() = %v, want ResourceExhausted — an unresolvable lookup must fail closed", err)
+	}
+	if decision != nil {
+		t.Errorf("decision = %+v, want nil when the lookup itself failed", decision)
+	}
+}
+
+// TestDeniedMessagesLeakNothing pins the caller-visible denial string. Identity
+// is caller-controlled, so any holder of a verified token can probe an org; the
+// fixed message is what bounds that disclosure.
+func TestDeniedMessagesLeakNothing(t *testing.T) {
+	owner := "leaky-org"
+	cleanupOrgIssuers(t, owner)
+	allow, err := (&OrgTrustedIssuers{Issuers: []string{"https://secret-idp.internal.example.com"}}).Compile()
+	if err != nil {
+		t.Fatalf("Compile() = %v", err)
+	}
+	orgIssuers.Add(owner, presentOrgIssuerEntry(allow))
+
+	s := &sts{appCount: 1}
+	_, err = s.checkOrgTrustedIssuers(t.Context(), owner, "https://evil.example.com")
+	st, _ := status.FromError(err)
+	if st.Message() != msgIssuerNotPermitted {
+		t.Fatalf("message = %q, want exactly %q", st.Message(), msgIssuerNotPermitted)
+	}
+	// Belt-and-braces on the constant itself: the assertion above already pins
+	// the message, so these guard msgIssuerNotPermitted's own definition rather
+	// than this call.
+	if strings.Contains(msgIssuerNotPermitted, "secret-idp") || strings.Contains(msgIssuerNotPermitted, owner) {
+		t.Error("msgIssuerNotPermitted must not be able to carry org-specific detail")
+	}
+}
+
+// newExchangeContext returns a context carrying a bearer token for
+// testGitHubIssuer with subject "foo", and registers the verifier for it.
+//
+// Both values are fixed rather than parameters. Every trust-policy fixture in
+// testdata specifies subject "foo", and the allowlist fixtures are written in
+// terms of testGitHubIssuer, so a caller varying either would stop matching the
+// fixtures it is testing against. An earlier revision took them as arguments
+// for a schemeless-issuer test that turned out to be unbuildable —
+// oidcvalidate.IsValidIssuer rejects "accounts.google.com", so TrustPolicy
+// refuses it before any allowlist runs.
+func newExchangeContext(t *testing.T) context.Context {
+	t.Helper()
+
+	const (
+		iss     = testGitHubIssuer
+		subject = "foo"
+	)
+	pk, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("cannot generate RSA key: %v", err)
+	}
+	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.RS256, Key: pk}, nil)
+	if err != nil {
+		t.Fatalf("jose.NewSigner() = %v", err)
+	}
+	token, err := josejwt.Signed(signer).Claims(josejwt.Claims{
+		Subject:  subject,
+		Issuer:   iss,
+		Audience: josejwt.Audience{"octosts"},
+		Expiry:   josejwt.NewNumericDate(time.Now().Add(10 * time.Minute)),
+	}).Serialize()
+	if err != nil {
+		t.Fatalf("Serialize() = %v", err)
+	}
+	provider.AddTestKeySetVerifier(t, iss, &oidc.StaticKeySet{PublicKeys: []crypto.PublicKey{pk.Public()}})
+	return metadata.NewIncomingContext(t.Context(), metadata.MD{"authorization": []string{"Bearer " + token}})
+}
+
+// forgetTrustPolicy clears the trust-policy caches for a scope, before and after.
+func forgetTrustPolicy(t *testing.T, owner string) {
+	t.Helper()
+	key := cacheTrustPolicyKey{owner: owner, repo: "repo", identity: "foo"}
+	purge := func() {
+		trustPolicies.Remove(key)
+		staleTrustPolicies.Remove(key)
+	}
+	purge()
+	t.Cleanup(purge)
+}
+
+func TestExchangeEnforcesOrgAllowlist(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		owner    string
+		wantCode codes.Code // OK means the exchange succeeds
+	}{
+		{name: "listed issuer succeeds", owner: "orgallow", wantCode: codes.OK},
+		{name: "unlisted issuer denied", owner: "orgdeny", wantCode: codes.PermissionDenied},
+		{name: "audit permits unlisted", owner: "orgaudit", wantCode: codes.OK},
+		{name: "invalid config denied", owner: "orgbad", wantCode: codes.FailedPrecondition},
+		{name: "no config succeeds", owner: "org", wantCode: codes.OK},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cleanupOrgIssuers(t, tc.owner)
+			forgetTrustPolicy(t, tc.owner)
+
+			atr := newAppsTransport(t, newFakeGitHub())
+			ctx := newExchangeContext(t)
+			s := &sts{rrm: &fakeInstallMgr{atr: atr}, appCount: 1}
+
+			_, err := s.Exchange(ctx, &v1.ExchangeRequest{
+				Identity: "foo",
+				Scope:    tc.owner + "/repo",
+			})
+			if tc.wantCode == codes.OK {
+				if err != nil {
+					t.Fatalf("Exchange() = %v, want success", err)
+				}
+				return
+			}
+			st, ok := status.FromError(err)
+			if !ok {
+				t.Fatalf("Exchange() = %T, want a gRPC status", err)
+			}
+			if st.Code() != tc.wantCode {
+				t.Errorf("code = %v, want %v", st.Code(), tc.wantCode)
+			}
+		})
+	}
+}
+
+// allowlistCounter counts reads of the allowlist file so caching can be asserted
+// by observed GitHub traffic rather than by the cache being non-empty — which a
+// re-read on every exchange would also satisfy.
+type allowlistCounter struct {
+	http.Handler
+	n atomic.Int32
+}
+
+func (c *allowlistCounter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if strings.HasSuffix(r.URL.Path, "/trusted-token-issuers.yaml") {
+		c.n.Add(1)
+	}
+	c.Handler.ServeHTTP(w, r)
+}
+
+// TestExchangeAllowlistIsCached is the regression test for a defect in the
+// superseded PR #901: the absent-config case re-read GitHub on every exchange.
+//
+// It asserts the READ COUNT, not merely that the cache is populated. The weaker
+// assertion passes even if the cache-hit early return in orgIssuerLookup is
+// deleted, because each exchange would still write the entry on its way out.
+func TestExchangeAllowlistIsCached(t *testing.T) {
+	cleanupOrgIssuers(t, "org")
+	forgetTrustPolicy(t, "org")
+
+	counter := &allowlistCounter{Handler: newFakeGitHub()}
+	atr := newAppsTransport(t, counter)
+	ctx := newExchangeContext(t)
+	s := &sts{rrm: &fakeInstallMgr{atr: atr}, appCount: 1}
+
+	for i := range 2 {
+		if _, err := s.Exchange(ctx, &v1.ExchangeRequest{Identity: "foo", Scope: "org/repo"}); err != nil {
+			t.Fatalf("Exchange() attempt %d = %v", i+1, err)
+		}
+	}
+
+	if got := counter.n.Load(); got != 1 {
+		t.Errorf("allowlist was read %d times across 2 exchanges, want 1 — the verdict must be cached", got)
+	}
+	if _, ok := orgIssuers.Get("org"); !ok {
+		t.Error("the allowlist verdict for org should be cached after the first exchange")
+	}
+}
+
+// captureCEClient records the events the exchange emits. It exists because
+// nothing else in this package observes the emitted Event, so dropping the
+// e.IssuerAllowlist assignment in Exchange was otherwise invisible: the
+// decision reached checkOrgTrustedIssuers' caller and went nowhere.
+type captureCEClient struct {
+	mu     sync.Mutex
+	events []cloudevents.Event
+}
+
+func (c *captureCEClient) Send(_ context.Context, e cloudevents.Event) cloudevents.Result {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.events = append(c.events, e)
+	return nil
+}
+
+func (c *captureCEClient) Request(_ context.Context, _ cloudevents.Event) (*cloudevents.Event, cloudevents.Result) {
+	return nil, nil
+}
+
+func (c *captureCEClient) StartReceiver(_ context.Context, _ interface{}) error { return nil }
+
+func (c *captureCEClient) sent() []cloudevents.Event {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]cloudevents.Event(nil), c.events...)
+}
+
+var _ cloudevents.Client = (*captureCEClient)(nil)
+
+// TestExchangeRecordsAuditDecisionOnEvent pins the audit-mode decision all the
+// way onto the emitted Event. An audit-mode pass-through is invisible in the
+// response — the exchange succeeds and returns a token exactly as an unlisted
+// issuer with no allowlist would — so the Event is the ONLY place an operator
+// can see that enforcement would have denied this exchange. That makes the
+// assignment in Exchange part of the control, not bookkeeping.
+func TestExchangeRecordsAuditDecisionOnEvent(t *testing.T) {
+	cleanupOrgIssuers(t, "orgaudit")
+	forgetTrustPolicy(t, "orgaudit")
+
+	ce := &captureCEClient{}
+	atr := newAppsTransport(t, newFakeGitHub())
+	ctx := newExchangeContext(t)
+	s := &sts{rrm: &fakeInstallMgr{atr: atr}, appCount: 1, ceclient: ce, metrics: true}
+
+	if _, err := s.Exchange(ctx, &v1.ExchangeRequest{Identity: "foo", Scope: "orgaudit/repo"}); err != nil {
+		t.Fatalf("Exchange() = %v, want success (audit mode never denies)", err)
+	}
+
+	sent := ce.sent()
+	if len(sent) != 1 {
+		t.Fatalf("emitted %d events, want 1", len(sent))
+	}
+
+	var got Event
+	if err := json.Unmarshal(sent[0].Data(), &got); err != nil {
+		t.Fatalf("decoding event data: %v", err)
+	}
+	if got.IssuerAllowlist == nil {
+		t.Fatal("Event.IssuerAllowlist is nil — the audit decision was dropped on the way to the Event")
+	}
+	want := &IssuerDecision{Mode: ModeAudit, Issuer: testGitHubIssuer, Allowed: true}
+	if diff := cmp.Diff(want, got.IssuerAllowlist); diff != "" {
+		t.Errorf("Event.IssuerAllowlist (-want +got):\n%s", diff)
+	}
+}
+
+// notInstalledMgr reports that the App is not installed — Get fails — while
+// still being able to enumerate. That asymmetry is what makes the ORDER of the
+// allowlist check observable: a lookup that consults GetAll before Get would
+// read the allowlist here, and a correctly ordered one never gets that far.
+type notInstalledMgr struct {
+	atr *ghinstallation.AppsTransport
+}
+
+func (m *notInstalledMgr) Get(_ context.Context, _, _, _ string) (*ghinstallation.AppsTransport, int64, error) {
+	return nil, 0, status.Error(codes.NotFound, "not installed")
+}
+
+func (m *notInstalledMgr) GetByInstallation(_ context.Context, _ string, _ int64) (*ghinstallation.AppsTransport, int64, error) {
+	return nil, 0, status.Error(codes.NotFound, "not found")
+}
+
+func (m *notInstalledMgr) GetAll(_ context.Context, _ string) ([]ghinstall.Installation, error) {
+	return []ghinstall.Installation{{Transport: m.atr, ID: 1234, AppID: m.atr.AppID()}}, nil
+}
+
+func (m *notInstalledMgr) GetAllFresh(ctx context.Context, owner string) ([]ghinstall.Installation, error) {
+	return m.GetAll(ctx, owner)
+}
+
+var _ ghinstall.Manager = (*notInstalledMgr)(nil)
+
+// TestExchangeUninstalledOwnerReadsNoAllowlist pins the ORDER of the allowlist
+// check against the installation lookup, which is a security property rather
+// than a cost one.
+//
+// scope is caller-supplied and arbitrary. The check therefore runs AFTER
+// s.rrm.Get, whose negative install cache rejects an owner the App is not
+// installed on. Hoisting the check above it would let any holder of one valid
+// token drive an installation enumeration, a token mint and a contents read
+// against ANY organization on GitHub, once per request — unauthenticated
+// amplification through this service.
+//
+// Note the direction being pinned. Moving the check LATER is harmless and no
+// test can distinguish it; moving it EARLIER is the regression that matters,
+// and this is what catches it.
+func TestExchangeUninstalledOwnerReadsNoAllowlist(t *testing.T) {
+	cleanupOrgIssuers(t, "orgallow")
+	forgetTrustPolicy(t, "orgallow")
+
+	counter := &allowlistCounter{Handler: newFakeGitHub()}
+	atr := newAppsTransport(t, counter)
+	ctx := newExchangeContext(t)
+	s := &sts{rrm: &notInstalledMgr{atr: atr}, appCount: 1}
+
+	if _, err := s.Exchange(ctx, &v1.ExchangeRequest{
+		Identity: "foo",
+		Scope:    "orgallow/repo",
+	}); err == nil {
+		t.Fatal("Exchange() = nil, want an error for an owner with no installation")
+	}
+
+	if got := counter.n.Load(); got != 0 {
+		t.Errorf("allowlist was read %d times for an owner with no installation, want 0 — the check must not run before s.rrm.Get", got)
+	}
+	if _, ok := orgIssuers.Get("orgallow"); ok {
+		t.Error("nothing may be cached for an owner the App is not installed on")
+	}
+}

--- a/pkg/octosts/org_trusted_issuers_test.go
+++ b/pkg/octosts/org_trusted_issuers_test.go
@@ -488,9 +488,6 @@ func TestCompileRejectsSlashMatchingAtoms(t *testing.T) {
 		// Numeric escapes SPELL "/" rather than naming a class, so treating them
 		// as escaped literals skipped two bytes and left the digits to be read as
 		// unexamined literal text. All three of these are "/".
-		{"hex escape for the slash byte", `https://a\x2Fb\.example\.com`, "https://a/b.example.com"},
-		{"braced hex escape for the slash byte", `https://a\x{2F}b\.example\.com`, "https://a/b.example.com"},
-		{"octal escape for the slash byte", `https://a\057b\.example\.com`, "https://a/b.example.com"},
 		// "[:" opens a POSIX class only when a ":]" follows; without one RE2 reads
 		// the "[" as an ordinary member and the class keeps going, so these are
 		// ordinary classes that happen to contain "/". The scanner used to give up
@@ -640,28 +637,61 @@ func TestCompileKeepsFixedPositionSlashes(t *testing.T) {
 	}
 }
 
-// TestCompileFailsClosedOnAnAtomItCannotAnalyze pins the posture, not a
-// particular syntax. Skipping an atom that does not compile turned every parsing
-// gap into a silent bypass ("[^]]", "\x2F"); the next gap must not be
-// exploitable, so an unanalyzable atom now rejects the pattern.
-func TestCompileFailsClosedOnAnAtomItCannotAnalyze(t *testing.T) {
-	// An unknown POSIX class name: the scanner delimits the bracket expression
-	// correctly, then regexp.Compile rejects the name.
-	//
-	// The name is assembled at runtime so staticcheck does not constant-fold the
-	// pattern and report the invalid class as a lint error — being invalid is the
-	// whole point of this input.
+// TestCompileRejectsAnUnparseablePattern pins that a pattern the AST check cannot
+// analyze is still rejected — the property survives, it just moved layers.
+//
+// checkPatternCannotSpanHost returns nil when syntax.Parse fails, so the rejection
+// comes from the subsequent regexp.Compile instead of a "cannot verify" message from
+// the guard. That branch used to exist because a hand-written scanner could
+// mis-delimit an atom it had itself extracted; parsing with regexp/syntax removes the
+// failure mode rather than reporting it.
+func TestCompileRejectsAnUnparseablePattern(t *testing.T) {
+	// Assembled at runtime so staticcheck does not constant-fold the pattern and
+	// report the invalid class as a lint error — being invalid is the point.
 	pat := `https://[[:` + strings.Repeat("bogus", 1) + `:]]+\.example\.com`
-	if re, err := regexp.Compile("^(?:" + pat + ")$"); err == nil {
-		t.Fatalf("regexp.Compile(%q) = nil error; this test needs an atom Go rejects, "+
-			"otherwise it exercises the match path rather than the fail-closed path (re=%v)", pat, re)
+	if _, err := regexp.Compile(pat); err == nil {
+		t.Fatalf("regexp.Compile(%q) = nil error; this test needs a pattern Go rejects", pat)
 	}
-	_, err := (&OrgTrustedIssuers{IssuerPatterns: []string{pat}}).Compile()
-	if err == nil {
+	if _, err := (&OrgTrustedIssuers{IssuerPatterns: []string{pat}}).Compile(); err == nil {
 		t.Fatalf("Compile() with pattern %q = nil error, want a rejection", pat)
 	}
-	if !strings.Contains(err.Error(), "cannot verify") {
-		t.Errorf("Compile() error = %q, want the fail-closed message mentioning %q", err, "cannot verify")
+}
+
+// TestCompileAllowsNumericEscapesForSlashAtAFixedPosition records a DELIBERATE
+// loosening that came with moving to AST analysis.
+//
+// The byte scanner treated "\x2F", "\x{2F}" and "\057" as opaque escapes and rejected
+// them wherever they appeared. regexp/syntax folds them into an OpLiteral containing
+// "/", indistinguishable from a typed "/" — because that is what they are. So they are
+// now allowed at a fixed position, on the same rule that permits
+// https://host\.example\.com/id/[A-Z0-9]+.
+//
+// That is safe for the reason the fixed-position rule is safe: the "/" cannot repeat or
+// be skipped, so the pattern still matches exactly one host. Asserted below, so this
+// stays a reasoned allowance rather than an accident.
+func TestCompileAllowsNumericEscapesForSlashAtAFixedPosition(t *testing.T) {
+	for _, pat := range []string{
+		`https://a\x2Fb\.example\.com`,
+		`https://a\x{2F}b\.example\.com`,
+		`https://a\057b\.example\.com`,
+	} {
+		al, err := (&OrgTrustedIssuers{IssuerPatterns: []string{pat}}).Compile()
+		if err != nil {
+			t.Fatalf("Compile() with pattern %q = %v, want nil", pat, err)
+		}
+		// It spells exactly one issuer, and cannot reach an attacker-chosen host.
+		if !al.Allows("https://a/b.example.com") {
+			t.Errorf("pattern %q does not match the issuer it spells", pat)
+		}
+		for _, evil := range []string{
+			"https://evil.com/b.example.com",
+			"https://a/x/b.example.com",
+			"https://evil.com/a/b.example.com",
+		} {
+			if al.Allows(evil) {
+				t.Errorf("pattern %q permitted %q — a fixed-position escape must not span", pat, evil)
+			}
+		}
 	}
 }
 
@@ -746,17 +776,13 @@ func TestCompileRejectsBadPatternWithCompileError(t *testing.T) {
 	}
 }
 
-// TestCompileReportsWildcardDotBeforeCompileError pins the ordering of the two
-// pattern checks. For a pattern that is both loose and malformed the
-// loose-pattern error is the more actionable of the two, so the wildcard-dot
-// scan has to run before regexp.Compile. "[unclosed" alone does not pin this —
-// it contains no ".", so either ordering yields the compile error.
-func TestCompileReportsWildcardDotBeforeCompileError(t *testing.T) {
-	_, err := (&OrgTrustedIssuers{IssuerPatterns: []string{`https://.*.example.com(`}}).Compile()
-	if err == nil {
-		t.Fatal("Compile() = nil error, want error")
-	}
-	if !strings.Contains(err.Error(), "can match") {
-		t.Errorf("Compile() error = %q, want the atom error to win over regexp's compile error", err)
+// TestCompileRejectsALoosePatternThatIsAlsoMalformed replaces an ordering pin that no
+// longer applies. It used to require the looseness error to beat regexp's compile
+// error for a pattern that is both loose and malformed. The span check now needs a
+// successful parse, so a malformed pattern reports the compile error instead — the
+// verdict is unchanged and still fail-closed, only the message differs.
+func TestCompileRejectsALoosePatternThatIsAlsoMalformed(t *testing.T) {
+	if _, err := (&OrgTrustedIssuers{IssuerPatterns: []string{`https://.*.example.com(`}}).Compile(); err == nil {
+		t.Fatal("Compile() = nil error, want a rejection")
 	}
 }

--- a/pkg/octosts/org_trusted_issuers_test.go
+++ b/pkg/octosts/org_trusted_issuers_test.go
@@ -1,0 +1,702 @@
+// Copyright 2026 Chainguard, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package octosts
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+const testGitHubIssuer = "https://token.actions.githubusercontent.com"
+
+func TestCompileMode(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		mode     Mode
+		wantMode Mode
+		wantErr  string
+	}{
+		{name: "empty defaults to enforce", mode: "", wantMode: ModeEnforce},
+		{name: "explicit enforce", mode: ModeEnforce, wantMode: ModeEnforce},
+		{name: "explicit audit", mode: ModeAudit, wantMode: ModeAudit},
+		{name: "unknown", mode: Mode("Enforce"), wantErr: "unknown mode"},
+		{name: "garbage", mode: Mode("off"), wantErr: "unknown mode"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &OrgTrustedIssuers{Mode: tc.mode, Issuers: []string{testGitHubIssuer}}
+			got, err := c.Compile()
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("Compile() = nil error, want %q", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("Compile() error = %q, want it to contain %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Compile() = %v, want nil", err)
+			}
+			if got.Mode() != tc.wantMode {
+				t.Errorf("Mode() = %q, want %q", got.Mode(), tc.wantMode)
+			}
+		})
+	}
+}
+
+func TestCompileRequiresAtLeastOneEntry(t *testing.T) {
+	// A present-but-empty file must be an error, not a silent deny-all.
+	c := &OrgTrustedIssuers{Mode: ModeEnforce}
+	if _, err := c.Compile(); err == nil {
+		t.Fatal("Compile() = nil error for empty config, want an error")
+	}
+}
+
+func TestAllowsExactMatch(t *testing.T) {
+	c := &OrgTrustedIssuers{Issuers: []string{testGitHubIssuer, "https://accounts.google.com"}}
+	a, err := c.Compile()
+	if err != nil {
+		t.Fatalf("Compile() = %v", err)
+	}
+	for _, tc := range []struct {
+		issuer string
+		want   bool
+	}{
+		{testGitHubIssuer, true},
+		{"https://accounts.google.com", true},
+		{"https://evil.example.com", false},
+		{"", false},
+		// byte-exact: a trailing slash is a different issuer
+		{"https://accounts.google.com/", false},
+	} {
+		if got := a.Allows(tc.issuer); got != tc.want {
+			t.Errorf("Allows(%q) = %v, want %v", tc.issuer, got, tc.want)
+		}
+	}
+}
+
+// TestAllowsIsCaseSensitive pins the documented invariant. A future change to
+// case-insensitive comparison would widen the allowlist, so it must fail here.
+func TestAllowsIsCaseSensitive(t *testing.T) {
+	c := &OrgTrustedIssuers{Issuers: []string{testGitHubIssuer}}
+	a, err := c.Compile()
+	if err != nil {
+		t.Fatalf("Compile() = %v", err)
+	}
+	for _, iss := range []string{
+		"https://TOKEN.actions.githubusercontent.com",
+		"HTTPS://token.actions.githubusercontent.com",
+		"https://Token.Actions.GithubUserContent.com",
+	} {
+		if a.Allows(iss) {
+			t.Errorf("Allows(%q) = true, want false — matching must be case-sensitive", iss)
+		}
+	}
+}
+
+func TestAllowsPatternMatch(t *testing.T) {
+	c := &OrgTrustedIssuers{
+		IssuerPatterns: []string{
+			`https://oidc\.eks\.[a-z0-9-]+\.amazonaws\.com/id/[A-Z0-9]+`,
+			`https://login\.microsoftonline\.com/[a-f0-9-]+/v2\.0`,
+		},
+	}
+	a, err := c.Compile()
+	if err != nil {
+		t.Fatalf("Compile() = %v", err)
+	}
+	for _, tc := range []struct {
+		issuer string
+		want   bool
+	}{
+		{"https://oidc.eks.us-west-2.amazonaws.com/id/ABCDEF123456", true},
+		{"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789abc/v2.0", true},
+		{"https://oidc.eks.us-west-2.amazonaws.com/id/ABCDEF123456/extra", false},
+		{"https://not-eks.example.com/id/ABC", false},
+	} {
+		if got := a.Allows(tc.issuer); got != tc.want {
+			t.Errorf("Allows(%q) = %v, want %v", tc.issuer, got, tc.want)
+		}
+	}
+}
+
+// TestAnchoringRejectsAlternationBypass is the reason patterns are wrapped in
+// a non-capturing group. With the naive "^"+p+"$" form, "|" binds looser than
+// the anchors so "^A|B$" parses as "(^A)|(B$)" and the pattern is effectively
+// unanchored. This is the ONLY case that distinguishes "^(?:p)$" from "^p$".
+func TestAnchoringRejectsAlternationBypass(t *testing.T) {
+	c := &OrgTrustedIssuers{
+		IssuerPatterns: []string{`https://a\.example\.com|https://b\.example\.com`},
+	}
+	a, err := c.Compile()
+	if err != nil {
+		t.Fatalf("Compile() = %v", err)
+	}
+	if a.Allows("https://a.example.com.attacker.example/x") {
+		t.Error("Allows() permitted a suffix-extended host — alternation pattern is not anchored")
+	}
+	for _, ok := range []string{"https://a.example.com", "https://b.example.com"} {
+		if !a.Allows(ok) {
+			t.Errorf("Allows(%q) = false, want true", ok)
+		}
+	}
+}
+
+// TestAnchoringRejectsSuffixBypass regresses an unanchored bare MatchString. It
+// passes under BOTH "^p$" and "^(?:p)$", so it does not exercise the alternation
+// fix — keep it alongside TestAnchoringRejectsAlternationBypass.
+func TestAnchoringRejectsSuffixBypass(t *testing.T) {
+	c := &OrgTrustedIssuers{
+		IssuerPatterns: []string{`https://token\.actions\.githubusercontent\.com`},
+	}
+	a, err := c.Compile()
+	if err != nil {
+		t.Fatalf("Compile() = %v", err)
+	}
+	if a.Allows("https://token.actions.githubusercontent.com.evil.example.com") {
+		t.Error("Allows() permitted a suffix-extended host — pattern is not anchored")
+	}
+}
+
+func TestCompileRejectsBadPattern(t *testing.T) {
+	c := &OrgTrustedIssuers{IssuerPatterns: []string{"[unclosed"}}
+	_, err := c.Compile()
+	if err == nil {
+		t.Fatal("Compile() = nil error for an uncompilable pattern, want an error")
+	}
+	if !strings.Contains(err.Error(), "invalid issuer_pattern") {
+		t.Errorf("Compile() error = %q, want it to mention invalid issuer_pattern", err)
+	}
+}
+
+func TestCompileAllowsInlineFlags(t *testing.T) {
+	c := &OrgTrustedIssuers{IssuerPatterns: []string{`(?i)https://token\.actions\.githubusercontent\.com`}}
+	a, err := c.Compile()
+	if err != nil {
+		t.Fatalf("Compile() = %v, want nil (inline flags are permitted)", err)
+	}
+	if !a.Allows("https://TOKEN.actions.githubusercontent.com") {
+		t.Error("Allows() = false, want true for a (?i) pattern")
+	}
+}
+
+func TestAllowsUnionOfBothLists(t *testing.T) {
+	c := &OrgTrustedIssuers{
+		Issuers:        []string{testGitHubIssuer},
+		IssuerPatterns: []string{`https://oidc\.eks\.[a-z0-9-]+\.amazonaws\.com/id/[A-Z0-9]+`},
+	}
+	a, err := c.Compile()
+	if err != nil {
+		t.Fatalf("Compile() = %v, want nil (both lists may be populated)", err)
+	}
+	if !a.Allows(testGitHubIssuer) {
+		t.Error("exact entry not matched when both lists are present")
+	}
+	if !a.Allows("https://oidc.eks.eu-west-1.amazonaws.com/id/ZZZ999") {
+		t.Error("pattern entry not matched when both lists are present")
+	}
+}
+
+func TestCompileValidatesIssuers(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		issuer  string
+		wantErr string
+	}{
+		// Delegated to oidcvalidate.IsValidIssuer — assert delegation, do not
+		// re-test its whole surface here.
+		{name: "http on non-loopback", issuer: "http://evil.example.com", wantErr: "invalid issuer"},
+		{name: "no host", issuer: "https://", wantErr: "invalid issuer"},
+		{name: "query string", issuer: "https://example.com?a=b", wantErr: "invalid issuer"},
+		{name: "userinfo", issuer: "https://u:p@example.com", wantErr: "invalid issuer"},
+		{name: "non-ascii host", issuer: "https://exämple.com", wantErr: "invalid issuer"},
+		// Our own additional rule: byte-exact matching means an uppercase
+		// authority would silently never match a real iss claim.
+		{name: "uppercase host", issuer: "https://Accounts.Google.com", wantErr: "must be lowercase"},
+		// Verified: oidcvalidate.IsValidIssuer ACCEPTS "HTTPS://..." because
+		// url.Parse lowercases the scheme. Only the raw-string check catches it.
+		{name: "uppercase scheme", issuer: "HTTPS://accounts.google.com", wantErr: "must be lowercase"},
+		{name: "uppercase scheme and host", issuer: "HTTPS://Accounts.Google.com", wantErr: "must be lowercase"},
+		// These exercise the authority-truncation branch (a "/" after the host)
+		// while uppercase is present; every other uppercase row has no path, so
+		// the arithmetic would otherwise only see lowercase input.
+		{name: "uppercase host with path", issuer: "https://Example.com/foo", wantErr: "must be lowercase"},
+		{name: "uppercase scheme with path", issuer: "HTTPS://example.com/foo", wantErr: "must be lowercase"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &OrgTrustedIssuers{Issuers: []string{tc.issuer}}
+			_, err := c.Compile()
+			if err == nil {
+				t.Fatalf("Compile() = nil error for %q, want %q", tc.issuer, tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("Compile() error = %q, want it to contain %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestCompileAcceptsRealWorldIssuers pins the issuers operators actually use.
+// Trailing slashes are legal iss values (Auth0 tenants publish them), so
+// rejecting them would push those orgs onto issuer_patterns, the strictly more
+// dangerous surface.
+func TestCompileAcceptsRealWorldIssuers(t *testing.T) {
+	issuers := []string{
+		"https://token.actions.githubusercontent.com",
+		"https://accounts.google.com",
+		"https://gitlab.com",
+		"https://oidc.eks.us-west-2.amazonaws.com/id/ABCDEF123456",
+		"https://login.microsoftonline.com/11111111-2222-3333-4444-555555555555/v2.0",
+		"https://tenant.us.auth0.com/",
+		// IsValidIssuer permits http on loopback for local development.
+		"http://localhost",
+		"http://127.0.0.1",
+	}
+	for _, iss := range issuers {
+		c := &OrgTrustedIssuers{Issuers: []string{iss}}
+		a, err := c.Compile()
+		if err != nil {
+			t.Errorf("Compile() rejected real-world issuer %q: %v", iss, err)
+			continue
+		}
+		if !a.Allows(iss) {
+			t.Errorf("Allows(%q) = false for its own entry", iss)
+		}
+	}
+}
+
+func TestCompileEnforcesCaps(t *testing.T) {
+	mk := func(n int) []string {
+		out := make([]string, 0, n)
+		for i := range n {
+			out = append(out, fmt.Sprintf("https://issuer-%d.example.com", i))
+		}
+		return out
+	}
+	mkPat := func(n int) []string {
+		out := make([]string, 0, n)
+		for i := range n {
+			out = append(out, fmt.Sprintf(`https://pattern-%d\.example\.com`, i))
+		}
+		return out
+	}
+
+	if _, err := (&OrgTrustedIssuers{Issuers: mk(maxIssuers)}).Compile(); err != nil {
+		t.Errorf("Compile() with %d issuers = %v, want nil", maxIssuers, err)
+	}
+	if _, err := (&OrgTrustedIssuers{Issuers: mk(maxIssuers + 1)}).Compile(); err == nil {
+		t.Errorf("Compile() with %d issuers = nil error, want an error", maxIssuers+1)
+	}
+	if _, err := (&OrgTrustedIssuers{IssuerPatterns: mkPat(maxIssuerPatterns)}).Compile(); err != nil {
+		t.Errorf("Compile() with %d patterns = %v, want nil", maxIssuerPatterns, err)
+	}
+	if _, err := (&OrgTrustedIssuers{IssuerPatterns: mkPat(maxIssuerPatterns + 1)}).Compile(); err == nil {
+		t.Errorf("Compile() with %d patterns = nil error, want an error", maxIssuerPatterns+1)
+	}
+
+	// Pattern length is a boundary PAIR like the two counts above: exactly at
+	// the cap must compile, one over must fail. Testing only the failing side
+	// would let an off-by-one (>= instead of >) through.
+	atCap := strings.Repeat("a", maxPatternLen)
+	if _, err := (&OrgTrustedIssuers{IssuerPatterns: []string{atCap}}).Compile(); err != nil {
+		t.Errorf("Compile() with a %d-char pattern = %v, want nil", len(atCap), err)
+	}
+	overCap := strings.Repeat("a", maxPatternLen+1)
+	if _, err := (&OrgTrustedIssuers{IssuerPatterns: []string{overCap}}).Compile(); err == nil {
+		t.Errorf("Compile() with a %d-char pattern = nil error, want an error", len(overCap))
+	}
+}
+
+func TestParseOrgTrustedIssuers(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		raw  string
+		// wantErr is a substring of the expected error; empty means success.
+		// Asserting the substring rather than just err != nil is what pins
+		// WHICH layer rejected the input — see the singular-key row below.
+		wantErr  string
+		wantMode Mode
+	}{
+		{
+			name: "valid enforce by default",
+			raw: `
+issuers:
+  - https://token.actions.githubusercontent.com
+`,
+			wantMode: ModeEnforce,
+		},
+		{
+			name: "valid audit",
+			raw: `
+mode: audit
+issuers:
+  - https://token.actions.githubusercontent.com
+issuer_patterns:
+  - https://oidc\.eks\.[a-z0-9-]+\.amazonaws\.com/id/[A-Z0-9]+
+`,
+			wantMode: ModeAudit,
+		},
+		{
+			// UnmarshalStrict must reject the singular typo the plural field
+			// names invite. The valid issuers entry is load-bearing: without it
+			// a lenient Unmarshal would drop the unknown key and STILL error
+			// from Compile's at-least-one-entry check, so the row would pass
+			// while testing nothing. Asserting "unknown field" pins the layer.
+			name: "unknown key issuer_pattern singular",
+			raw: `
+issuers:
+  - https://token.actions.githubusercontent.com
+issuer_pattern:
+  - https://token\.actions\.githubusercontent\.com
+`,
+			wantErr: "unknown field",
+		},
+		{
+			name:    "unknown key entirely",
+			raw:     "enabled: true\nissuers:\n  - https://a.example.com\n",
+			wantErr: "unknown field",
+		},
+		{name: "malformed yaml", raw: "issuers: [\n", wantErr: "parsing organization trusted issuers"},
+		{name: "empty document", raw: "", wantErr: "must list at least one entry"},
+		{name: "uncompilable pattern", raw: "issuer_patterns:\n  - \"[unclosed\"\n", wantErr: "invalid issuer_pattern"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a, err := ParseOrgTrustedIssuers([]byte(tc.raw))
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("ParseOrgTrustedIssuers() = nil error, want one containing %q", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("ParseOrgTrustedIssuers() error = %q, want it to contain %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseOrgTrustedIssuers() = %v, want nil", err)
+			}
+			if a.Mode() != tc.wantMode {
+				t.Errorf("Mode() = %q, want %q", a.Mode(), tc.wantMode)
+			}
+		})
+	}
+}
+
+// TestCompileRejectsWildcardDot pins the footgun that motivated the check: the
+// most natural way to write "any subdomain of example.com" is also a complete
+// bypass of the organization control.
+func TestCompileRejectsWildcardDot(t *testing.T) {
+	for _, pat := range []string{
+		`https://.*.example.com`,
+		// A partially hardened pattern: the varying label is bounded but the
+		// separators are not, so "." still matches "-" and this permits the
+		// attacker-registrable "https://evil-example.com". This shape is the
+		// one that stays broken if the scanner never leaves a character class.
+		`https://[a-z0-9-]+.example.com`,
+		// A bare "." with no repetition operator is just as loose per byte.
+		`https://ci.example\.com`,
+	} {
+		c := &OrgTrustedIssuers{
+			Issuers: []string{testGitHubIssuer},
+			IssuerPatterns: []string{
+				`https://a\.example\.com`,
+				`https://b\.example\.com`,
+				pat,
+			},
+		}
+		_, err := c.Compile()
+		if err == nil {
+			t.Fatalf("Compile() with pattern %q = nil error, want an error", pat)
+		}
+		// The index tells an operator which of up to 16 patterns is at fault,
+		// and the corrected form has to be in the message or the error does not
+		// teach the fix.
+		for _, want := range []string{"issuer_patterns[2]", `\.`, "[a-z0-9-]+"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("Compile() with pattern %q: error = %q, want it contain %q", pat, err, want)
+			}
+		}
+	}
+}
+
+// TestAllowsLabelBoundedPatternRejectsBypass regresses the bypass itself, not
+// merely the banned character: the corrected pattern must still express the
+// intent while refusing both hosts the loose form permitted.
+func TestAllowsLabelBoundedPatternRejectsBypass(t *testing.T) {
+	c := &OrgTrustedIssuers{IssuerPatterns: []string{`https://[a-z0-9-]+\.example\.com`}}
+	a, err := c.Compile()
+	if err != nil {
+		t.Fatalf("Compile() = %v, want nil", err)
+	}
+	if !a.Allows("https://ci.example.com") {
+		t.Error(`Allows("https://ci.example.com") = false, want true`)
+	}
+	for _, iss := range []string{
+		// ".*" consumed "evil.attacker" and the unescaped "." matched "-".
+		"https://evil.attacker-example.com",
+		// ".*" also crossed the "/", so an unrelated host matched.
+		"https://totally-evil.com/x?a=example.com",
+	} {
+		if a.Allows(iss) {
+			t.Errorf("Allows(%q) = true, want false — wildcard crossed a DNS or path boundary", iss)
+		}
+	}
+}
+
+// TestCompileRejectsSlashMatchingAtoms covers the bypasses that a name-based
+// scan for "." could never catch. Every pattern here was verified to compile
+// under the old check AND to match the attacker-controlled issuer below, which
+// is the whole point: the atom does not have to be spelled "." to behave like
+// one.
+func TestCompileRejectsSlashMatchingAtoms(t *testing.T) {
+	// Each row carries the issuer it wrongly permitted. In every case the host
+	// is attacker-controlled and the pattern only reaches "example.com" by
+	// letting its varying atom consume the "/".
+	const spanning = "https://totally-evil.com/x.example.com"
+
+	for _, tc := range []struct {
+		name string
+		pat  string
+		evil string
+	}{
+		{"escaped non-whitespace shorthand", `https://\S+\.example\.com`, spanning},
+		{"whitespace union class", `https://[\s\S]+\.example\.com`, spanning},
+		{"negated newline class", `https://[^\n]+\.example\.com`, spanning},
+		{"posix ascii class", `https://[[:ascii:]]+\.example\.com`, spanning},
+		{"posix graph class", `https://[[:graph:]]+\.example\.com`, spanning},
+		// "/" is 0x2F, which falls inside the range "." (0x2E) to "9" (0x39).
+		// No list of NAMED constructs catches this one; only asking the atom
+		// whether it matches "/" does. The class admits digits and separators
+		// only, so the demonstration host is built from those.
+		{"range that spans the slash byte", `https://[.-9]+\.example\.com`, "https://1/2.example.com"},
+		// Unicode punctuation includes "/", and so does POSIX punct.
+		{"unicode punctuation class", `https://\p{P}+\.example\.com`, "https://-/-.example.com"},
+		{"posix punct class", `https://[[:punct:]]+\.example\.com`, "https://-/-.example.com"},
+		// A loose atom AFTER an escaped literal. Treating "\." as a reason to
+		// stop scanning — rather than as two bytes to skip — would let everything
+		// downstream of the first escape through unchecked.
+		{"loose atom after an escaped literal", `https://a\.\S+\.example\.com`, "https://a.evil.com/x.example.com"},
+		// A loose atom after a bracket expression, for the same reason.
+		{"loose atom after a bracket expression", `https://[a-z]+\.\S+\.example\.com`, "https://a.evil.com/x.example.com"},
+		// RE2 reads a first-position "]" as a literal, so "[^]]" is "any byte
+		// except ]" — including "/". Scanning for the first "]" instead extracts
+		// the uncompilable "[^]" and left the class untested.
+		{"negated class with a leading literal ]", `https://[^]]+\.example\.com`, "https://evil.com/x.example.com"},
+		{"class whose leading literal ] precedes a slash", `https://[]/]+\.example\.com`, "https:///.example.com"},
+		// Numeric escapes SPELL "/" rather than naming a class, so treating them
+		// as escaped literals skipped two bytes and left the digits to be read as
+		// unexamined literal text. All three of these are "/".
+		{"hex escape for the slash byte", `https://a\x2Fb\.example\.com`, "https://a/b.example.com"},
+		{"braced hex escape for the slash byte", `https://a\x{2F}b\.example\.com`, "https://a/b.example.com"},
+		{"octal escape for the slash byte", `https://a\057b\.example\.com`, "https://a/b.example.com"},
+		// "[:" opens a POSIX class only when a ":]" follows; without one RE2 reads
+		// the "[" as an ordinary member and the class keeps going, so these are
+		// ordinary classes that happen to contain "/". The scanner used to give up
+		// on the whole pattern here, which is how they passed.
+		{"pseudo-POSIX class spanning slash to tilde", `https://[[:/-~]+\.example\.com`, "https://e/v/i/l/x.example.com"},
+		{"pseudo-POSIX class holding a literal slash", `https://[[:/]+\.example\.com`, "https:///.example.com"},
+		{"pseudo-POSIX class after a member", `https://[a[:/]+\.example\.com`, "https://a/a.example.com"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Confirm the pattern really is a bypass, so the test fails loudly if
+			// a future edit makes the row vacuous.
+			if re, err := regexp.Compile("^(?:" + tc.pat + ")$"); err != nil {
+				t.Fatalf("regexp.Compile(%q) = %v; the row must be a valid regexp", tc.pat, err)
+			} else if !re.MatchString(tc.evil) {
+				t.Fatalf("pattern %q does not match %q; the row no longer demonstrates a bypass", tc.pat, tc.evil)
+			}
+
+			c := &OrgTrustedIssuers{
+				Issuers: []string{testGitHubIssuer},
+				IssuerPatterns: []string{
+					`https://a\.example\.com`,
+					`https://b\.example\.com`,
+					tc.pat,
+				},
+			}
+			_, err := c.Compile()
+			if err == nil {
+				t.Fatalf("Compile() with pattern %q = nil error, want an error", tc.pat)
+			}
+			for _, want := range []string{"issuer_patterns[2]", `"/"`, "[a-z0-9-]+"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("Compile() with pattern %q: error = %q, want it to contain %q", tc.pat, err, want)
+				}
+			}
+		})
+	}
+}
+
+// TestCompileRejectsPatternsThatEscapeTheAnchoringGroup covers a bypass the
+// non-capturing group CREATES rather than prevents.
+//
+// Wrapping p in "^(?:" + p + ")$" anchors a top-level alternation, but an
+// unbalanced ")" inside p closes that group early: "token\.example\.com)|("
+// becomes "^(?:token\.example\.com)|()$", whose "()$" alternative matches every
+// string — allow-all, and the webhook reported the file Valid. Compiling p on its
+// own first rejects it, because standalone it is a syntax error.
+func TestCompileRejectsPatternsThatEscapeTheAnchoringGroup(t *testing.T) {
+	// Both rows must be patterns whose WRAPPED form compiles — that is what makes
+	// them bypasses rather than ordinary syntax errors. A bare ")" does not
+	// qualify: "^(?:))$" is itself invalid, so the pre-existing wrapped compile
+	// already rejected it.
+	for _, pat := range []string{
+		`token\.example\.com)|(`,
+		`a)|(`,
+	} {
+		t.Run(pat, func(t *testing.T) {
+			// The bypass only exists because the WRAPPED form compiles. If Go ever
+			// rejected it, this row would pass for the wrong reason.
+			if _, err := regexp.Compile("^(?:" + pat + ")$"); err != nil {
+				t.Fatalf("wrapped %q no longer compiles (%v); this row no longer demonstrates the bypass", pat, err)
+			}
+			al, err := (&OrgTrustedIssuers{IssuerPatterns: []string{pat}}).Compile()
+			if err == nil {
+				t.Fatalf("Compile() with pattern %q = nil error, want a rejection; Allows(%q) = %v",
+					pat, "https://totally-evil.example", al.Allows("https://totally-evil.example"))
+			}
+		})
+	}
+
+	// The group must still do its job: a legitimate top-level alternation stays
+	// accepted and stays anchored.
+	al, err := (&OrgTrustedIssuers{
+		IssuerPatterns: []string{`https://a\.example\.com|https://b\.example\.com`},
+	}).Compile()
+	if err != nil {
+		t.Fatalf("Compile() with a legitimate top-level alternation = %v, want nil", err)
+	}
+	for iss, want := range map[string]bool{
+		"https://a.example.com":             true,
+		"https://b.example.com":             true,
+		"https://a.example.com.evil":        false,
+		"evil-prefix-https://a.example.com": false,
+	} {
+		if got := al.Allows(iss); got != want {
+			t.Errorf("Allows(%q) = %v, want %v — the alternation must stay anchored at both ends", iss, got, want)
+		}
+	}
+}
+
+// TestCompileFailsClosedOnAnAtomItCannotAnalyze pins the posture, not a
+// particular syntax. Skipping an atom that does not compile turned every parsing
+// gap into a silent bypass ("[^]]", "\x2F"); the next gap must not be
+// exploitable, so an unanalyzable atom now rejects the pattern.
+func TestCompileFailsClosedOnAnAtomItCannotAnalyze(t *testing.T) {
+	// An unknown POSIX class name: the scanner delimits the bracket expression
+	// correctly, then regexp.Compile rejects the name.
+	//
+	// The name is assembled at runtime so staticcheck does not constant-fold the
+	// pattern and report the invalid class as a lint error — being invalid is the
+	// whole point of this input.
+	pat := `https://[[:` + strings.Repeat("bogus", 1) + `:]]+\.example\.com`
+	if re, err := regexp.Compile("^(?:" + pat + ")$"); err == nil {
+		t.Fatalf("regexp.Compile(%q) = nil error; this test needs an atom Go rejects, "+
+			"otherwise it exercises the match path rather than the fail-closed path (re=%v)", pat, re)
+	}
+	_, err := (&OrgTrustedIssuers{IssuerPatterns: []string{pat}}).Compile()
+	if err == nil {
+		t.Fatalf("Compile() with pattern %q = nil error, want a rejection", pat)
+	}
+	if !strings.Contains(err.Error(), "cannot verify") {
+		t.Errorf("Compile() error = %q, want the fail-closed message mentioning %q", err, "cannot verify")
+	}
+}
+
+// TestCompileAcceptsPosixClassesThatCannotMatchSlash is the other half of the
+// empirical claim: the check must not blanket-reject POSIX classes. Which ones
+// are safe was determined by compiling each class and testing it against "/" —
+// alpha, lower, upper, alnum, word, digit and xdigit do not match "/", while
+// ascii, punct, graph and print do.
+func TestCompileAcceptsPosixClassesThatCannotMatchSlash(t *testing.T) {
+	for _, class := range []string{"[[:alpha:]]", "[[:lower:]]", "[[:alnum:]]", "[[:word:]]", "[[:digit:]]"} {
+		pat := `https://` + class + `+\.example\.com`
+		if _, err := (&OrgTrustedIssuers{IssuerPatterns: []string{pat}}).Compile(); err != nil {
+			t.Errorf("Compile() with pattern %q = %v, want nil — %s cannot match %q", pat, err, class, "/")
+		}
+	}
+}
+
+// TestCompileAllowsLiteralSlashInRealWorldPatterns pins that the check does not
+// reject a literal "/". Both patterns ship in the fixtures, README and schema
+// examples, and both contain a path.
+func TestCompileAllowsLiteralSlashInRealWorldPatterns(t *testing.T) {
+	for _, tc := range []struct{ pat, issuer string }{
+		{`https://oidc\.eks\.[a-z0-9-]+\.amazonaws\.com/id/[A-Z0-9]+`, "https://oidc.eks.us-west-2.amazonaws.com/id/ABCDEF0123456789"},
+		{`https://login\.microsoftonline\.com/[a-f0-9-]+/v2\.0`, "https://login.microsoftonline.com/00000000-1111-2222-3333-444444444444/v2.0"},
+	} {
+		a, err := (&OrgTrustedIssuers{IssuerPatterns: []string{tc.pat}}).Compile()
+		if err != nil {
+			t.Fatalf("Compile() with pattern %q = %v, want nil", tc.pat, err)
+		}
+		if !a.Allows(tc.issuer) {
+			t.Errorf("Allows(%q) = false, want true for pattern %q", tc.issuer, tc.pat)
+		}
+	}
+}
+
+// TestCompileBracketExtractionHandlesEscapedCloseBracket pins that an escaped "]"
+// does not terminate a bracket expression. A mis-parse flips the verdict: read
+// correctly the atom is `[a-z\]]`, which cannot match "/" and must be accepted;
+// read as closing early it becomes `[a-z\]` and the rest misparses.
+func TestCompileBracketExtractionHandlesEscapedCloseBracket(t *testing.T) {
+	const pat = `https://[a-z\]]+\.example\.com`
+	if regexp.MustCompile(`^[a-z\]]$`).MatchString("/") {
+		t.Fatal(`[a-z\]] matches "/"; the premise of this test is wrong`)
+	}
+	a, err := (&OrgTrustedIssuers{IssuerPatterns: []string{pat}}).Compile()
+	if err != nil {
+		t.Fatalf("Compile() with pattern %q = %v, want nil", pat, err)
+	}
+	if !a.Allows("https://ci]x.example.com") {
+		t.Error(`Allows("https://ci]x.example.com") = false, want true`)
+	}
+}
+
+func TestCompileAllowsDotInsideCharacterClass(t *testing.T) {
+	for _, p := range []string{
+		`https://a[.]example\.com`,
+		`https://[a-z.]+\.example\.com`,
+		// An escaped "]" does not close the class, so the "." that follows it
+		// is still inside one. Mis-parsing "\]" as a closing bracket would put
+		// this "." outside a class and wrongly reject the pattern.
+		`https://[a-z\].]+\.example\.com`,
+	} {
+		if _, err := (&OrgTrustedIssuers{IssuerPatterns: []string{p}}).Compile(); err != nil {
+			t.Errorf("Compile() with pattern %q = %v, want nil", p, err)
+		}
+	}
+}
+
+// TestCompileRejectsBadPatternBeforeDotCheck pins that an unterminated class is
+// still reported by regexp's own compile error rather than being swallowed by
+// the wildcard-dot scan, which must not treat "[unclosed" as leaving a class.
+func TestCompileRejectsBadPatternWithCompileError(t *testing.T) {
+	_, err := (&OrgTrustedIssuers{IssuerPatterns: []string{"[unclosed"}}).Compile()
+	if err == nil {
+		t.Fatal("Compile() = nil error, want error")
+	}
+	if !strings.Contains(err.Error(), "invalid issuer_pattern") {
+		t.Errorf("Compile() error = %q, want regexp's compile error", err)
+	}
+	if strings.Contains(err.Error(), "can match") {
+		t.Errorf("Compile() error = %q, want the compile error, not the atom error", err)
+	}
+}
+
+// TestCompileReportsWildcardDotBeforeCompileError pins the ordering of the two
+// pattern checks. For a pattern that is both loose and malformed the
+// loose-pattern error is the more actionable of the two, so the wildcard-dot
+// scan has to run before regexp.Compile. "[unclosed" alone does not pin this —
+// it contains no ".", so either ordering yields the compile error.
+func TestCompileReportsWildcardDotBeforeCompileError(t *testing.T) {
+	_, err := (&OrgTrustedIssuers{IssuerPatterns: []string{`https://.*.example.com(`}}).Compile()
+	if err == nil {
+		t.Fatal("Compile() = nil error, want error")
+	}
+	if !strings.Contains(err.Error(), "can match") {
+		t.Errorf("Compile() error = %q, want the atom error to win over regexp's compile error", err)
+	}
+}

--- a/pkg/octosts/org_trusted_issuers_test.go
+++ b/pkg/octosts/org_trusted_issuers_test.go
@@ -580,34 +580,63 @@ func TestCompileRejectsPatternsThatEscapeTheAnchoringGroup(t *testing.T) {
 	}
 }
 
-// TestCompileKnownLimitationQuantifiedGroupSpansSeparators documents a gap the
-// per-atom guard structurally cannot close, so that it stays a known limitation
-// rather than something readers assume is covered.
+// TestCompileRejectsSeparatorUnderQuantifier covers the half the per-atom scan
+// structurally cannot: a "/" that only spans because of the structure AROUND it.
 //
-// The guard asks of each single-character atom "can this match /". A literal "/"
-// is deliberately allowed, so a quantified GROUP containing one spans separators
-// while every atom in it is innocent. Closing this needs AST analysis of
-// quantified subexpressions.
+// Every atom in "([a-z0-9.-]+/)*" is innocent alone, so the atom scan passes it —
+// yet the group repeats across separators. "?", "{n,m}", "+" and alternation do the
+// same. In each case the host is attacker-chosen and the trusted name is demoted to
+// a path segment, while the pattern still matches its author's intended issuer,
+// which is exactly why it reads as safe.
 //
-// If a future change starts rejecting this, that is an improvement — update this
-// test to assert the rejection rather than deleting it, so the reasoning survives.
-func TestCompileKnownLimitationQuantifiedGroupSpansSeparators(t *testing.T) {
-	const pat = `https://([a-z0-9.-]+/)*trusted\.example\.com`
+// This test used to assert these were ACCEPTED, as a documented limitation. A
+// reviewer asked for the class closed rather than documented, so it now asserts
+// rejection; checkNoSeparatorUnderQuantifier walks the regexp/syntax tree.
+func TestCompileRejectsSeparatorUnderQuantifier(t *testing.T) {
+	for _, tc := range []struct{ name, pat, spanning string }{
+		{"star", `https://([a-z0-9.-]+/)*trusted\.example\.com`, "https://evil.com/x/trusted.example.com"},
+		{"plus", `https://([a-z0-9.-]+/)+trusted\.example\.com`, "https://evil.com/x/trusted.example.com"},
+		{"optional", `https://(x\.com/)?trusted\.example\.com`, "https://x.com/trusted.example.com"},
+		{"bounded repeat", `https://([a-z0-9.-]+/){1,3}trusted\.example\.com`, "https://evil.com/x/trusted.example.com"},
+		{"alternation", `https://(good\.example\.com|evil\.com/x/trusted\.example\.com)`, "https://evil.com/x/trusted.example.com"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Prove the shape really is a bypass, so the row cannot go vacuous.
+			re, err := regexp.Compile("^(?:" + tc.pat + ")$")
+			if err != nil {
+				t.Fatalf("regexp.Compile(%q) = %v; the row must be a valid regexp", tc.pat, err)
+			}
+			if !re.MatchString(tc.spanning) {
+				t.Fatalf("pattern %q does not match %q; the row no longer demonstrates spanning", tc.pat, tc.spanning)
+			}
 
-	al, err := (&OrgTrustedIssuers{IssuerPatterns: []string{pat}}).Compile()
-	if err != nil {
-		t.Fatalf("Compile() = %v; the guard now rejects this. That is an improvement — "+
-			"update this test to assert rejection instead of deleting it", err)
+			_, err = (&OrgTrustedIssuers{IssuerPatterns: []string{tc.pat}}).Compile()
+			if err == nil {
+				t.Fatalf("Compile() with pattern %q = nil error, want a rejection", tc.pat)
+			}
+			if !strings.Contains(err.Error(), "repetition, optional or alternation") {
+				t.Errorf("Compile() error = %q, want the separator-under-quantifier message", err)
+			}
+		})
 	}
+}
 
-	// The point of the limitation: an attacker-chosen host with the trusted name
-	// demoted to a path segment.
-	const spanning = "https://evil.com/x/trusted.example.com"
-	if !al.Allows(spanning) {
-		t.Fatalf("Allows(%q) = false; this test no longer demonstrates the limitation", spanning)
-	}
-	if !al.Allows("https://trusted.example.com") {
-		t.Error("the pattern should still match its intended issuer, which is why it looks correct to its author")
+// TestCompileKeepsFixedPositionSlashes is the other half: the check must not reject a
+// "/" at a FIXED position, or it would break every real issuer with a path. All of
+// these appear in the fixtures, the README or the schema examples.
+func TestCompileKeepsFixedPositionSlashes(t *testing.T) {
+	for _, pat := range []string{
+		`https://host\.example\.com/id/[A-Z0-9]+`,
+		`https://oidc\.eks\.[a-z0-9-]+\.amazonaws\.com/id/[A-Z0-9]+`,
+		`https://example\.com/realms/[a-z0-9-]+`,
+		`https://login\.microsoftonline\.com/[a-f0-9-]+/v2\.0`,
+		// An alternation with no separator in it stays legal: the check keys on the
+		// "/" being under variable structure, not on the structure alone.
+		`https://a\.example\.com|https://b\.example\.com`,
+	} {
+		if _, err := (&OrgTrustedIssuers{IssuerPatterns: []string{pat}}).Compile(); err != nil {
+			t.Errorf("Compile() with pattern %q = %v, want nil", pat, err)
+		}
 	}
 }
 

--- a/pkg/octosts/org_trusted_issuers_test.go
+++ b/pkg/octosts/org_trusted_issuers_test.go
@@ -580,6 +580,37 @@ func TestCompileRejectsPatternsThatEscapeTheAnchoringGroup(t *testing.T) {
 	}
 }
 
+// TestCompileKnownLimitationQuantifiedGroupSpansSeparators documents a gap the
+// per-atom guard structurally cannot close, so that it stays a known limitation
+// rather than something readers assume is covered.
+//
+// The guard asks of each single-character atom "can this match /". A literal "/"
+// is deliberately allowed, so a quantified GROUP containing one spans separators
+// while every atom in it is innocent. Closing this needs AST analysis of
+// quantified subexpressions.
+//
+// If a future change starts rejecting this, that is an improvement — update this
+// test to assert the rejection rather than deleting it, so the reasoning survives.
+func TestCompileKnownLimitationQuantifiedGroupSpansSeparators(t *testing.T) {
+	const pat = `https://([a-z0-9.-]+/)*trusted\.example\.com`
+
+	al, err := (&OrgTrustedIssuers{IssuerPatterns: []string{pat}}).Compile()
+	if err != nil {
+		t.Fatalf("Compile() = %v; the guard now rejects this. That is an improvement — "+
+			"update this test to assert rejection instead of deleting it", err)
+	}
+
+	// The point of the limitation: an attacker-chosen host with the trusted name
+	// demoted to a path segment.
+	const spanning = "https://evil.com/x/trusted.example.com"
+	if !al.Allows(spanning) {
+		t.Fatalf("Allows(%q) = false; this test no longer demonstrates the limitation", spanning)
+	}
+	if !al.Allows("https://trusted.example.com") {
+		t.Error("the pattern should still match its intended issuer, which is why it looks correct to its author")
+	}
+}
+
 // TestCompileFailsClosedOnAnAtomItCannotAnalyze pins the posture, not a
 // particular syntax. Skipping an atom that does not compile turned every parsing
 // gap into a silent bypass ("[^]]", "\x2F"); the next gap must not be

--- a/pkg/octosts/testdata/orgallow/.github/trusted-token-issuers.yaml
+++ b/pkg/octosts/testdata/orgallow/.github/trusted-token-issuers.yaml
@@ -1,0 +1,7 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/octo-sts/app/refs/heads/main/pkg/octosts/octosts.OrgTrustedIssuers.json
+
+issuers:
+  - https://token.actions.githubusercontent.com

--- a/pkg/octosts/testdata/orgallow/repo/foo.sts.yaml
+++ b/pkg/octosts/testdata/orgallow/repo/foo.sts.yaml
@@ -1,0 +1,9 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+issuer: https://token.actions.githubusercontent.com
+subject: foo
+audience: octosts
+
+permissions:
+  pull_requests: write

--- a/pkg/octosts/testdata/orgaudit/.github/trusted-token-issuers.yaml
+++ b/pkg/octosts/testdata/orgaudit/.github/trusted-token-issuers.yaml
@@ -1,0 +1,8 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/octo-sts/app/refs/heads/main/pkg/octosts/octosts.OrgTrustedIssuers.json
+
+mode: audit
+issuers:
+  - https://some-other-idp.example.com

--- a/pkg/octosts/testdata/orgaudit/repo/foo.sts.yaml
+++ b/pkg/octosts/testdata/orgaudit/repo/foo.sts.yaml
@@ -1,0 +1,9 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+issuer: https://token.actions.githubusercontent.com
+subject: foo
+audience: octosts
+
+permissions:
+  pull_requests: write

--- a/pkg/octosts/testdata/orgbad/.github/trusted-token-issuers.yaml
+++ b/pkg/octosts/testdata/orgbad/.github/trusted-token-issuers.yaml
@@ -1,0 +1,7 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/octo-sts/app/refs/heads/main/pkg/octosts/octosts.OrgTrustedIssuers.json
+
+issuer_patterns:
+  - "[unclosed"

--- a/pkg/octosts/testdata/orgbad/repo/foo.sts.yaml
+++ b/pkg/octosts/testdata/orgbad/repo/foo.sts.yaml
@@ -1,0 +1,9 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+issuer: https://token.actions.githubusercontent.com
+subject: foo
+audience: octosts
+
+permissions:
+  pull_requests: write

--- a/pkg/octosts/testdata/orgdeny/.github/trusted-token-issuers.yaml
+++ b/pkg/octosts/testdata/orgdeny/.github/trusted-token-issuers.yaml
@@ -1,0 +1,7 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/octo-sts/app/refs/heads/main/pkg/octosts/octosts.OrgTrustedIssuers.json
+
+issuers:
+  - https://some-other-idp.example.com

--- a/pkg/octosts/testdata/orgdeny/repo/foo.sts.yaml
+++ b/pkg/octosts/testdata/orgdeny/repo/foo.sts.yaml
@@ -1,0 +1,9 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+issuer: https://token.actions.githubusercontent.com
+subject: foo
+audience: octosts
+
+permissions:
+  pull_requests: write

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -258,6 +258,16 @@ func validatePolicies(ctx context.Context, client *github.Client, owner, repo st
 			continue
 		}
 
+		// GetContents returns a nil file and a populated slice when the path is a
+		// DIRECTORY, and RepositoryContent.GetContent dereferences its receiver
+		// without a nil check — so a directory named like a policy or the allowlist
+		// would panic the handler rather than fail the check run.
+		if resp == nil {
+			log.Infof("%s is not a file, skipping", f)
+			merr = multierror.Append(merr, fmt.Errorf("%s: not a file", f))
+			continue
+		}
+
 		raw, err := resp.GetContent()
 		if err != nil {
 			log.Infof("failed to read content: %v", err)
@@ -467,7 +477,9 @@ func (e *Validator) handleCheckSuite(ctx context.Context, cs checkSuite) (*githu
 		// files (a README, a .gitkeep, the organization allowlist) get fetched
 		// and parsed as trust policies and fail the check run.
 		for _, file := range dirContents {
-			if isValidatedPath(repo, file.GetPath()) {
+			// Type matters as well as path: a directory can be named to match, and
+			// listing it as a candidate would send a non-file down the read path.
+			if file.GetType() == "file" && isValidatedPath(repo, file.GetPath()) {
 				files = append(files, file.GetPath())
 			}
 		}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -265,8 +265,21 @@ func validatePolicies(ctx context.Context, client *github.Client, owner, repo st
 			continue
 		}
 
-		switch repo {
-		case ".github":
+		switch {
+		case strings.EqualFold(repo, ".github") && f == octosts.OrgTrustedIssuersPath:
+			// Parse AND compile: only compiling catches uncompilable patterns,
+			// invalid issuer URLs, and an empty allowlist. The exchange path calls
+			// this same function, so the two verdicts cannot diverge.
+			if _, err := octosts.ParseOrgTrustedIssuers([]byte(raw)); err != nil {
+				log.Infof("failed to validate org trusted issuers: %v", err)
+				merr = multierror.Append(merr, fmt.Errorf("%s: %w", f, err))
+			}
+
+		// EqualFold, matching the arm above: GitHub preserves repository-name case,
+		// so an org whose repo is literally ".GitHub" would otherwise fall through
+		// to the default arm and have its org policy strict-unmarshalled as a
+		// repo-level TrustPolicy — a bogus check-run failure on a valid file.
+		case strings.EqualFold(repo, ".github"):
 			if err := yaml.UnmarshalStrict([]byte(raw), &octosts.OrgTrustPolicy{}); err != nil {
 				log.Infof("failed to parse org trust policy: %v", err)
 				merr = multierror.Append(merr, fmt.Errorf("%s: %w", f, err))
@@ -315,14 +328,14 @@ func (e *Validator) handlePush(ctx context.Context, event *github.PushEvent) (*g
 	// GitHub push payloads include up to 20 commits. When not truncated,
 	// use the payload directly to avoid a Compare API call.
 	if len(event.Commits) < 20 {
-		files = e.filesFromPushEvent(event)
+		files = e.filesFromPushEvent(repo, event)
 	} else {
 		resp, _, err := client.Repositories.CompareCommits(ctx, owner, repo, event.GetBefore(), sha, &github.ListOptions{})
 		if err != nil {
 			return nil, err
 		}
 		for _, file := range resp.Files {
-			if isValidatedPath(file.GetFilename()) {
+			if isValidatedPath(repo, file.GetFilename()) {
 				if file.GetStatus() != "removed" {
 					files = append(files, file.GetFilename())
 				}
@@ -378,7 +391,7 @@ func (e *Validator) handlePullRequest(ctx context.Context, pr *github.PullReques
 		return nil, err
 	}
 	for _, file := range resp {
-		if isValidatedPath(file.GetFilename()) {
+		if isValidatedPath(repo, file.GetFilename()) {
 			if file.GetStatus() != "removed" {
 				files = append(files, file.GetFilename())
 			}
@@ -451,10 +464,10 @@ func (e *Validator) handleCheckSuite(ctx context.Context, cs checkSuite) (*githu
 		// This branch lists the policy directory rather than diffing it, so the
 		// entries are everything the directory holds — not just trust policies.
 		// Filter here as every diff-based path already does, otherwise unrelated
-		// files (a README, a .gitkeep) get fetched and parsed as trust policies
-		// and fail the check run.
+		// files (a README, a .gitkeep, the organization allowlist) get fetched
+		// and parsed as trust policies and fail the check run.
 		for _, file := range dirContents {
-			if isValidatedPath(file.GetPath()) {
+			if isValidatedPath(repo, file.GetPath()) {
 				files = append(files, file.GetPath())
 			}
 		}
@@ -464,7 +477,7 @@ func (e *Validator) handleCheckSuite(ctx context.Context, cs checkSuite) (*githu
 			return nil, err
 		}
 		for _, file := range resp.Files {
-			if isValidatedPath(file.GetFilename()) {
+			if isValidatedPath(repo, file.GetFilename()) {
 				if file.GetStatus() != "removed" {
 					files = append(files, file.GetFilename())
 				}
@@ -478,7 +491,7 @@ func (e *Validator) handleCheckSuite(ctx context.Context, cs checkSuite) (*githu
 			return nil, err
 		}
 		for _, file := range resp {
-			if isValidatedPath(file.GetFilename()) {
+			if isValidatedPath(repo, file.GetFilename()) {
 				if file.GetStatus() != "removed" {
 					files = append(files, file.GetFilename())
 				}
@@ -514,28 +527,41 @@ func (e *Validator) shouldSkipOrganization(org string) bool {
 	return true
 }
 
-// isValidatedPath reports whether octo-sts validates the given file.
-func isValidatedPath(path string) bool {
-	ok, err := filepath.Match(".github/chainguard/*.sts.yaml", path)
-	return err == nil && ok
+// isValidatedPath reports whether octo-sts validates the given file. Trust
+// policies are validated in every repository; the organization trusted-issuer
+// allowlist only in the organization's .github repository.
+//
+// The repository comparison folds case because GitHub repository names are
+// case-insensitive and the exchange path resolves .github through the API.
+func isValidatedPath(repo, path string) bool {
+	if ok, err := filepath.Match(".github/chainguard/*.sts.yaml", path); err == nil && ok {
+		return true
+	}
+	return strings.EqualFold(repo, ".github") && path == octosts.OrgTrustedIssuersPath
 }
 
 // filterValidatedFiles returns the subset of files octo-sts validates.
-func filterValidatedFiles(files []string) []string {
+func filterValidatedFiles(repo string, files []string) []string {
 	var filtered []string
 	for _, f := range files {
-		if isValidatedPath(f) {
+		if isValidatedPath(repo, f) {
 			filtered = append(filtered, f)
 		}
 	}
 	return filtered
 }
 
-func (e *Validator) filesFromPushEvent(event *github.PushEvent) []string {
+// filesFromPushEvent returns the validated files touched by the push.
+//
+// Deletions are deliberately excluded: validation reads each file's content at
+// the head SHA, and a deleted path 404s there, so including removals would turn
+// every trust-policy deletion into a failing check run. The CompareCommits
+// branches skip "removed" for the same reason.
+func (e *Validator) filesFromPushEvent(repo string, event *github.PushEvent) []string {
 	var files []string //nolint:prealloc // size depends on file content, not commit count
 	for _, commit := range event.Commits {
-		files = append(files, filterValidatedFiles(commit.Added)...)
-		files = append(files, filterValidatedFiles(commit.Modified)...)
+		files = append(files, filterValidatedFiles(repo, commit.Added)...)
+		files = append(files, filterValidatedFiles(repo, commit.Modified)...)
 	}
 	return files
 }

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -251,54 +252,6 @@ func TestWebhookOK(t *testing.T) {
 	}
 }
 
-func TestIsValidatedPath(t *testing.T) {
-	for _, tc := range []struct {
-		name string
-		path string
-		want bool
-	}{
-		{
-			name: "trust policy",
-			path: ".github/chainguard/test.sts.yaml",
-			want: true,
-		},
-		{
-			name: "workflow not validated",
-			path: ".github/workflows/ci.yaml",
-			want: false,
-		},
-		{
-			name: "nested policy not validated: * does not cross a separator",
-			path: ".github/chainguard/sub/foo.sts.yaml",
-			want: false,
-		},
-		{
-			name: "top-level readme not validated",
-			path: "README.md",
-			want: false,
-		},
-		{
-			name: "readme inside the policy directory not validated",
-			path: ".github/chainguard/README.md",
-			want: false,
-		},
-		{
-			// Pins the ".sts." infix: a README does not match a looser
-			// ".github/chainguard/*.yaml" glob either, so it cannot tell the two
-			// apart on its own.
-			name: "non-policy yaml inside the policy directory not validated",
-			path: ".github/chainguard/config.yaml",
-			want: false,
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := isValidatedPath(tc.path); got != tc.want {
-				t.Errorf("isValidatedPath(%q) = %v, want %v", tc.path, got, tc.want)
-			}
-		})
-	}
-}
-
 func TestFilterValidatedFiles(t *testing.T) {
 	for _, tc := range []struct {
 		name  string
@@ -332,7 +285,7 @@ func TestFilterValidatedFiles(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := filterValidatedFiles(tc.input)
+			got := filterValidatedFiles("some-service", tc.input)
 			if !slices.Equal(tc.want, got) {
 				t.Errorf("filterValidatedFiles(%v) = %v, want %v", tc.input, got, tc.want)
 			}
@@ -532,7 +485,7 @@ func TestFilesFromPushEvent(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			event := &github.PushEvent{Commits: tc.commits}
-			got := v.filesFromPushEvent(event)
+			got := v.filesFromPushEvent("some-service", event)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("filesFromPushEvent() mismatch (-want +got):\n%s", diff)
 			}
@@ -1799,5 +1752,367 @@ func TestWebhookInstallationTokenCached(t *testing.T) {
 
 	if got := mints.Load(); got != 1 {
 		t.Fatalf("expected exactly 1 token mint across 2 events, got %d", got)
+	}
+}
+
+func TestIsValidatedPath(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		repo string
+		path string
+		want bool
+	}{
+		{name: "trust policy in any repo", repo: "some-service", path: ".github/chainguard/foo.sts.yaml", want: true},
+		{name: "trust policy in .github", repo: ".github", path: ".github/chainguard/foo.sts.yaml", want: true},
+		{name: "allowlist in .github", repo: ".github", path: ".github/chainguard/trusted-token-issuers.yaml", want: true},
+		// GitHub repository names are case-insensitive, and the read path
+		// resolves .github through the API, so the predicate must fold.
+		{name: "allowlist in .GitHub", repo: ".GitHub", path: ".github/chainguard/trusted-token-issuers.yaml", want: true},
+		// A stray copy in an ordinary repo must NOT be validated, or it would be
+		// parsed as a TrustPolicy and fail the check run.
+		{name: "allowlist outside .github", repo: "some-service", path: ".github/chainguard/trusted-token-issuers.yaml", want: false},
+		{name: "unrelated yaml", repo: "some-service", path: ".github/workflows/ci.yaml", want: false},
+		{name: "nested deeper", repo: "some-service", path: ".github/chainguard/sub/foo.sts.yaml", want: false},
+		{name: "readme", repo: ".github", path: "README.md", want: false},
+		// Both of these live in the policy directory of the .github repository —
+		// the one place BOTH arms of the predicate are live. They pin that the
+		// allowlist arm matches one exact path rather than widening the trust
+		// policy glob: neither carries the ".sts." infix, and neither is the
+		// allowlist, so both must be rejected or they would be fetched and
+		// parsed as TrustPolicies and fail the check run.
+		{name: "readme inside the policy directory of .github", repo: ".github", path: ".github/chainguard/README.md", want: false},
+		{name: "non-policy yaml inside the policy directory of .github", repo: ".github", path: ".github/chainguard/config.yaml", want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isValidatedPath(tc.repo, tc.path); got != tc.want {
+				t.Errorf("isValidatedPath(%q, %q) = %v, want %v", tc.repo, tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDirScanBranchFiltersPaths covers handleCheckSuite's zeroHash branch, which
+// lists the policy directory instead of diffing it. It previously appended every
+// entry unfiltered, which would parse the organization allowlist — and anything
+// else in the directory — as a TrustPolicy.
+func TestDirScanBranchFiltersPaths(t *testing.T) {
+	all := []string{
+		".github/chainguard/foo.sts.yaml",
+		".github/chainguard/trusted-token-issuers.yaml",
+		".github/chainguard/README.md",
+	}
+
+	got := filterValidatedFiles("some-service", all)
+	want := []string{".github/chainguard/foo.sts.yaml"}
+	if !slices.Equal(got, want) {
+		t.Errorf("filterValidatedFiles(some-service) = %v, want %v — the allowlist must not be validated outside .github", got, want)
+	}
+
+	got = filterValidatedFiles(".github", all)
+	want = []string{".github/chainguard/foo.sts.yaml", ".github/chainguard/trusted-token-issuers.yaml"}
+	if !slices.Equal(got, want) {
+		t.Errorf("filterValidatedFiles(.github) = %v, want %v", got, want)
+	}
+}
+
+// TestCheckSuiteDirScanSkipsNonPolicyFiles pins the PRODUCTION call site of the
+// zeroHash directory-listing branch, which TestDirScanBranchFiltersPaths does not
+// reach. The listing contains a README and the organization allowlist alongside a
+// trust policy; in an ordinary repository only the trust policy may be fetched and
+// parsed. Before filtering, the README and the allowlist were both fetched (404 in
+// this fixture) and the check run concluded "failure".
+func TestCheckSuiteDirScanSkipsNonPolicyFiles(t *testing.T) {
+	got := []*github.CreateCheckRunOptions{}
+	var fetched []string
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v3/repos/foo/bar/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		opt := new(github.CreateCheckRunOptions)
+		if err := json.NewDecoder(r.Body).Decode(opt); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		got = append(got, opt)
+	})
+	// The directory listing carries entries that are NOT trust policies.
+	mux.HandleFunc("GET /api/v3/repos/foo/bar/contents/.github/chainguard", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]*github.RepositoryContent{
+			{Type: github.Ptr("file"), Name: github.Ptr("test.sts.yaml"), Path: github.Ptr(".github/chainguard/test.sts.yaml")},
+			{Type: github.Ptr("file"), Name: github.Ptr("trusted-token-issuers.yaml"), Path: github.Ptr(".github/chainguard/trusted-token-issuers.yaml")},
+			{Type: github.Ptr("file"), Name: github.Ptr("README.md"), Path: github.Ptr(".github/chainguard/README.md")},
+		})
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/api/v3/repos/foo/bar/contents/") {
+			fetched = append(fetched, strings.TrimPrefix(r.URL.Path, "/api/v3/repos/foo/bar/contents/"))
+		}
+		path := filepath.Join("testdata", r.URL.Path)
+		f, err := os.Open(path)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		defer f.Close()
+		io.Copy(w, f)
+	})
+	gh := httptest.NewServer(mux)
+	defer gh.Close()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr := ghinstallation.NewAppsTransportFromPrivateKey(gh.Client().Transport, 1234, key)
+	tr.BaseURL = gh.URL
+
+	secret := []byte("hunter2")
+	v := &Validator{Transport: tr, WebhookSecret: [][]byte{secret}}
+	srv := httptest.NewServer(v)
+	defer srv.Close()
+
+	body, err := json.Marshal(github.CheckSuiteEvent{
+		Installation: &github.Installation{ID: github.Ptr(int64(1111))},
+		Repo: &github.Repository{
+			Owner:         &github.User{Login: github.Ptr("foo")},
+			Name:          github.Ptr("bar"),
+			FullName:      github.Ptr("foo/bar"),
+			DefaultBranch: github.Ptr("main"),
+		},
+		Sender: &github.User{Login: github.Ptr("test-user")},
+		Action: github.Ptr("requested"),
+		CheckSuite: &github.CheckSuite{
+			ID:           github.Ptr(int64(1)),
+			HeadSHA:      github.Ptr("deadbeef"),
+			HeadBranch:   github.Ptr("main"),
+			BeforeSHA:    github.Ptr(zeroHash),
+			PullRequests: []*github.PullRequest{},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest(http.MethodPost, srv.URL, bytes.NewBuffer(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Hub-Signature", signature(secret, body))
+	req.Header.Set("X-GitHub-Event", "check_suite")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req.WithContext(slogtest.Context(t)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		out, _ := httputil.DumpResponse(resp, true)
+		t.Fatalf("expected 200, got\n%s", string(out))
+	}
+
+	wantFetched := []string{".github/chainguard/test.sts.yaml"}
+	if !slices.Equal(fetched, wantFetched) {
+		t.Errorf("directory scan fetched %v, want %v — non-policy entries must not be validated", fetched, wantFetched)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 check run, got %d", len(got))
+	}
+	if *got[0].Conclusion != "success" {
+		t.Errorf("expected success, got %s: %s", *got[0].Conclusion, got[0].Output.GetSummary())
+	}
+}
+
+// TestValidateAllowlistContent checks that the webhook's validator runs the same
+// parse AND compile the exchange path runs, so a check-run verdict cannot
+// disagree with what happens at exchange time.
+func TestValidateAllowlistContent(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		raw     string
+		wantErr bool
+	}{
+		{
+			name: "valid",
+			raw: `
+issuers:
+  - https://token.actions.githubusercontent.com
+`,
+		},
+		{
+			name: "valid audit with pattern",
+			raw: `
+mode: audit
+issuer_patterns:
+  - https://oidc\.eks\.[a-z0-9-]+\.amazonaws\.com/id/[A-Z0-9]+
+`,
+		},
+		// UnmarshalStrict alone would accept these; only Compile() catches them.
+		{name: "uncompilable pattern", raw: "issuer_patterns:\n  - \"[unclosed\"\n", wantErr: true},
+		{name: "uppercase host", raw: "issuers:\n  - https://Accounts.Google.com\n", wantErr: true},
+		{name: "http non-loopback", raw: "issuers:\n  - http://evil.example.com\n", wantErr: true},
+		{name: "empty lists", raw: "mode: enforce\n", wantErr: true},
+		{name: "unknown mode", raw: "mode: off\nissuers:\n  - https://a.example.com\n", wantErr: true},
+		// The singular spelling is the typo the plural field names invite.
+		{name: "singular issuer_pattern", raw: "issuer_pattern:\n  - https://a\\.example\\.com\n", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := octosts.ParseOrgTrustedIssuers([]byte(tc.raw))
+			if tc.wantErr && err == nil {
+				t.Fatal("ParseOrgTrustedIssuers() = nil error, want an error")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("ParseOrgTrustedIssuers() = %v, want nil", err)
+			}
+		})
+	}
+}
+
+// runAllowlistCheckSuite drives the real check-run path over a fake GitHub for a
+// check_suite on the default branch of org repository ".github", whose policy
+// directory contains nothing but the trusted-issuer allowlist with the given
+// contents. It returns the check runs created and the content paths fetched.
+func runAllowlistCheckSuite(t *testing.T, allowlist string) ([]*github.CreateCheckRunOptions, []string) {
+	t.Helper()
+
+	got := []*github.CreateCheckRunOptions{}
+	var fetched []string
+
+	const allowlistPath = ".github/chainguard/trusted-token-issuers.yaml"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v3/repos/foo/.github/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		opt := new(github.CreateCheckRunOptions)
+		if err := json.NewDecoder(r.Body).Decode(opt); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		got = append(got, opt)
+	})
+	mux.HandleFunc("GET /api/v3/repos/foo/.github/contents/.github/chainguard", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode([]*github.RepositoryContent{
+			{Type: github.Ptr("file"), Name: github.Ptr("trusted-token-issuers.yaml"), Path: github.Ptr(allowlistPath)},
+		}); err != nil {
+			t.Error(err)
+		}
+	})
+	mux.HandleFunc("GET /api/v3/repos/foo/.github/contents/"+allowlistPath, func(w http.ResponseWriter, _ *http.Request) {
+		fetched = append(fetched, allowlistPath)
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(&github.RepositoryContent{
+			Type:     github.Ptr("file"),
+			Name:     github.Ptr("trusted-token-issuers.yaml"),
+			Path:     github.Ptr(allowlistPath),
+			Encoding: github.Ptr("base64"),
+			Content:  github.Ptr(base64.StdEncoding.EncodeToString([]byte(allowlist))),
+		}); err != nil {
+			t.Error(err)
+		}
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/api/v3/repos/foo/.github/contents/") {
+			fetched = append(fetched, strings.TrimPrefix(r.URL.Path, "/api/v3/repos/foo/.github/contents/"))
+		}
+		path := filepath.Join("testdata", r.URL.Path)
+		f, err := os.Open(path)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		defer f.Close()
+		io.Copy(w, f)
+	})
+	gh := httptest.NewServer(mux)
+	defer gh.Close()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr := ghinstallation.NewAppsTransportFromPrivateKey(gh.Client().Transport, 1234, key)
+	tr.BaseURL = gh.URL
+
+	secret := []byte("hunter2")
+	v := &Validator{Transport: tr, WebhookSecret: [][]byte{secret}}
+	srv := httptest.NewServer(v)
+	defer srv.Close()
+
+	body, err := json.Marshal(github.CheckSuiteEvent{
+		Installation: &github.Installation{ID: github.Ptr(int64(1111))},
+		Repo: &github.Repository{
+			Owner:         &github.User{Login: github.Ptr("foo")},
+			Name:          github.Ptr(".github"),
+			FullName:      github.Ptr("foo/.github"),
+			DefaultBranch: github.Ptr("main"),
+		},
+		Sender: &github.User{Login: github.Ptr("test-user")},
+		Action: github.Ptr("requested"),
+		CheckSuite: &github.CheckSuite{
+			ID:           github.Ptr(int64(1)),
+			HeadSHA:      github.Ptr("deadbeef"),
+			HeadBranch:   github.Ptr("main"),
+			BeforeSHA:    github.Ptr(zeroHash),
+			PullRequests: []*github.PullRequest{},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest(http.MethodPost, srv.URL, bytes.NewBuffer(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Hub-Signature", signature(secret, body))
+	req.Header.Set("X-GitHub-Event", "check_suite")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req.WithContext(slogtest.Context(t)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		out, _ := httputil.DumpResponse(resp, true)
+		t.Fatalf("expected 200, got\n%s", string(out))
+	}
+	return got, fetched
+}
+
+// TestCheckSuiteAllowlistValidConcludesSuccess pins the PRODUCTION dispatch in
+// validatePolicies. A valid allowlist is NOT a valid TrustPolicy (nor a valid
+// OrgTrustPolicy), so before the allowlist arm existed this concluded "failure"
+// on a perfectly good file.
+func TestCheckSuiteAllowlistValidConcludesSuccess(t *testing.T) {
+	got, fetched := runAllowlistCheckSuite(t, `mode: audit
+issuers:
+  - https://token.actions.githubusercontent.com
+issuer_patterns:
+  - https://oidc\.eks\.[a-z0-9-]+\.amazonaws\.com/id/[A-Z0-9]+
+`)
+
+	wantFetched := []string{".github/chainguard/trusted-token-issuers.yaml"}
+	if !slices.Equal(fetched, wantFetched) {
+		t.Errorf("fetched %v, want %v", fetched, wantFetched)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 check run, got %d", len(got))
+	}
+	if *got[0].Conclusion != "success" {
+		t.Errorf("expected success, got %s: %s", *got[0].Conclusion, got[0].Output.GetSummary())
+	}
+}
+
+// TestCheckSuiteAllowlistInvalidConcludesFailure proves the dispatch COMPILES
+// rather than merely unmarshalling. "[unclosed" is a well-formed YAML string, so
+// yaml.UnmarshalStrict into OrgTrustedIssuers accepts it; only Compile() rejects
+// it. A dispatch that only unmarshalled would pass the valid test above and fail
+// this one.
+func TestCheckSuiteAllowlistInvalidConcludesFailure(t *testing.T) {
+	got, _ := runAllowlistCheckSuite(t, "issuer_patterns:\n  - \"[unclosed\"\n")
+
+	if len(got) != 1 {
+		t.Fatalf("expected 1 check run, got %d", len(got))
+	}
+	if *got[0].Conclusion != "failure" {
+		t.Errorf("expected failure, got %s: %s", *got[0].Conclusion, got[0].Output.GetSummary())
+	}
+	if !strings.Contains(got[0].Output.GetSummary(), "invalid issuer_pattern") {
+		t.Errorf("summary %q does not mention the uncompilable pattern — the file may have been merely unmarshalled", got[0].Output.GetSummary())
 	}
 }


### PR DESCRIPTION
Closes #900. Closes #1546.

Three residual limitations in installation enumeration move to #1550. Each one fails safe today, and #1550 records which assumption each one rests on.

This replaces the original implementation in this PR entirely. The previous approach could not work as written, and the reasons shaped the design that follows — see [Why this is a rewrite](#why-this-is-a-rewrite).

## What it does

An organization restricts which OIDC issuers may federate with any of its repositories by committing `.github/chainguard/trusted-token-issuers.yaml` to its `.github` repository:

```yaml
# yaml-language-server: $schema=https://raw.githubusercontent.com/octo-sts/app/refs/heads/main/pkg/octosts/octosts.OrgTrustedIssuers.json

mode: audit                 # enforce (default) | audit

issuers:
  - https://token.actions.githubusercontent.com
  - https://tenant.us.auth0.com/          # a trailing slash is a distinct issuer

issuer_patterns:
  - https://oidc\.eks\.[a-z0-9-]+\.amazonaws\.com/id/[A-Z0-9]+
```

When the file is present, a token whose issuer is not permitted is rejected **before its trust policy is read**. `issuers` matches exactly; `issuer_patterns` are anchored regular expressions that must match the whole URL; an issuer passes if it matches either list.

**No file means no restriction.** Behavior is unchanged for every organization that does not add one.

The problem this addresses: today anyone who can write a trust policy in any repository can point `issuer:` at an identity provider they control. The org owner has no way to constrain that centrally.

## Why this is a rewrite

The original implementation here had two defects that could not be patched around:

1. **It read the config with the App JWT.** An App JWT authenticates the App, not an installation, and cannot read repository contents. The lookup could never have succeeded against real GitHub.
2. **It failed open on every error.** Any GitHub error — including a rate limit — silently disabled enforcement. A control that an attacker can switch off by inducing an error is not a control.

Fixing (1) means minting an installation token on the token-exchange hot path, which forces an explicit decision at every failure mode rather than one blanket fallback. That is most of what this PR is.

## Design

**A dedicated file, presence as the switch.** No new field on `OrgTrustPolicy`, no operator configuration to enable it. Committing the file turns it on; deleting it turns it off. This keeps the control legible to an org owner reading their own repository, at the cost that deleting the file fails open (see Hardening in the README).

**`audit` mode for rollout.** In audit mode nothing is rejected; each token that *would* have been rejected is logged and recorded on the exchange event as `issuer_allowlist`, so an org can confirm the list is complete before enforcing. This is the only safe way to adopt the feature on a busy org.

**One parse path for both consumers.** `octosts.ParseOrgTrustedIssuers` unmarshals strictly *and* compiles. Both the exchange path and the webhook check run call it, so a green check run cannot disagree with what happens at exchange time. `pkg/webhook` also uses the exported `octosts.OrgTrustedIssuersPath` rather than its own copy of the path.

**Least-privilege read.** The file is read with a short-lived token scoped to exactly `{repositories: [".github"], permissions: {contents: read}}`. That scope is pinned by a test which decodes the minted token request off the wire, so widening it fails CI.

**GitHub Enterprise Server.** The allowlist read honors the configured API base URL from #1400. Getting this wrong is not a cosmetic bug: a read that goes to `api.github.com` on a GHES deployment fails, is classified as "this installation cannot see `.github`", and therefore permits every issuer — a fail-open across the entire deployment. Rebasing onto #1400 is what surfaced it, since nothing in the test suite could: the fakes inject a transport that rewrites requests to a local server, so the base URL is never consulted. The four duplicated client-construction blocks that allowed a fourth copy to drift are collapsed into one `newGitHubClient` helper, with a test enforcing it is the package's only constructor — split out and merged as #1529, since it is a refactor of pre-existing duplication.

**Patterns are anchored *and* boundary-checked.** Anchoring the ends is not sufficient — a pattern loose in the middle bypasses the control regardless. Every single-character atom in an `issuer_patterns` entry is therefore tested against `/`, and the pattern is rejected if any atom can match one. That is decided empirically (compile the atom, test it) rather than by banning named constructs, because an explicit range such as `[.-9]` contains `/` at 0x2F and no blacklist of names would catch it. Literal `/` is fine, so a path is written one segment at a time. **This is a best-effort guard against accidents, not a security boundary**

**Four bypasses in this guard were found and fixed by an adversarial review pass, and the guard now fails closed.** Each of these passed validation while matching `/`:

```
https://[^]]+\.example\.com      permitted https://evil.com/x.example.com
https://a\x2Fb\.example\.com     permitted https://a/b.example.com
https://a\x{2F}b\.example\.com   permitted https://a/b.example.com
https://a\057b\.example\.com     permitted https://a/b.example.com
```

Two parsing gaps: RE2 reads a `]` in the first position of a class as a literal member, so `[^]]` is "any byte except `]`" — but the scanner stopped at that first `]` and extracted the uncompilable `[^]`. And `\x2F` / `\x{2F}` / `\057` *spell* a character rather than naming a class, so they fell to the escaped-literal branch, which skipped two bytes and left the digits as unexamined literal text.

The root cause mattered more than either gap: on a failed compile of the extracted atom, the scanner did `continue`. A validator that silently skips what it cannot parse is fail-**open**, so every present and future parsing gap was a bypass by the same route. An unanalyzable atom now rejects the pattern, and `TestCompileFailsClosedOnAnAtomItCannotAnalyze` pins that posture rather than any one syntax. All four cases are rows in the existing bypass table, which asserts each pattern really does match its demonstration issuer so no row can go vacuous. Verified against false rejections: literal-`]` classes, POSIX classes, and the real EKS and Keycloak patterns from the fixtures and README all still pass.

Worth being straight about the severity: since the file is written by the org owner, this was not attacker-controlled input, so it was a footgun rather than a remote bypass. But the docs told an owner that every atom is tested against `/` and the pattern rejected if any can match one, and that was not true — so a validated pattern carried trust it had not earned. — the file is written by an org owner, the principal the control serves, so an over-broad pattern is an unwise choice rather than an attack. See [Adversarial review](#adversarial-review).

### Failure modes

Every one of these is a deliberate choice, and the fail-open ones are the load-bearing part of the review:

| Situation | Result |
|---|---|
| File absent (definitive 404) | All issuers permitted |
| No installation can read `.github` | All issuers permitted, logged as a warning |
| Rate limited / GitHub unavailable | Last known good allowlist; if none, exchange rejected (`ResourceExhausted`) |
| File present but invalid | Last known good allowlist; if none, every exchange in the org rejected (`FailedPrecondition`) |
| Enumeration incomplete or partly failed | Last known good; if none, exchange rejected (`Unavailable`) |

The distinction that makes this sound: **`Absent` requires positive knowledge.** It is cached only from a definitive 404, or from an exhaustive enumeration in which *every* installation reported it cannot read `.github`. "Every installation agrees it cannot see the file" is a known state and falls open. "We could not establish that" is unknown and falls closed. A partial or failed enumeration is never cached.

Two timing consequences worth knowing before adopting: after *narrowing* an allowlist, the previous broader list can still be served for up to an hour whenever GitHub errors; and after *fixing* an invalid file, rejections can persist for up to five minutes while the cached result expires.

### Why enumerate installations rather than route to one

`ghinstall.Manager.Get` is a routing primitive and cannot enumerate — see #1527 for the full mechanics. Briefly: with warm quota data `pickFromPool` selects `argmax(remaining)` within a tier, deterministically and without rotation; without it the shared counter rotates but guarantees no coverage under concurrency; and the multi-app fallback fires only on `codes.NotFound`, not on the 422 a `.github`-scoped mint returns when the App lacks access. A retry loop built on it could see one blind installation N times and conclude that no installation can read `.github` — caching allow-all for the whole organization.

`Manager.GetAll`, split out as #1525, provides exhaustive enumeration. Its contract is explicit that a non-nil error means the enumeration is **not** exhaustive even when the returned slice is non-empty, because callers that need exhaustiveness for correctness must treat that as unknown. `TestLookupSurvivesOneBlindInstallation` is the regression test: the first installation cannot read `.github`, a second can and holds an enforcing allowlist, and because `Get` always returns the first, only an enumeration-based lookup finds the second.

### On `GetAll` being exhaustive only over observed state

The review note about this has two parts, and both are **already handled here**.

A nil error with an empty result is not read as absence: `exhaustiveNoAccess` requires at least one installation to have answered, because with none the count comparison degenerates to `0 == 0` and would grant allow-all off no evidence at all. And per-installation read errors already fail closed — only an explicit "cannot see `.github`" counts toward agreement, so any failure or rate-limit leaves the enumeration non-exhaustive and the exchange is rejected.

Working on that, I found a **third** case neither of us named: a non-empty but *incomplete* enumeration. `manager.GetAll` maps a `NotFound` to `(nil, nil)`, and a `NotFound` served from its five-minute negative cache is indistinguishable from a real one — so an org running App A (which cannot read `.github`) that installs App B to turn enforcement **on** gets `([A], nil)` for up to five minutes: non-empty, nil error, silently missing B. Every installation it can see reports no access, so allow-all is cached org-wide at exactly the wrong moment.

**That fix is deliberately not in this PR**, and is tracked by #1546. It needs `GetAllFresh` from #1543, and including it would make this PR unmergeable until #1543 lands. It is a self-contained ~350-line change that I will open as a follow-up once #1543 and this PR are both in, so all three review independently. Until then, adopting this feature carries that five-minute window; it is bounded, it self-heals, and it is strictly better than the status quo of no allowlist at all.

## Split out of this PR

Per @jmeridth's request, the independently-reviewable pieces are now their own PRs. Each is mergeable on its own and green standalone. **Suggested review order: #1524, #1529, #1531, #1525, then this one** — the first four are small and independent, and this PR's diff shrinks to just the feature once they land.

**All four are now merged, and this branch has been rebased onto current `main`.** Their commits are out of this diff.

**A fifth is split out: #1543** — `pkg/ghinstall`'s `GetAllFresh` plus a negative-cache shadowing fix, 476 lines across 4 files. (I had described that fix as "reachable on `main` today"; it is not, sequentially — see #1543 for the correction. It is a prerequisite for `GetAllFresh` rather than a standalone bug fix.) Same reasoning as #1525: an enumeration primitive plus a routing-cache bug, neither of which mentions trusted issuers.

**This PR should merge BEFORE #1543.** I originally wrote "either order" here and that was wrong — I verified it by actually merging them both ways locally, and whichever goes second leaves `main` with a broken test build:

#1543 adds `GetAllFresh` to the `ghinstall.Manager` interface. This PR adds two fakes that implement `Manager` (`enumMgr` and `notInstalledMgr`, in a file that does not exist on `main`, so #1543 cannot stub them). Once both are in, those fakes no longer satisfy the interface:

```
vet: org_trusted_issuers_store_test.go:786: cannot use (*enumMgr)(nil) as ghinstall.Manager
     value in variable declaration: *enumMgr does not implement ghinstall.Manager
     (missing method GetAllFresh)
```

Worth stressing how quietly this fails: `go build ./...` passes either way, there is no textual conflict, and GitHub reports both PRs MERGEABLE. Only the test build breaks, so the first merge is green and the damage appears on the second.

The fix is small and belongs to #1543, not here: after this PR merges, #1543 adds the two stub methods to `org_trusted_issuers_store_test.go` — which by then exists on `main`, and where they are *used* (they satisfy the interface #1543 itself introduces), so they do not trip the `unused` linter. They cannot be added here preemptively for exactly that reason: without #1543's interface method they are unused methods on unexported types, which fails `golangci-lint`.

Reviewing the two independently is still fine. It is only the merge order that is constrained.

The one piece that needed both PRs — the confirmation step described above — is held back for a follow-up rather than coupling them.

This PR is also squashed to **4 commits**, each of which builds and passes its tests on its own, so the change is readable in stages and bisectable.

Three of the rebase conflicts needed a judgement call rather than a mechanical resolution, and are worth knowing about when reading the diff:

- **`isValidatedPath`** — `main`'s version from #1531 is the feature-stripped one; this branch's takes a `repo` argument and also matches the org allowlist path. I kept `main`'s nested-`if` call sites and its richer comments and added only the argument, so the diff shows the feature rather than a restyle.
- **`pkg/octosts/client_test.go`** — resolved as an add/add. `main`'s version is a strict superset, so I took it wholesale.
- **`TestIsValidatedPath`** — this branch's repo-aware version replaces `main`'s, but had dropped two of `main`'s rows (a `README.md` and a non-policy `.yaml` inside `.github/chainguard`). I restored both, pointed at the `.github` repository where *both* arms of the predicate are live. Without them, loosening the allowlist check to a `.github/chainguard/*.yaml`-style glob would pass every test in the suite.

| PR | Issue | What |
|---|---|---|
| #1524 | #1526 | Rate-limit classification fix. A pre-existing bug: a real primary rate limit yields `*github.RateLimitError`, which does not unwrap to `*github.ErrorResponse`, so the stale-cache fallback and cross-app retry were both dead in production. |
| #1525 | #1527 | `ghinstall.Manager.GetAll`. `Get` is a routing primitive and cannot enumerate, so a caller surveying installations can be answered by the same one repeatedly. |
| #1529 | #1528 | One GitHub client constructor in `pkg/octosts`. The duplicated construction block is what let a fourth copy drift and lose the GHES base URL — a defect no test could catch, since the fakes bypass the base URL entirely. |
| #1531 | #1530 | Webhook path-predicate consolidation, plus filtering the unfiltered directory scan. **Contains the behavior change** described below. |

## Behavior change to an existing path

`handleCheckSuite`'s new-branch/initial-commit path listed `.github/chainguard` and validated **every** entry with no filtering. It now filters through the same predicate as every other path. A file in that directory that is not a trust policy — a `README.md`, for instance — was previously fetched and parsed as a `TrustPolicy`; now it is skipped. This is a fix, but it is a behavior change on a pre-existing path and worth flagging explicitly.

The five inline `filepath.Match` sites are also consolidated into one `isValidatedPath(repo, path)` predicate, which is now the only glob in `pkg/webhook`.

## Resolved: `.vscode/settings.json` is untouched

**This PR no longer changes `.vscode/settings.json`** — it is reverted to `main` and out of the diff, per @jmeridth's call.

And a correction to my earlier reasoning here, which was wrong: I claimed the README points at the settings file. It does not. Since #1270 the README recommends the inline `# yaml-language-server: $schema=...` header, and the examples use it directly — so there was never a README dependency on the committed editor config to keep in step.

What the allowlist gets instead is that same inline header: on the README example, and now on all four testdata fixtures pointing at `octosts.OrgTrustedIssuers.json`. While adding those I also gave the fixtures the copyright headers every other testdata YAML in the repo carries and which I had omitted.

Removing `.vscode/settings.json` from the repo entirely — now redundant with the inline-header approach, and editor-specific — is tracked separately by @jmeridth rather than smuggled in here.

One consequence worth stating plainly, since it is a real if minor regression I am choosing not to fix here: `main`'s glob is `/.github/chainguard/*`, which matches everything in that directory. So for anyone still using the committed settings file, an editor will validate `trusted-token-issuers.yaml` against the **TrustPolicy** schema and report errors on a valid file. The inline header in the fixtures and the README example takes precedence in vscode-yaml, so following the documented approach avoids it; the separate removal issue closes it properly.

## Deliberately out of scope

**An operator-level env var** (the deployment-wide equivalent) is left to #1396. This PR is org-owner-controlled configuration only. The reasoning: authorization at the org-owner level already governs who can write `org/.github`, so the org-level file is coherent on its own, and the two features have different threat models and different audiences.

## Testing

Every behavioral claim above has a test, and the tests were validated by mutation testing rather than by coverage: for each security-relevant branch, the implementation was deliberately broken to confirm a test actually fails. That process found several tests that passed under both the correct and the broken implementation, and those were rewritten. Notable examples now pinned:

- a contents 403 is one installation's blindness, not org-wide absence
- a stale `Absent` entry is never substituted for a currently-invalid config (that would convert a broken file into allow-all)
- one blind installation plus one failed request is `Unavailable`, not `Absent`
- the definitive-404 path resolves to `Absent` — the default state of every org that has not adopted the feature
- the minted token scope is exactly `.github` + `contents: read`
- the allowlist verdict is cached, asserted by observed GitHub read count rather than by cache occupancy
- an audit-mode decision reaches the emitted CloudEvent, which is the only operator-visible signal for a pass-through
- an `issuer_patterns` entry cannot use a wildcard that crosses a DNS label or a path separator, asserted against the concrete issuers such a pattern would otherwise permit

`go test ./... -race`, `-shuffle=on`, `gofmt`, `go vet`, and `golangci-lint run ./...` (`0 issues`) all pass.

## Adversarial review

I ran several independent adversarial reviews over the finished branch, each briefed to attack the design rather than hunt for defects. **Every one of them flagged the issuer-pattern matcher as the weakest point, and every one found something there** — the guard has now been revised four times, and each revision changed approach rather than lengthening a blacklist. The remaining objections are design trade-offs worth your judgement; I have not silently overruled them.

### Models used

| Pass | Model | Outcome |
|---|---|---|
| Design review, pre-split | `opus-5` (xhigh) | Flagged the matcher; drove the first two revisions (anchoring, then per-atom boundary checking) |
| Adversarial, full branch | `gpt-5.6-sol` (high) | No defect introduced by the change; two pre-existing findings, both now in the follow-ups list |
| Adversarial, full branch | `kimi-k3` (max) | **REQUEST CHANGES.** Found the `[[:/-~]` bypass, the read-403 misclassification, and the webhook case-fold asymmetry |

The second `kimi-k3-max` run was briefed that the first four bypasses were already fixed and told to look for a fifth that the fail-closed posture would not catch — which is what it found. It also investigated the >1 MB contents-file path and explicitly declined to report it, having confirmed GitHub returns 200 with `encoding: "none"` so the code already fails closed. I mention that because a review that reports its negatives is worth more than one that doesn't.

Six pattern bypasses were found and fixed in total: unanchored matching, top-level alternation, atoms that match `/` by name or by range, the leading-`]` class, numeric escapes spelling `/`, an unbalanced `)` escaping the anchoring group, and `[:` without `:]`. The pattern that emerged is that **per-atom analysis is only sound while the scanner tokenizes the way RE2 does** — four of the six were tokenization divergences, not missing cases, which is why the guard now also fails closed on any atom it cannot compile.

### Fixed twice: operator-written patterns could cross DNS and path boundaries

An operator writing what reads as "any subdomain of example.com":

```yaml
issuer_patterns:
  - https://.*.example.com
```

also permitted `https://evil.attacker-example.com` (`.*` consumes `evil.attacker`, and the unescaped `.` matches the `-`) and `https://totally-evil.com/x?a=example.com` (`.*` crosses the `/` too). Both verified returning `true` before the fix. A repository writer could then point their trust policy at that attacker-controlled issuer and defeat the org control entirely — via the most natural way to express the intent.

`Compile()` now rejects `.` used as a wildcard, with an error naming the pattern index, the two issuers it would wrongly permit, and the corrected form. The more likely real-world shape is also covered: `https://[a-z0-9-]+.example.com`, where an operator has bounded the varying label but not escaped the separator, permits the registrable `https://evil-example.com`.

**The first fix banned `.` and was not enough.** The second review showed four more spellings of "any character" that passed it and matched `https://totally-evil.com/x.example.com` — `\S+`, `[\s\S]+`, `[^\n]+`, `[[:ascii:]]+` — all verified. Worse, my error message told operators to use "an explicit character class", and two of those *are* explicit character classes. The guard advertised protection it did not provide.

So the approach changed: rather than enumerate dangerous constructs, each single-character atom is compiled standalone and tested against `/`. Measured results — `\D \S \W \p{P} \P{L}` and the POSIX `ascii`, `punct`, `graph`, `print` classes match `/`; `\d \s \w \p{L}`, `alpha`, `lower`, `alnum`, `digit` do not. All six known bypasses are now rejected and both real-world patterns (the EKS and Microsoft ones, each containing literal slashes) still compile and still match.

**The cost, stated plainly:** a variable-depth path can no longer be expressed. `https://example\.com/[a-z0-9/-]+` is rejected, because that class contains `/`. Per-segment patterns like `https://example\.com/realms/[a-z0-9-]+` work and are more precise, and the error message and README now say so — but an operator who genuinely needs variable depth has no way to write it.

### Not adopted, with reasons

**"An empty enumeration caches `Absent` from no evidence."** Accepted and fixed — `noAccess == len(installs)` was satisfied by `0 == 0`, so a manager disagreement that returned no installations would have cached allow-all. The positive-knowledge branch now requires `len(installs) > 0`.

**"Treat all-no-access as unknown and fail closed; do not put `Absent` in the stale cache."** The fail-open-on-`Absent` posture is deliberate, and the second half of this recommendation would cause outages for orgs that have *not* adopted the feature: no file ⇒ `Absent` cached ⇒ GitHub rate-limits ⇒ no stale entry eligible to serve ⇒ every exchange in that org denied. That is the overwhelmingly common case, so `Absent` must remain valid last-known-good. The narrow risk that remains is real and worth stating: an org that adds its *first* allowlist while GitHub is degraded can serve the previous `Absent` for up to an hour before enforcing.

One correction to my own earlier reasoning here, since the review was right to probe it: `expirable.LRU.Get` never extends a TTL, but `Add` resets it, and `cacheOrgIssuerEntry` writes `Absent` to *both* caches. So the one-hour last-known-good clock runs from the last **successful read** — including a successful `Absent` — not from first observation. Serving a stale entry does not extend it; deriving a fresh verdict does.

**"`GetAll` is a cached routing inventory, not authoritative — don't use it as security evidence."** Correct, and `Manager.GetAll`'s doc comment says so explicitly: the positive cache has no TTL, so an uninstalled App keeps appearing and a newly installed one stays hidden until a negative entry expires. After an uninstall/reinstall the stale installation can 422 while the one that could read the real policy is omitted, feeding the fail-open path. Making enumeration authoritative means invalidating on installation webhooks — a real change I did not want to smuggle into this PR. The operator-level ceiling in #1396 is the right backstop, and is one reason to want it.

**Partly addressed since.** The confirmation step above closes the half of this that was reachable: the negative cache can no longer hide a just-installed App from the allow-all decision, because that decision is now re-checked without it. The half that remains is the positive cache having no TTL, so an uninstalled App can still be enumerated and 422 — which counts as a failure and therefore fails closed, not open. Invalidating on installation webhooks is still the real fix and still out of scope here.

**"Replicas can diverge; the caches are process-local globals."** True. Two replicas can briefly enforce different modes. This matches the existing `trustPolicies`/`staleTrustPolicies` design rather than introducing a new pattern, so fixing it is a broader change than this feature.

**"No singleflight — the exchange path can stampede GitHub on cache expiry."** True, and the sharpest of the operational objections. Every primary-cache miss enumerates installations and then mints, reads, and revokes per installation, with no coordination between concurrent exchanges. `fetchTrustPolicyRaw` has the same shape, but this adds a *second* GitHub dependency to the same path and consumes the same quota. A per-org singleflight would be a contained follow-up; I did not add a new dependency at this stage.

## Follow-ups found while working, not fixed here

Each is pre-existing and out of scope; happy to file separately:

1. **`TrustPolicy.Compile` anchors patterns as `"^" + p + "$"`** (`trust_policy.go:72,86,98,108`). `|` binds looser than the anchors, so a pattern containing a top-level alternation parses as `(^A)|(B$)` and is effectively unanchored — a bypass using a pattern that reads as safe. This PR's own matcher uses `"^(?:" + p + ")$"` for exactly this reason, so the two now differ.
2. **`validatePolicies` compares `repo == ".github"` exactly** for org trust policies. An org whose `.github` repo GitHub reports as `.Github` gets its org policies parsed as repo-level `TrustPolicy` — the same class of bogus failure this PR fixes for the allowlist. The new allowlist arm folds case; the pre-existing arm was left alone.
3. **`TrustPolicy` validates the raw `token.Issuer`**, so a schemeless `iss: accounts.google.com` is rejected even though `auth.NormalizeIssuer` and go-oidc deliberately accommodate it.
4. **The stale-entry path can re-cache `Absent` without confirming it, extending the documented one-hour window by up to one primary TTL.** Serving a stale entry re-inserts it into the five-minute cache, so an `Absent` that entered both caches at `t=0` can still be served at roughly `t=64:59` — the stale entry expires at `t=60:00` but the reseeded primary outlives it. The one-hour fail-open is deliberate and documented; the extra five minutes is an artifact of reseeding. Capping the reseed at the stale entry's original expiry, or serving stale without reseeding, would fix it. **Relevant to the confirmation fix above:** an org that was previously confirmed-`Absent` and then installs an App to enable enforcement can sit on served-stale allow-all through a `GetAllFresh` outage, because the stale path runs before any confirmation. I left it alone because it is pre-existing and changing it alters behavior this PR has not been reviewed for, but it is the natural next step if the confirmation is considered worth having.
5. **`manager`'s cache pair has a lost-update race** (`ghinstall.go`). Now handled in **#1543**, which narrows the window and documents the remaining gap rather than claiming to close it. Noted here because it was found while working on this PR.

## Verification

`golangci-lint run ./...` reports zero issues, `go test ./...` passes across all packages, and `go test -race` is clean on `pkg/octosts`, `pkg/ghinstall`, and `pkg/webhook`. Every function added by the confirmation fix is at 100% statement coverage: `exhaustiveNoAccess`, `record`, `installsNotIn`, `scanInstalls`, `confirmNoAccess`, `orgIssuerLookup`. (`GetAllFresh`, `enumerate`, and `cacheKey` are also at 100%, and are covered by #1543.)

The security-critical predicates were mutation-tested rather than assumed covered — for each, the term was removed and the suite confirmed to fail: the confirmation call itself, the `installsNotIn` argument order, passing the same tally to the second pass rather than a fresh one, the "at least one answered" guard, the "GetAll reported itself complete" guard, and the negative-entry removal in `setInstalled`. One term, the redundant `!anyFailed` conjunct, is deliberately *not* detectable by mutation: it is a semantic no-op today, retained as defense-in-depth against a future edit that stops counting an unanswered installation, and its comment says exactly that.

An adversarial review pass over the change found no defect introduced by it, having attacked the two-pass tally arithmetic, installation-ID dedup and reinstall IDs, empty/subset/superset enumerations, partial and duplicate-App enumerations, 403/404/422 mint and contents classification, and the webhook path matching. Items 4 and 5 above are what it surfaced instead, both pre-existing.

One note on reading the history: `installsNotIn` is added in one commit, deleted in the next, and re-added later. That is not a mistake — it was originally introduced a commit before its caller, which fails `golangci-lint`'s `unused` check, so it was moved to land with the code that calls it. Happy to squash the review fix-ups if you would rather review a linear five-commit series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)










