### PR TITLE
set require_team to false in the gclb

### DIFF
--- a/iac/gclb.tf
+++ b/iac/gclb.tf
@@ -42,4 +42,6 @@ module "serverless-gclb" {
       name = module.app.webhook.name
     }
   }
+
+  require_team = false
 }


### PR DESCRIPTION

https://github.com/octo-sts/app/actions/runs/16491677451/job/46627834124

```
╷
│ Error: Invalid value for variable
│ 
│   on  line 0:
│   (source code not available)
│ 
│ team needs to specified or disable check by setting require_team = false
│ 
│ This was checked by the validation rule at
│ .terraform/modules/serverless-gclb/modules/serverless-gclb/variables.tf:65,3-13.
╵
```