### PR TITLE
configure startup prober

### DIFF
--- a/modules/app/main.tf
+++ b/modules/app/main.tf
@@ -108,6 +108,16 @@ module "this" {
         name  = "EVENT_INGRESS_URI"
         value = { for k, v in module.sts-emits-events : k => v.uri }
       }]
+
+      startup_probe = {
+        tcp_socket = {
+          port = 8080
+        }
+        initial_delay_seconds = 30
+        timeout_seconds       = 240
+        period_seconds        = 240
+        failure_threshold     = 1
+      }
     }
   }
 


### PR DESCRIPTION
```
│ Error: Error waiting for Updating Service: Error code 9, message: Revision 'octo-sts-00509-jsp' is not ready and cannot serve traffic. The user-provided container failed to start and listen on the port defined provided by the PORT=8080 environment variable within the allocated timeout. This can happen when the container port is misconfigured or if the timeout is too short. The health check timeout can be extended. Logs for this revision might contain more information.
```


manually updated the startup prober, and the deploy succeeded 