### PR TITLE
chore(README): add API Insights Read-only update

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ The following permissions are the currently enabled in octo-Sts and will be avai
 
 #### Organization Permissions
 
-- **API Insights**: `No Access`
+- **API Insights**: `Read-only`
 - **Administration**: `Read/Write`
 - **Blocking users**: `No Access`
 - **Custom organizations roles**: `No Access`


### PR DESCRIPTION
We've updated the `Insights API` scope from `No access` to `Read-only` to facilitate more accurate Organization usage reporting via apps leveraging octo-sts.