### PR TITLE
add repository in the claim_pattern schema

### DIFF
--- a/iac/sts_exchange.schema.json
+++ b/iac/sts_exchange.schema.json
@@ -84,6 +84,11 @@
                 "mode": "NULLABLE"
             },
             {
+                "name": "repository",
+                "type": "STRING",
+                "mode": "NULLABLE"
+            },
+            {
                 "name": "workflow_ref",
                 "type": "STRING",
                 "mode": "NULLABLE"


### PR DESCRIPTION
```
Error while reading data, error message: JSON parsing error in row starting at position 34687: No such field: trust_policy.claim_pattern.repository. File: gs://octo-sts-recorder-us-central1-92d6/dev.octo-sts.exchange/1755788264379546229

```