### PR TITLE
fix prober missing variable

### DIFF
--- a/iac/prober.tf
+++ b/iac/prober.tf
@@ -21,6 +21,7 @@ module "prober" {
     STS_DOMAIN = "octo-sts.dev"
   }
 
+  require_team          = false
   enable_alert          = true
   notification_channels = local.notification_channels
 }
@@ -48,13 +49,15 @@ module "negative_prober" {
     STS_DOMAIN = "octo-sts.dev"
   }
 
+  require_team          = false
   enable_alert          = true
   notification_channels = local.notification_channels
 }
 
 module "dashboard" {
-  source       = "chainguard-dev/common/infra//modules/dashboard/service"
-  version      = "0.6.170"
+  source  = "chainguard-dev/common/infra//modules/dashboard/service"
+  version = "0.6.170"
+
   service_name = var.name
   project_id   = var.project_id
 


### PR DESCRIPTION
https://github.com/octo-sts/app/actions/runs/16516427124/job/46708348733


```
Invalid value for variable

on  line 0:
  (source code not available)

team needs to specified or disable check by setting require_team = false

This was checked by the validation rule at
.terraform/modules/negative_prober/modules/prober/variables.tf:233,3-13.
Invalid value for variable

on  line 0:
  (source code not available)

team needs to specified or disable check by setting require_team = false

This was checked by the validation rule at
.terraform/modules/prober/modules/prober/variables.tf:233,3-13.
```