### PR TITLE
feat: Optional EVENT_INGRESS_URI

### DIFF
--- a/pkg/envconfig/envconfig.go
+++ b/pkg/envconfig/envconfig.go
@@ -20,7 +20,7 @@ type EnvConfig struct {
 
 type EnvConfigApp struct {
 	Domain          string `envconfig:"STS_DOMAIN" required:"true"`
-	EventingIngress string `envconfig:"EVENT_INGRESS_URI" required:"true"`
+	EventingIngress string `envconfig:"EVENT_INGRESS_URI" required:"false"`
 }
 
 type EnvConfigWebhook struct {

--- a/pkg/nopceclient/nopceclient.go
+++ b/pkg/nopceclient/nopceclient.go
@@ -1,0 +1,22 @@
+package nopceclient
+
+import (
+	"context"
+
+	"github.com/cloudevents/sdk-go/v2/event"
+	"github.com/cloudevents/sdk-go/v2/protocol"
+)
+
+type Client struct{}
+
+func (n Client) Send(_ context.Context, _ event.Event) protocol.Result {
+	return nil
+}
+
+func (n Client) Request(_ context.Context, _ event.Event) (*event.Event, protocol.Result) {
+	panic("implement me")
+}
+
+func (n Client) StartReceiver(_ context.Context, _ interface{}) error {
+	panic("implement me")
+}


### PR DESCRIPTION
## WHAT

- Add `nopceclient` which does nothing, as a dummy CloudEvents client
- Make it use the dummy client when when `METRICS` is set to `false`

## WHY
CloudEvents logging is not essential to run the service. This is for who wanna run the service with minimum requirements.

## ISSUE
#949 