### PR TITLE
Add `/healthcheck` endpoints to facilitate deploying to k8s

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -20,6 +20,8 @@ import (
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 
 	envConfig "github.com/octo-sts/app/pkg/envconfig"
 	"github.com/octo-sts/app/pkg/ghtransport"
@@ -93,11 +95,9 @@ func main() {
 		log.Panicf("failed to register root GET handler: %v", err)
 	}
 
-	if err := d.MUX.HandlePath(http.MethodGet, "/healthcheck", func(w http.ResponseWriter, r *http.Request, _ map[string]string) {
-		w.WriteHeader(http.StatusOK)
-	}); err != nil {
-		log.Panicf("failed to register healthcheck GET handler: %v", err)
-	}
+	// Register health check service
+	healthServer := health.NewServer()
+	healthpb.RegisterHealthServer(d.Server, healthServer)
 
 	if err := d.ListenAndServe(ctx); err != nil {
 		log.Panicf("ListenAndServe() = %v", err)

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -93,6 +93,12 @@ func main() {
 		log.Panicf("failed to register root GET handler: %v", err)
 	}
 
+	if err := d.MUX.HandlePath(http.MethodGet, "/healthcheck", func(w http.ResponseWriter, r *http.Request, _ map[string]string) {
+		w.WriteHeader(http.StatusOK)
+	}); err != nil {
+		log.Panicf("failed to register healthcheck GET handler: %v", err)
+	}
+
 	if err := d.ListenAndServe(ctx); err != nil {
 		log.Panicf("ListenAndServe() = %v", err)
 	}

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -94,6 +94,9 @@ func main() {
 		WebhookSecret: webhookSecrets,
 		Organizations: orgs,
 	})
+	mux.HandleFunc("/healthcheck", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
 	srv := &http.Server{
 		Addr:              fmt.Sprintf(":%d", baseCfg.Port),
 		ReadHeaderTimeout: 10 * time.Second,


### PR DESCRIPTION
Adds `/healthcheck` endpoints to the `app` and `webhook` servers so that k8s deployment can check when the node is up.