### PR TITLE
add new field to the bq schema

### DIFF
--- a/iac/sts_exchange.schema.json
+++ b/iac/sts_exchange.schema.json
@@ -131,6 +131,11 @@
                 "mode": "NULLABLE"
             },
             {
+                "name": "attestations",
+                "type": "STRING",
+                "mode": "NULLABLE"
+            },
+            {
                 "name": "blocking",
                 "type": "STRING",
                 "mode": "NULLABLE"


### PR DESCRIPTION
```
Error while reading data, error message: JSON parsing error in row starting at position 511: No such field: trust_policy.permissions.attestations. File: gs://octo-sts-recorder-us-central1-92d6/dev.octo-sts.exchange/1755625346152359977

```

