### PR TITLE
Drop noisy logging

### DIFF
--- a/pkg/octosts/octosts.go
+++ b/pkg/octosts/octosts.go
@@ -71,7 +71,7 @@ type cacheTrustPolicyKey struct {
 
 // Exchange implements pboidc.SecurityTokenServiceServer
 func (s *sts) Exchange(ctx context.Context, request *pboidc.ExchangeRequest) (_ *pboidc.RawToken, err error) {
-	clog.FromContext(ctx).Infof("exchange request: %#v", request)
+	clog.FromContext(ctx).Infof("exchange request: %#v", request.GetIdentity())
 	e := Event{
 		Scope:    request.Scope,
 		Identity: request.Identity,

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -89,7 +89,7 @@ func (e *Validator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err != nil {
-		log.Errorf("error handling event %T: %v", event, err)
+		log.Errorf("error handling event: %v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -245,7 +245,6 @@ func (e *Validator) handlePush(ctx context.Context, event *github.PushEvent) (*g
 	if err != nil {
 		return nil, err
 	}
-	log.Infof("%+v\n%+v", resp, resp.Files)
 	var files []string
 	for _, file := range resp.Files {
 		if ok, err := filepath.Match(".github/chainguard/*.sts.yaml", file.GetFilename()); err == nil && ok {


### PR DESCRIPTION
We've got a few sources of noisy logs; this PR cleans them up so that we aren't emitting hundreds of thousands of logs per hour.