### PR TITLE
add timestamp field to event for better debugging

### DIFF
--- a/iac/sts_exchange.schema.json
+++ b/iac/sts_exchange.schema.json
@@ -348,5 +348,10 @@
         "name": "error",
         "type": "STRING",
         "mode": "NULLABLE"
+    },
+    {
+        "name": "time",
+        "type": "TIMESTAMP",
+        "mode": "NULLABLE"
     }
 ]

--- a/pkg/octosts/event.go
+++ b/pkg/octosts/event.go
@@ -3,6 +3,8 @@
 
 package octosts
 
+import "time"
+
 type Event struct {
 	Actor          Actor           `json:"actor"`
 	TrustPolicy    *OrgTrustPolicy `json:"trust_policy"`
@@ -11,6 +13,7 @@ type Event struct {
 	Identity       string          `json:"identity"`
 	TokenSHA256    string          `json:"token_sha256"`
 	Error          string          `json:"error,omitempty"`
+	Time           time.Time       `json:"time"`
 }
 
 type Actor struct {

--- a/pkg/octosts/octosts.go
+++ b/pkg/octosts/octosts.go
@@ -92,6 +92,7 @@ func (s *sts) Exchange(ctx context.Context, request *pboidc.ExchangeRequest) (_ 
 	e := Event{
 		Scope:    requestScope,
 		Identity: request.GetIdentity(),
+		Time:     time.Now(),
 	}
 
 	if s.metrics {


### PR DESCRIPTION
the lack of a time field in events prevents us to correlate events to spikes in usage

adding time field