### PR TITLE
add event_name to the claim_pattern struct

### DIFF
--- a/iac/sts_exchange.schema.json
+++ b/iac/sts_exchange.schema.json
@@ -74,6 +74,11 @@
           "mode": "NULLABLE",
           "fields": [
             {
+                "name": "event_name",
+                "type": "STRING",
+                "mode": "NULLABLE"
+            },
+            {
                 "name": "job_workflow_ref",
                 "type": "STRING",
                 "mode": "NULLABLE"


### PR DESCRIPTION
```
Error while reading data, error message: JSON parsing error in row starting at position 19050: No such field: trust_policy.claim_pattern.event_name. File: gs://octo-sts-recorder-us-central1-92d6/dev.octo-sts.exchange/1755787701184712608

```