### PR TITLE
feat: add ORG_POLICY_REPO environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,29 @@ This will read the `# yaml-language-server: $schema=...` header and provide code
 ### Organization Trusted Token Issuers
 
 An organization restricts which OIDC issuers can federate with its repositories.
-Add `.github/chainguard/trusted-token-issuers.yaml` to the organization's `.github`
-repository. octo-sts rejects a token with an issuer that the file does not permit.
+Add `<ORG_POLICY_REPO>/.github/chainguard/trusted-token-issuers.yaml` to the
+organization's policy repository (`.github` by default; see `ORG_POLICY_REPO`
+below). octo-sts rejects a token with an issuer that the file does not permit.
 It rejects the token before it reads the trust policy.
+
+#### Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ORG_POLICY_REPO` | `.github` | Repository within the organization that holds the org-issuer allowlist. Must exist and be accessible to the App before enforcement takes effect. |
+
+> **Warning: migration hazard.** If you set `ORG_POLICY_REPO=my-policies` while
+> the allowlist is still in `.github`, octo-sts reads `my-policies` instead.
+> That file does not exist yet, so the read returns 404. A 404 is treated as
+> "no allowlist" — meaning **all issuers are permitted** for that organization,
+> silently. Create or move the allowlist into the new repository and protect it
+> **before** flipping `ORG_POLICY_REPO`.
+
+> **Note: two-binary config skew.** The exchange service and the webhook
+> validator each read `ORG_POLICY_REPO` from their own deployment config. If
+> you set `ORG_POLICY_REPO` on only one of the two, the webhook validates a
+> different repository than the exchange enforces. Update both deployments
+> together.
 
 ```yaml
 # yaml-language-server: $schema=https://raw.githubusercontent.com/octo-sts/app/refs/heads/main/pkg/octosts/octosts.OrgTrustedIssuers.json
@@ -153,25 +173,25 @@ over-broad pattern is therefore an unwise choice, not an attack.
 
 Audit mode does not protect you against a broken file or a failed lookup.
 
-#### Requirement: the App must be able to read `.github`
+#### Requirement: the App must be able to read the policy repository
 
 octo-sts reads the allowlist with a short-lived `contents: read` token. The token
-is scoped to the `.github` repository. **Enforcement silently does not apply if
-octo-sts cannot read that repository.** The most common cause is an App that is
-installed on selected repositories only.
+is scoped to the `ORG_POLICY_REPO` repository (`.github` by default).
+**Enforcement silently does not apply if octo-sts cannot read that repository.**
+The most common cause is an App that is installed on selected repositories only.
 
 octo-sts cannot report which cause it hit. GitHub answers a token request for an
 inaccessible repository with one 422 status. That status does not separate "the
 repository does not exist" from "you do not have access".
 
-Grant the App access to `.github` before you rely on this control.
+Grant the App access to the policy repository before you rely on this control.
 
 #### When the lookup fails
 
 | Situation | Result |
 | --- | --- |
 | File absent | octo-sts permits all issuers |
-| No App can read `.github` | octo-sts permits all issuers and logs a warning. It first re-reads the installation list from GitHub, without its local cache. See effect 4 below |
+| No App can read `ORG_POLICY_REPO` | octo-sts permits all issuers and logs a warning. It first re-reads the installation list from GitHub, without its local cache. See effect 4 below |
 | Rate limited, or GitHub unavailable | octo-sts uses the last known good allowlist. If there is none, it rejects the exchange |
 | File present but invalid | octo-sts uses the last known good allowlist. If there is none, it rejects every exchange in the organization |
 
@@ -193,19 +213,20 @@ the incident. One successful read replaces the state. Check that enforcement
 started. Do not assume it started.
 
 Effect 4 has a different cause. Before octo-sts concludes that no installation can
-read `.github`, it re-reads the installation list from GitHub without its local
-cache. GitHub does not list a new installation at once. octo-sts cannot see an
-installation that GitHub has not yet propagated.
+read the policy repository, it re-reads the installation list from GitHub without
+its local cache. GitHub does not list a new installation at once. octo-sts cannot
+see an installation that GitHub has not yet propagated.
 
 #### Hardening
 
-This control is only as strong as write access to `org/.github`.
+This control is only as strong as write access to the policy repository.
 
-- **Create `org/.github` before you need it.** GitHub does not reserve the name. In
-  an organization without this repository, any member who can create a repository
-  becomes the sole author of this control. Restrict who can create repositories.
+- **Create the policy repository before you need it.** GitHub does not reserve
+  repository names. In an organization without this repository, any member who can
+  create a repository becomes the sole author of this control. Restrict who can
+  create repositories.
 
-- **Protect the default branch of `org/.github`.** Make the
+- **Protect the default branch of the policy repository.** Make the
   `Trust Policy Validation` check a **required** status check. The check validates
   this file on every pull request. It only reports. It blocks nothing until you make
   it required.
@@ -214,12 +235,12 @@ This control is only as strong as write access to `org/.github`.
 
 - **Scope organization-level trust policies with `repositories:`.** An
   organization-level policy that grants `contents: write` without a `repositories:`
-  restriction covers every repository the installation can see. That includes
-  `.github`. A federated identity can then rewrite the allowlist that constrains it.
-  Any permission that writes, renames, or deletes `org/.github` defeats this
-  control. **Deletion of the file fails open.**
+  restriction covers every repository the installation can see. That includes the
+  policy repository. A federated identity can then rewrite the allowlist that
+  constrains it. Any permission that writes, renames, or deletes the allowlist file
+  defeats this control. **Deletion of the file fails open.**
 
-- **`.github-private` is not consulted.** The file must live in `.github`.
+- **`.github-private` is not consulted.** The file must live in `ORG_POLICY_REPO`.
 
 ### Federating a token
 

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -126,7 +126,7 @@ func main() {
 		}
 	}
 
-	pboidc.RegisterSecurityTokenServiceServer(d.Server, octosts.NewSecurityTokenServiceServer(rrm, sticky, len(managers), ceclient, appConfig.Domain, baseCfg.Metrics))
+	pboidc.RegisterSecurityTokenServiceServer(d.Server, octosts.NewSecurityTokenServiceServer(rrm, sticky, len(managers), ceclient, appConfig.Domain, baseCfg.Metrics, appConfig.OrgPolicyRepo))
 	if err := d.RegisterHandler(ctx, pboidc.RegisterSecurityTokenServiceHandlerFromEndpoint); err != nil {
 		log.Panicf("failed to register gateway endpoint: %v", err)
 	}

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -125,7 +125,7 @@ func main() {
 		clog.FromContext(ctx).Warn("EVENT_INGRESS_URI unset; exchange events will not be emitted")
 	}
 
-	pboidc.RegisterSecurityTokenServiceServer(d.Server, octosts.NewSecurityTokenServiceServer(rrm, sticky, len(managers), ceclient, appConfig.Domain, baseCfg.Metrics, baseCfg.GitHubBaseURL))
+	pboidc.RegisterSecurityTokenServiceServer(d.Server, octosts.NewSecurityTokenServiceServer(rrm, sticky, len(managers), ceclient, appConfig.Domain, baseCfg.Metrics, baseCfg.GitHubBaseURL, appConfig.OrgPolicyRepo))
 	if err := d.RegisterHandler(ctx, pboidc.RegisterSecurityTokenServiceHandlerFromEndpoint); err != nil {
 		log.Panicf("failed to register gateway endpoint: %v", err)
 	}

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -107,6 +107,7 @@ func main() {
 		Transport:     atr,
 		WebhookSecret: webhookSecrets,
 		Organizations: orgs,
+		OrgPolicyRepo: webhookConfig.OrgPolicyRepo,
 	})
 	mux.HandleFunc("/healthcheck", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/pkg/envconfig/envconfig.go
+++ b/pkg/envconfig/envconfig.go
@@ -38,6 +38,7 @@ type EnvConfig struct {
 type EnvConfigApp struct {
 	Domain          string `envconfig:"STS_DOMAIN" required:"true"`
 	EventingIngress string `envconfig:"EVENT_INGRESS_URI" required:"false"`
+	OrgPolicyRepo   string `envconfig:"ORG_POLICY_REPO" required:"false" default:".github"`
 }
 
 type EnvConfigWebhook struct {

--- a/pkg/envconfig/envconfig.go
+++ b/pkg/envconfig/envconfig.go
@@ -45,7 +45,11 @@ type EnvConfig struct {
 type EnvConfigApp struct {
 	Domain          string `envconfig:"STS_DOMAIN" required:"true"`
 	EventingIngress string `envconfig:"EVENT_INGRESS_URI" required:"false"`
-	OrgPolicyRepo   string `envconfig:"ORG_POLICY_REPO" required:"false" default:".github"`
+	// OrgPolicyRepo is the repository name (without owner) that holds
+	// org-scoped trust policies. It applies to every organization this
+	// instance serves. Defaults to ".github". Must not be empty; setting
+	// ORG_POLICY_REPO="" is rejected at startup.
+	OrgPolicyRepo string `envconfig:"ORG_POLICY_REPO" required:"false" default:".github"`
 }
 
 type EnvConfigWebhook struct {
@@ -60,6 +64,10 @@ func AppConfig() (*EnvConfigApp, error) {
 	var err error
 	if err = envconfig.Process("", cfg); err != nil {
 		return nil, err
+	}
+
+	if cfg.OrgPolicyRepo == "" {
+		return nil, errors.New("ORG_POLICY_REPO must not be empty")
 	}
 
 	return cfg, err

--- a/pkg/envconfig/envconfig.go
+++ b/pkg/envconfig/envconfig.go
@@ -56,6 +56,10 @@ type EnvConfigWebhook struct {
 	WebhookSecret string `envconfig:"GITHUB_WEBHOOK_SECRET" required:"true"`
 	// If set, only process events from these organizations (comma separated).
 	OrganizationFilter string `envconfig:"GITHUB_WEBHOOK_ORGANIZATION_FILTER"`
+	// OrgPolicyRepo is the repository name (without owner) that holds org-scoped
+	// trust policies and the org trusted-issuer allowlist. Defaults to ".github".
+	// Must not be empty; setting ORG_POLICY_REPO="" is rejected at startup.
+	OrgPolicyRepo string `envconfig:"ORG_POLICY_REPO" required:"false" default:".github"`
 }
 
 func AppConfig() (*EnvConfigApp, error) {
@@ -79,6 +83,10 @@ func WebhookConfig() (*EnvConfigWebhook, error) {
 	var err error
 	if err = envconfig.Process("", cfg); err != nil {
 		return nil, err
+	}
+
+	if cfg.OrgPolicyRepo == "" {
+		return nil, errors.New("ORG_POLICY_REPO must not be empty")
 	}
 
 	return cfg, err

--- a/pkg/envconfig/envconfig.go
+++ b/pkg/envconfig/envconfig.go
@@ -45,6 +45,7 @@ type EnvConfig struct {
 type EnvConfigApp struct {
 	Domain          string `envconfig:"STS_DOMAIN" required:"true"`
 	EventingIngress string `envconfig:"EVENT_INGRESS_URI" required:"false"`
+	OrgPolicyRepo   string `envconfig:"ORG_POLICY_REPO" required:"false" default:".github"`
 }
 
 type EnvConfigWebhook struct {

--- a/pkg/envconfig/envconfig_test.go
+++ b/pkg/envconfig/envconfig_test.go
@@ -295,6 +295,22 @@ func TestAppConfig(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "ORG_POLICY_REPO explicitly empty rejected",
+			envVars: map[string]string{
+				"STS_DOMAIN":      "octo-sts-test.local",
+				"ORG_POLICY_REPO": "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "ORG_POLICY_REPO custom value accepted",
+			envVars: map[string]string{
+				"STS_DOMAIN":      "octo-sts-test.local",
+				"ORG_POLICY_REPO": "my-policies",
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/octosts/octosts.go
+++ b/pkg/octosts/octosts.go
@@ -47,14 +47,15 @@ const (
 // NewSecurityTokenServiceServer creates an STS that exchanges OIDC tokens for
 // GitHub installation tokens. rrm handles installation selection; sticky (may
 // be nil) persists checks:write routing for check-run ownership.
-func NewSecurityTokenServiceServer(rrm ghinstall.Manager, sticky stickystore.Store, appCount int, ceclient cloudevents.Client, domain string, metrics bool) pboidc.SecurityTokenServiceServer {
+func NewSecurityTokenServiceServer(rrm ghinstall.Manager, sticky stickystore.Store, appCount int, ceclient cloudevents.Client, domain string, metrics bool, orgPolicyRepo string) pboidc.SecurityTokenServiceServer {
 	return &sts{
-		rrm:      rrm,
-		sticky:   sticky,
-		appCount: appCount,
-		ceclient: ceclient,
-		domain:   domain,
-		metrics:  metrics,
+		rrm:           rrm,
+		sticky:        sticky,
+		appCount:      appCount,
+		ceclient:      ceclient,
+		domain:        domain,
+		metrics:       metrics,
+		orgPolicyRepo: orgPolicyRepo,
 	}
 }
 
@@ -63,12 +64,13 @@ var trustPolicies = expirablelru.NewLRU[cacheTrustPolicyKey, string](200, nil, t
 type sts struct {
 	pboidc.UnimplementedSecurityTokenServiceServer
 
-	rrm      ghinstall.Manager
-	sticky   stickystore.Store
-	appCount int
-	ceclient cloudevents.Client
-	domain   string
-	metrics  bool
+	rrm           ghinstall.Manager
+	sticky        stickystore.Store
+	appCount      int
+	ceclient      cloudevents.Client
+	domain        string
+	metrics       bool
+	orgPolicyRepo string
 }
 
 type cacheTrustPolicyKey struct {
@@ -278,12 +280,15 @@ func (s *sts) lookupInstallAndTrustPolicy(ctx context.Context, scope, identity, 
 
 	owner, repo := path.Dir(scope), path.Base(scope)
 	if owner == "." {
-		owner, repo = repo, ".github"
+		owner, repo = repo, s.orgPolicyRepo
 	} else {
 		otp.Repositories = []string{repo}
 	}
 
-	if repo == ".github" {
+	// If the repo is the org policy repo, then parse with an org policy even
+	// if the repo was specified explicitly because we will reject the
+	// repositories field in policies otherwise.
+	if repo == s.orgPolicyRepo {
 		tp = otp
 	}
 

--- a/pkg/octosts/octosts.go
+++ b/pkg/octosts/octosts.go
@@ -47,15 +47,16 @@ const (
 // NewSecurityTokenServiceServer creates an STS that exchanges OIDC tokens for
 // GitHub installation tokens. rrm handles installation selection; sticky (may
 // be nil) persists checks:write routing for check-run ownership.
-func NewSecurityTokenServiceServer(rrm ghinstall.Manager, sticky stickystore.Store, appCount int, ceclient cloudevents.Client, domain string, metrics bool, baseURL string) pboidc.SecurityTokenServiceServer {
+func NewSecurityTokenServiceServer(rrm ghinstall.Manager, sticky stickystore.Store, appCount int, ceclient cloudevents.Client, domain string, metrics bool, baseURL string, orgPolicyRepo string) pboidc.SecurityTokenServiceServer {
 	return &sts{
-		rrm:      rrm,
-		sticky:   sticky,
-		appCount: appCount,
-		ceclient: ceclient,
-		domain:   domain,
-		metrics:  metrics,
-		baseURL:  baseURL,
+		rrm:           rrm,
+		sticky:        sticky,
+		appCount:      appCount,
+		ceclient:      ceclient,
+		domain:        domain,
+		metrics:       metrics,
+		baseURL:       baseURL,
+		orgPolicyRepo: orgPolicyRepo,
 	}
 }
 
@@ -65,13 +66,14 @@ var staleTrustPolicies = expirablelru.NewLRU[cacheTrustPolicyKey, string](200, n
 type sts struct {
 	pboidc.UnimplementedSecurityTokenServiceServer
 
-	rrm      ghinstall.Manager
-	sticky   stickystore.Store
-	appCount int
-	ceclient cloudevents.Client
-	domain   string
-	metrics  bool
-	baseURL  string
+	rrm           ghinstall.Manager
+	sticky        stickystore.Store
+	appCount      int
+	ceclient      cloudevents.Client
+	domain        string
+	metrics       bool
+	baseURL       string
+	orgPolicyRepo string
 }
 
 type cacheTrustPolicyKey struct {
@@ -293,12 +295,15 @@ func (s *sts) lookupInstallAndTrustPolicy(ctx context.Context, scope, identity, 
 
 	owner, repo := path.Dir(scope), path.Base(scope)
 	if owner == "." {
-		owner, repo = repo, ".github"
+		owner, repo = repo, s.orgPolicyRepo
 	} else {
 		otp.Repositories = []string{repo}
 	}
 
-	if repo == ".github" {
+	// If the repo is the org policy repo, then parse with an org policy even
+	// if the repo was specified explicitly because we will reject the
+	// repositories field in policies otherwise.
+	if repo == s.orgPolicyRepo {
 		tp = otp
 	}
 

--- a/pkg/octosts/octosts.go
+++ b/pkg/octosts/octosts.go
@@ -302,7 +302,7 @@ func (s *sts) lookupInstallAndTrustPolicy(ctx context.Context, scope, identity, 
 
 	owner, repo := path.Dir(scope), path.Base(scope)
 	if owner == "." {
-		owner, repo = repo, s.orgPolicyRepo
+		owner, repo = repo, s.policyRepo()
 	} else {
 		otp.Repositories = []string{repo}
 	}
@@ -310,7 +310,7 @@ func (s *sts) lookupInstallAndTrustPolicy(ctx context.Context, scope, identity, 
 	// If the repo is the org policy repo, then parse with an org policy even
 	// if the repo was specified explicitly because we will reject the
 	// repositories field in policies otherwise.
-	if repo == s.orgPolicyRepo {
+	if repo == s.policyRepo() {
 		tp = otp
 	}
 

--- a/pkg/octosts/octosts.go
+++ b/pkg/octosts/octosts.go
@@ -76,6 +76,13 @@ type sts struct {
 	orgPolicyRepo string
 }
 
+func (s *sts) policyRepo() string {
+	if s.orgPolicyRepo != "" {
+		return s.orgPolicyRepo
+	}
+	return ".github"
+}
+
 type cacheTrustPolicyKey struct {
 	owner    string
 	repo     string

--- a/pkg/octosts/octosts_test.go
+++ b/pkg/octosts/octosts_test.go
@@ -145,8 +145,9 @@ func TestExchange(t *testing.T) {
 	ctx = metadata.NewIncomingContext(ctx, metadata.MD{"authorization": []string{"Bearer " + token}})
 
 	sts := &sts{
-		rrm:      &fakeInstallMgr{atr: atr},
-		appCount: 1,
+		rrm:           &fakeInstallMgr{atr: atr},
+		appCount:      1,
+		orgPolicyRepo: ".github",
 	}
 	for _, tc := range []struct {
 		name string
@@ -232,8 +233,9 @@ func TestExchangeValidation(t *testing.T) {
 	ctx = metadata.NewIncomingContext(ctx, metadata.MD{"authorization": []string{"Bearer " + token}})
 
 	sts := &sts{
-		rrm:      &fakeInstallMgr{atr: atr},
-		appCount: 1,
+		rrm:           &fakeInstallMgr{atr: atr},
+		appCount:      1,
+		orgPolicyRepo: ".github",
 	}
 
 	tests := []struct {
@@ -373,8 +375,9 @@ func TestExchangeRateLimit(t *testing.T) {
 			ctx = metadata.NewIncomingContext(ctx, metadata.MD{"authorization": []string{"Bearer " + token}})
 
 			s := &sts{
-				rrm:      &fakeInstallMgr{atr: atr},
-				appCount: 1,
+				rrm:           &fakeInstallMgr{atr: atr},
+				appCount:      1,
+				orgPolicyRepo: ".github",
 			}
 			_, err = s.Exchange(ctx, &v1.ExchangeRequest{
 				Identity: tc.identity,

--- a/pkg/octosts/octosts_test.go
+++ b/pkg/octosts/octosts_test.go
@@ -201,6 +201,78 @@ func TestExchange(t *testing.T) {
 	}
 }
 
+// TestExchangeCustomOrgPolicyRepo verifies that an org-scoped exchange reads
+// its trust policy from the repo named by ORG_POLICY_REPO rather than the
+// hardcoded ".github" default.
+func TestExchangeCustomOrgPolicyRepo(t *testing.T) {
+	key := cacheTrustPolicyKey{owner: "org", repo: "my-policies", identity: "foo"}
+	trustPolicies.Remove(key)
+	t.Cleanup(func() { trustPolicies.Remove(key) })
+
+	ctx := context.Background()
+	atr := newGitHubClient(t, newFakeGitHub())
+
+	pk, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("cannot generate RSA key %v", err)
+	}
+	signer, err := jose.NewSigner(jose.SigningKey{
+		Algorithm: jose.RS256,
+		Key:       pk,
+	}, nil)
+	if err != nil {
+		t.Fatalf("jose.NewSigner() = %v", err)
+	}
+
+	iss := "https://token.actions.githubusercontent.com"
+	token, err := josejwt.Signed(signer).Claims(josejwt.Claims{
+		Subject:  "foo",
+		Issuer:   iss,
+		Audience: josejwt.Audience{"octosts"},
+		Expiry:   josejwt.NewNumericDate(time.Now().Add(10 * time.Minute)),
+	}).Serialize()
+	if err != nil {
+		t.Fatalf("CompactSerialize failed: %v", err)
+	}
+	provider.AddTestKeySetVerifier(t, iss, &oidc.StaticKeySet{
+		PublicKeys: []crypto.PublicKey{pk.Public()},
+	})
+	ctx = metadata.NewIncomingContext(ctx, metadata.MD{"authorization": []string{"Bearer " + token}})
+
+	sts := &sts{
+		rrm:           &fakeInstallMgr{atr: atr},
+		appCount:      1,
+		orgPolicyRepo: "my-policies",
+	}
+
+	tok, err := sts.Exchange(ctx, &v1.ExchangeRequest{
+		Identity: "foo",
+		Scope:    "org",
+	})
+	if err != nil {
+		t.Fatalf("Exchange failed: %v", err)
+	}
+
+	b, err := base64.StdEncoding.DecodeString(tok.Token)
+	if err != nil {
+		t.Fatalf("DecodeString failed: %v", err)
+	}
+	got := new(github.InstallationTokenOptions)
+	if err := json.Unmarshal(b, got); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	// Distinct permission from testdata/org/.github/foo.sts.yaml so this
+	// test would fail if the lookup silently fell back to the default repo.
+	want := &github.InstallationTokenOptions{
+		Permissions: &github.InstallationPermissions{
+			Contents: github.Ptr("read"),
+		},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Error(diff)
+	}
+}
+
 func TestExchangeValidation(t *testing.T) {
 	ctx := context.Background()
 	atr := newGitHubClient(t, newFakeGitHub())

--- a/pkg/octosts/octosts_test.go
+++ b/pkg/octosts/octosts_test.go
@@ -202,8 +202,9 @@ func TestExchange(t *testing.T) {
 	ctx = metadata.NewIncomingContext(ctx, metadata.MD{"authorization": []string{"Bearer " + token}})
 
 	sts := &sts{
-		rrm:      &fakeInstallMgr{atr: atr},
-		appCount: 1,
+		rrm:           &fakeInstallMgr{atr: atr},
+		appCount:      1,
+		orgPolicyRepo: ".github",
 	}
 	for _, tc := range []struct {
 		name string
@@ -289,8 +290,9 @@ func TestExchangeValidation(t *testing.T) {
 	ctx = metadata.NewIncomingContext(ctx, metadata.MD{"authorization": []string{"Bearer " + token}})
 
 	sts := &sts{
-		rrm:      &fakeInstallMgr{atr: atr},
-		appCount: 1,
+		rrm:           &fakeInstallMgr{atr: atr},
+		appCount:      1,
+		orgPolicyRepo: ".github",
 	}
 
 	tests := []struct {
@@ -454,8 +456,9 @@ func TestExchangeRateLimit(t *testing.T) {
 			ctx = metadata.NewIncomingContext(ctx, metadata.MD{"authorization": []string{"Bearer " + token}})
 
 			s := &sts{
-				rrm:      &fakeInstallMgr{atr: atr},
-				appCount: 1,
+				rrm:           &fakeInstallMgr{atr: atr},
+				appCount:      1,
+				orgPolicyRepo: ".github",
 			}
 			_, err = s.Exchange(ctx, &v1.ExchangeRequest{
 				Identity: tc.identity,

--- a/pkg/octosts/octosts_test.go
+++ b/pkg/octosts/octosts_test.go
@@ -258,6 +258,78 @@ func TestExchange(t *testing.T) {
 	}
 }
 
+// TestExchangeCustomOrgPolicyRepo verifies that an org-scoped exchange reads
+// its trust policy from the repo named by ORG_POLICY_REPO rather than the
+// hardcoded ".github" default.
+func TestExchangeCustomOrgPolicyRepo(t *testing.T) {
+	key := cacheTrustPolicyKey{owner: "org", repo: "my-policies", identity: "foo"}
+	trustPolicies.Remove(key)
+	t.Cleanup(func() { trustPolicies.Remove(key) })
+
+	ctx := context.Background()
+	atr := newAppsTransport(t, newFakeGitHub())
+
+	pk, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("cannot generate RSA key %v", err)
+	}
+	signer, err := jose.NewSigner(jose.SigningKey{
+		Algorithm: jose.RS256,
+		Key:       pk,
+	}, nil)
+	if err != nil {
+		t.Fatalf("jose.NewSigner() = %v", err)
+	}
+
+	iss := "https://token.actions.githubusercontent.com"
+	token, err := josejwt.Signed(signer).Claims(josejwt.Claims{
+		Subject:  "foo",
+		Issuer:   iss,
+		Audience: josejwt.Audience{"octosts"},
+		Expiry:   josejwt.NewNumericDate(time.Now().Add(10 * time.Minute)),
+	}).Serialize()
+	if err != nil {
+		t.Fatalf("CompactSerialize failed: %v", err)
+	}
+	provider.AddTestKeySetVerifier(t, iss, &oidc.StaticKeySet{
+		PublicKeys: []crypto.PublicKey{pk.Public()},
+	})
+	ctx = metadata.NewIncomingContext(ctx, metadata.MD{"authorization": []string{"Bearer " + token}})
+
+	sts := &sts{
+		rrm:           &fakeInstallMgr{atr: atr},
+		appCount:      1,
+		orgPolicyRepo: "my-policies",
+	}
+
+	tok, err := sts.Exchange(ctx, &v1.ExchangeRequest{
+		Identity: "foo",
+		Scope:    "org",
+	})
+	if err != nil {
+		t.Fatalf("Exchange failed: %v", err)
+	}
+
+	b, err := base64.StdEncoding.DecodeString(tok.Token)
+	if err != nil {
+		t.Fatalf("DecodeString failed: %v", err)
+	}
+	got := new(github.InstallationTokenOptions)
+	if err := json.Unmarshal(b, got); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	// Distinct permission from testdata/org/.github/foo.sts.yaml so this
+	// test would fail if the lookup silently fell back to the default repo.
+	want := &github.InstallationTokenOptions{
+		Permissions: &github.InstallationPermissions{
+			Contents: github.Ptr("read"),
+		},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Error(diff)
+	}
+}
+
 func TestExchangeValidation(t *testing.T) {
 	ctx := context.Background()
 	atr := newAppsTransport(t, newFakeGitHub())

--- a/pkg/octosts/org_trusted_issuers_store.go
+++ b/pkg/octosts/org_trusted_issuers_store.go
@@ -224,8 +224,9 @@ func classifyMintError(ctx context.Context, owner string, err error) fetchResult
 	return failedFetch()
 }
 
-// classifyContentsError maps a GetContents failure.
-func classifyContentsError(ctx context.Context, owner string, err error) fetchResult {
+// classifyContentsError maps a GetContents failure. policyRepo is the
+// repository name that was read, for use in log messages.
+func classifyContentsError(ctx context.Context, owner, policyRepo string, err error) fetchResult {
 	if isOrgIssuerRateLimit(err) {
 		clog.WarnContextf(ctx, "org trusted issuers: read rate limited for %s", owner)
 		return rateLimitedFetch()
@@ -242,7 +243,7 @@ func classifyContentsError(ctx context.Context, owner string, err error) fetchRe
 			// 403 is often org-wide (IP allowlist, SAML/SSO, ToS lock, API incident) and
 			// would make every installation "agree" no allowlist applies. Genuine
 			// per-installation blindness fails at the MINT with 422, the sole agreement.
-			clog.WarnContextf(ctx, "org trusted issuers: read forbidden for %s/.github (403, not a rate limit); treating as unknown", owner)
+			clog.WarnContextf(ctx, "org trusted issuers: read forbidden for %s/%s (403, not a rate limit); treating as unknown", owner, policyRepo)
 			return failedFetch()
 		}
 	}
@@ -291,7 +292,7 @@ func (s *sts) fetchOrgIssuersOnce(ctx context.Context, base *ghinstallation.Apps
 		&github.RepositoryContentGetOptions{},
 	)
 	if err != nil {
-		return classifyContentsError(ctx, owner, err)
+		return classifyContentsError(ctx, owner, s.policyRepo(), err)
 	}
 	if file == nil {
 		// A directory: GetContent() dereferences Encoding unguarded and would panic.
@@ -416,7 +417,7 @@ func (s *sts) confirmNoAccess(ctx context.Context, owner string, scanned []ghins
 	// Re-check rather than reuse the earlier verdict: the newly-found installations may
 	// have added a failure, which is fatal to the conclusion.
 	if t.exhaustiveNoAccess() {
-		clog.WarnContextf(ctx, "no installation can read %s/.github (re-enumerated without the installation cache); org issuer enforcement not applied", owner)
+		clog.WarnContextf(ctx, "no installation can read %s/%s (re-enumerated without the installation cache); org issuer enforcement not applied", owner, s.policyRepo())
 		return absentOrgIssuerEntry(), true
 	}
 

--- a/pkg/octosts/org_trusted_issuers_store.go
+++ b/pkg/octosts/org_trusted_issuers_store.go
@@ -259,7 +259,7 @@ func (s *sts) fetchOrgIssuersOnce(ctx context.Context, base *ghinstallation.Apps
 
 	atr := ghinstallation.NewFromAppsTransport(base, install)
 	atr.InstallationTokenOptions = &github.InstallationTokenOptions{
-		Repositories: []string{".github"},
+		Repositories: []string{s.policyRepo()},
 		Permissions: &github.InstallationPermissions{
 			Contents: ptr("read"),
 		},
@@ -287,7 +287,7 @@ func (s *sts) fetchOrgIssuersOnce(ctx context.Context, base *ghinstallation.Apps
 	}
 
 	file, _, _, err := client.Repositories.GetContents(ctx,
-		owner, ".github", OrgTrustedIssuersPath,
+		owner, s.policyRepo(), OrgTrustedIssuersPath,
 		&github.RepositoryContentGetOptions{},
 	)
 	if err != nil {

--- a/pkg/octosts/org_trusted_issuers_store_test.go
+++ b/pkg/octosts/org_trusted_issuers_store_test.go
@@ -391,7 +391,7 @@ func TestClassifyContentsError(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := classifyContentsError(t.Context(), "org", fmt.Errorf("wrapped: %w", tc.err))
+			got := classifyContentsError(t.Context(), "org", ".github", fmt.Errorf("wrapped: %w", tc.err))
 			if got.kind != tc.wantKind {
 				t.Fatalf("kind = %v, want %v", got.kind, tc.wantKind)
 			}

--- a/pkg/octosts/testdata/org/my-policies/foo.sts.yaml
+++ b/pkg/octosts/testdata/org/my-policies/foo.sts.yaml
@@ -1,0 +1,9 @@
+# Copyright 2024 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+issuer: https://token.actions.githubusercontent.com
+subject: foo
+audience: octosts
+
+permissions:
+  contents: read

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -48,6 +48,11 @@ type Validator struct {
 
 	Organizations []string
 
+	// OrgPolicyRepo is the repository name (without owner) that holds
+	// org-scoped trust policies and the org trusted-issuer allowlist.
+	// Defaults to ".github" when empty.
+	OrgPolicyRepo string
+
 	// clients caches one client per installation ID so the transport's token is
 	// reused (~1h) instead of re-minted per event. Keyed on installation ID
 	// alone: IDs are globally unique and the webhook serves one App. Building a
@@ -55,6 +60,13 @@ type Validator struct {
 	// can guard the whole get-or-create.
 	clientsMu sync.Mutex
 	clients   *lru.Cache[int64, *github.Client]
+}
+
+func (e *Validator) policyRepo() string {
+	if e.OrgPolicyRepo != "" {
+		return e.OrgPolicyRepo
+	}
+	return ".github"
 }
 
 // prActionsThatChangeFiles is the set of pull_request actions that can alter
@@ -199,7 +211,7 @@ func (e *Validator) handleSHA(ctx context.Context, client *github.Client, owner,
 		return nil, nil
 	}
 
-	err := validatePolicies(ctx, client, owner, repo, sha, files)
+	err := validatePolicies(ctx, client, owner, repo, sha, files, e.policyRepo())
 	// If we were rate-limited, acknowledge the delivery and skip the CheckRun.
 	// Returning an error would surface as a 5xx, which GitHub treats as a
 	// failed delivery and redelivers — amplifying load on the rate-limited API.
@@ -242,7 +254,7 @@ func (e *Validator) handleSHA(ctx context.Context, client *github.Client, owner,
 	return cr, nil
 }
 
-func validatePolicies(ctx context.Context, client *github.Client, owner, repo string, sha string, files []string) error {
+func validatePolicies(ctx context.Context, client *github.Client, owner, repo, sha string, files []string, orgPolicyRepo string) error {
 	var merr error
 	for _, f := range sets.List(sets.New(files...)) {
 		log := clog.FromContext(ctx).With("path", f)
@@ -276,7 +288,7 @@ func validatePolicies(ctx context.Context, client *github.Client, owner, repo st
 		}
 
 		switch {
-		case strings.EqualFold(repo, ".github") && f == octosts.OrgTrustedIssuersPath:
+		case strings.EqualFold(repo, orgPolicyRepo) && f == octosts.OrgTrustedIssuersPath:
 			// Parse AND compile: only compiling catches uncompilable patterns,
 			// invalid issuer URLs, and an empty allowlist. The exchange path calls
 			// this same function, so the two verdicts cannot diverge.
@@ -289,7 +301,7 @@ func validatePolicies(ctx context.Context, client *github.Client, owner, repo st
 		// so an org whose repo is literally ".GitHub" would otherwise fall through
 		// to the default arm and have its org policy strict-unmarshalled as a
 		// repo-level TrustPolicy — a bogus check-run failure on a valid file.
-		case strings.EqualFold(repo, ".github"):
+		case strings.EqualFold(repo, orgPolicyRepo):
 			if err := yaml.UnmarshalStrict([]byte(raw), &octosts.OrgTrustPolicy{}); err != nil {
 				log.Infof("failed to parse org trust policy: %v", err)
 				merr = multierror.Append(merr, fmt.Errorf("%s: %w", f, err))
@@ -345,7 +357,7 @@ func (e *Validator) handlePush(ctx context.Context, event *github.PushEvent) (*g
 			return nil, err
 		}
 		for _, file := range resp.Files {
-			if isValidatedPath(repo, file.GetFilename()) {
+			if isValidatedPath(repo, file.GetFilename(), e.policyRepo()) {
 				if file.GetStatus() != "removed" {
 					files = append(files, file.GetFilename())
 				}
@@ -401,7 +413,7 @@ func (e *Validator) handlePullRequest(ctx context.Context, pr *github.PullReques
 		return nil, err
 	}
 	for _, file := range resp {
-		if isValidatedPath(repo, file.GetFilename()) {
+		if isValidatedPath(repo, file.GetFilename(), e.policyRepo()) {
 			if file.GetStatus() != "removed" {
 				files = append(files, file.GetFilename())
 			}
@@ -479,7 +491,7 @@ func (e *Validator) handleCheckSuite(ctx context.Context, cs checkSuite) (*githu
 		for _, file := range dirContents {
 			// Type matters as well as path: a directory can be named to match, and
 			// listing it as a candidate would send a non-file down the read path.
-			if file.GetType() == "file" && isValidatedPath(repo, file.GetPath()) {
+			if file.GetType() == "file" && isValidatedPath(repo, file.GetPath(), e.policyRepo()) {
 				files = append(files, file.GetPath())
 			}
 		}
@@ -489,7 +501,7 @@ func (e *Validator) handleCheckSuite(ctx context.Context, cs checkSuite) (*githu
 			return nil, err
 		}
 		for _, file := range resp.Files {
-			if isValidatedPath(repo, file.GetFilename()) {
+			if isValidatedPath(repo, file.GetFilename(), e.policyRepo()) {
 				if file.GetStatus() != "removed" {
 					files = append(files, file.GetFilename())
 				}
@@ -503,7 +515,7 @@ func (e *Validator) handleCheckSuite(ctx context.Context, cs checkSuite) (*githu
 			return nil, err
 		}
 		for _, file := range resp {
-			if isValidatedPath(repo, file.GetFilename()) {
+			if isValidatedPath(repo, file.GetFilename(), e.policyRepo()) {
 				if file.GetStatus() != "removed" {
 					files = append(files, file.GetFilename())
 				}
@@ -541,22 +553,22 @@ func (e *Validator) shouldSkipOrganization(org string) bool {
 
 // isValidatedPath reports whether octo-sts validates the given file. Trust
 // policies are validated in every repository; the organization trusted-issuer
-// allowlist only in the organization's .github repository.
+// allowlist only in the organization's org policy repository (orgPolicyRepo).
 //
 // The repository comparison folds case because GitHub repository names are
-// case-insensitive and the exchange path resolves .github through the API.
-func isValidatedPath(repo, path string) bool {
+// case-insensitive and the exchange path resolves the repo name through the API.
+func isValidatedPath(repo, path, orgPolicyRepo string) bool {
 	if ok, err := filepath.Match(".github/chainguard/*.sts.yaml", path); err == nil && ok {
 		return true
 	}
-	return strings.EqualFold(repo, ".github") && path == octosts.OrgTrustedIssuersPath
+	return strings.EqualFold(repo, orgPolicyRepo) && path == octosts.OrgTrustedIssuersPath
 }
 
 // filterValidatedFiles returns the subset of files octo-sts validates.
-func filterValidatedFiles(repo string, files []string) []string {
+func filterValidatedFiles(repo string, files []string, orgPolicyRepo string) []string {
 	var filtered []string
 	for _, f := range files {
-		if isValidatedPath(repo, f) {
+		if isValidatedPath(repo, f, orgPolicyRepo) {
 			filtered = append(filtered, f)
 		}
 	}
@@ -572,8 +584,8 @@ func filterValidatedFiles(repo string, files []string) []string {
 func (e *Validator) filesFromPushEvent(repo string, event *github.PushEvent) []string {
 	var files []string //nolint:prealloc // size depends on file content, not commit count
 	for _, commit := range event.Commits {
-		files = append(files, filterValidatedFiles(repo, commit.Added)...)
-		files = append(files, filterValidatedFiles(repo, commit.Modified)...)
+		files = append(files, filterValidatedFiles(repo, commit.Added, e.policyRepo())...)
+		files = append(files, filterValidatedFiles(repo, commit.Modified, e.policyRepo())...)
 	}
 	return files
 }

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -60,7 +60,7 @@ func TestValidatePolicy(t *testing.T) {
 		t.Fatal(err)
 	}
 	ctx := slogtest.Context(t)
-	if err := validatePolicies(ctx, gh, "foo", "bar", "deadbeef", []string{".github/chainguard/test.sts.yaml"}); err != nil {
+	if err := validatePolicies(ctx, gh, "foo", "bar", "deadbeef", []string{".github/chainguard/test.sts.yaml"}, ".github"); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -285,7 +285,7 @@ func TestFilterValidatedFiles(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := filterValidatedFiles("some-service", tc.input)
+			got := filterValidatedFiles("some-service", tc.input, ".github")
 			if !slices.Equal(tc.want, got) {
 				t.Errorf("filterValidatedFiles(%v) = %v, want %v", tc.input, got, tc.want)
 			}
@@ -1784,7 +1784,7 @@ func TestIsValidatedPath(t *testing.T) {
 		{name: "non-policy yaml inside the policy directory of .github", repo: ".github", path: ".github/chainguard/config.yaml", want: false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := isValidatedPath(tc.repo, tc.path); got != tc.want {
+			if got := isValidatedPath(tc.repo, tc.path, ".github"); got != tc.want {
 				t.Errorf("isValidatedPath(%q, %q) = %v, want %v", tc.repo, tc.path, got, tc.want)
 			}
 		})
@@ -1802,13 +1802,13 @@ func TestDirScanBranchFiltersPaths(t *testing.T) {
 		".github/chainguard/README.md",
 	}
 
-	got := filterValidatedFiles("some-service", all)
+	got := filterValidatedFiles("some-service", all, ".github")
 	want := []string{".github/chainguard/foo.sts.yaml"}
 	if !slices.Equal(got, want) {
 		t.Errorf("filterValidatedFiles(some-service) = %v, want %v — the allowlist must not be validated outside .github", got, want)
 	}
 
-	got = filterValidatedFiles(".github", all)
+	got = filterValidatedFiles(".github", all, ".github")
 	want = []string{".github/chainguard/foo.sts.yaml", ".github/chainguard/trusted-token-issuers.yaml"}
 	if !slices.Equal(got, want) {
 		t.Errorf("filterValidatedFiles(.github) = %v, want %v", got, want)


### PR DESCRIPTION
This PR adds a new environment variable called `ORG_POLICY_REPO` that allows you to specify the repository in your GitHub organization that should house org-level trust policy files.  This is useful for folks who are self-hosting octo-sts and would prefer to keep their trust policy files  in a dedicated or private repository separate from `.github`.