### PR TITLE
feat(ghinstall): route by checks:write permission to reduce rate-limit skew

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@
 # vendor/
 
 # ai
-**/.clause/*.local.*
+**/.claude/*.local.*
 
 # Go workspace file
 go.work

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -81,6 +81,7 @@ func main() {
 		log.Panic("no apps with valid KMS keys configured")
 	}
 	im := ghinstall.NewMultiManager(managers)
+	rrm := ghinstall.NewRoundRobin(managers)
 
 	d := duplex.New(
 		baseCfg.Port,
@@ -98,7 +99,7 @@ func main() {
 		}
 	}
 
-	pboidc.RegisterSecurityTokenServiceServer(d.Server, octosts.NewSecurityTokenServiceServer(im, ceclient, appConfig.Domain, baseCfg.Metrics))
+	pboidc.RegisterSecurityTokenServiceServer(d.Server, octosts.NewSecurityTokenServiceServer(im, rrm, ceclient, appConfig.Domain, baseCfg.Metrics))
 	if err := d.RegisterHandler(ctx, pboidc.RegisterSecurityTokenServiceHandlerFromEndpoint); err != nil {
 		log.Panicf("failed to register gateway endpoint: %v", err)
 	}

--- a/pkg/ghinstall/ghinstall.go
+++ b/pkg/ghinstall/ghinstall.go
@@ -104,7 +104,7 @@ func NewRoundRobin(managers []Manager) Manager {
 }
 
 func (rr *roundRobin) Get(ctx context.Context, owner, scope, identity string) (*ghinstallation.AppsTransport, int64, error) {
-	idx := int(rr.counter.Add(1) % uint64(len(rr.managers)))
+	idx := rr.counter.Add(1) % uint64(len(rr.managers))
 
 	atr, id, err := rr.managers[idx].Get(ctx, owner, scope, identity)
 	if err == nil {
@@ -116,7 +116,7 @@ func (rr *roundRobin) Get(ctx context.Context, owner, scope, identity string) (*
 	if st, ok := status.FromError(err); ok && st.Code() == codes.NotFound {
 		clog.InfoContextf(ctx, "app not installed for %q, trying other apps", owner)
 		for i, m := range rr.managers {
-			if i == idx {
+			if uint64(i) == idx {
 				continue
 			}
 			atr, id, err = m.Get(ctx, owner, scope, identity)

--- a/pkg/ghinstall/ghinstall.go
+++ b/pkg/ghinstall/ghinstall.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"net/http"
+	"sync/atomic"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/chainguard-dev/clog"
@@ -78,13 +79,58 @@ func (m *manager) Get(ctx context.Context, owner, _, _ string) (*ghinstallation.
 	return nil, 0, status.Errorf(codes.NotFound, "no installation found for %q", owner)
 }
 
-type multiManager struct {
+// roundRobin distributes requests across managers using an atomic counter.
+// It does not use scope or identity for routing, so different callers with
+// the same (scope, identity) may land on different apps. Use this only when
+// the caller's trust policy does not require checks:write — i.e., when there
+// is no GitHub check-run ownership constraint.
+type roundRobin struct {
 	managers []Manager
+	counter  atomic.Uint64
 }
 
-// Deprecated: use NewMultiManager.
+// NewRoundRobin creates a Manager that distributes requests across the given
+// managers using an atomic round-robin counter.
+//
+// Use this when the trust policy does NOT require checks:write. For policies
+// that do require checks:write, use NewMultiManager (consistent hashing) so
+// that the same GitHub App always handles a given (scope, identity) and can
+// therefore update check runs it previously created.
 func NewRoundRobin(managers []Manager) Manager {
-	return NewMultiManager(managers)
+	if len(managers) == 0 {
+		panic("ghinstall: NewRoundRobin requires at least one manager")
+	}
+	return &roundRobin{managers: managers}
+}
+
+func (rr *roundRobin) Get(ctx context.Context, owner, scope, identity string) (*ghinstallation.AppsTransport, int64, error) {
+	idx := int(rr.counter.Add(1) % uint64(len(rr.managers)))
+
+	atr, id, err := rr.managers[idx].Get(ctx, owner, scope, identity)
+	if err == nil {
+		return atr, id, nil
+	}
+
+	// If the selected app is not installed for this owner, try the remaining
+	// apps in order so that installation gaps are handled gracefully.
+	if st, ok := status.FromError(err); ok && st.Code() == codes.NotFound {
+		clog.InfoContextf(ctx, "app not installed for %q, trying other apps", owner)
+		for i, m := range rr.managers {
+			if i == idx {
+				continue
+			}
+			atr, id, err = m.Get(ctx, owner, scope, identity)
+			if err == nil {
+				return atr, id, nil
+			}
+		}
+	}
+
+	return nil, 0, err
+}
+
+type multiManager struct {
+	managers []Manager
 }
 
 // NewMultiManager creates a Manager that distributes requests across the given
@@ -99,6 +145,9 @@ func NewRoundRobin(managers []Manager) Manager {
 // apps. If the selected app is not installed for an owner, the remaining apps
 // are tried in order.
 func NewMultiManager(managers []Manager) Manager {
+	if len(managers) == 0 {
+		panic("ghinstall: NewMultiManager requires at least one manager")
+	}
 	return &multiManager{managers: managers}
 }
 

--- a/pkg/ghinstall/ghinstall_test.go
+++ b/pkg/ghinstall/ghinstall_test.go
@@ -397,6 +397,163 @@ func TestMultiManagerFallbackNotInstalled(t *testing.T) {
 	}
 }
 
+func TestNewRoundRobinPanicsOnEmpty(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for empty managers slice, got none")
+		}
+	}()
+	NewRoundRobin(nil)
+}
+
+func TestNewMultiManagerPanicsOnEmpty(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for empty managers slice, got none")
+		}
+	}()
+	NewMultiManager(nil)
+}
+
+func TestRoundRobin(t *testing.T) {
+	ctx := context.Background()
+	installID := int64(42)
+	appIDs := []int64{12345678, 87654321}
+
+	// Both apps installed for "my-org".
+	managers := make([]Manager, 0, len(appIDs))
+	for _, appID := range appIDs {
+		atr := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/app/installations":
+				json.NewEncoder(w).Encode([]github.Installation{{
+					ID:      github.Ptr(installID),
+					Account: &github.User{Login: github.Ptr("my-org")},
+				}})
+			default:
+				w.WriteHeader(http.StatusNotImplemented)
+			}
+		}), appID)
+		m, err := New(atr)
+		if err != nil {
+			t.Fatalf("New() = %v", err)
+		}
+		managers = append(managers, m)
+	}
+
+	rr := NewRoundRobin(managers)
+
+	// Round-robin must distribute across apps: the same (scope, identity) must
+	// NOT always return the same app (unlike consistent hashing).
+	const scope, identity = "my-org/repo", "my-identity"
+	seen := map[int64]bool{}
+	for range 4 {
+		atr, gotID, err := rr.Get(ctx, "my-org", scope, identity)
+		if err != nil {
+			t.Fatalf("Get() = %v", err)
+		}
+		if gotID != installID {
+			t.Errorf("install ID: got = %d, wanted = %d", gotID, installID)
+		}
+		seen[atr.AppID()] = true
+	}
+	if len(seen) != len(appIDs) {
+		t.Errorf("round-robin did not distribute across all apps: only saw app IDs %v", seen)
+	}
+}
+
+func TestRoundRobinFallback(t *testing.T) {
+	ctx := context.Background()
+	installID := int64(42)
+	primaryAppID := int64(12345678)
+	secondaryAppID := int64(87654321)
+
+	// Primary app is installed for "my-org"; secondary is not.
+	primaryATR := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/app/installations":
+			json.NewEncoder(w).Encode([]github.Installation{{
+				ID:      github.Ptr(installID),
+				Account: &github.User{Login: github.Ptr("my-org")},
+			}})
+		default:
+			w.WriteHeader(http.StatusNotImplemented)
+		}
+	}), primaryAppID)
+	primaryMgr, err := New(primaryATR)
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	secondaryATR := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/app/installations":
+			json.NewEncoder(w).Encode([]github.Installation{}) // not installed
+		default:
+			w.WriteHeader(http.StatusNotImplemented)
+		}
+	}), secondaryAppID)
+	secondaryMgr, err := New(secondaryATR)
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	rr := NewRoundRobin([]Manager{primaryMgr, secondaryMgr})
+
+	// All calls must resolve via the primary app since the secondary is not installed.
+	for i := range 4 {
+		atr, gotID, err := rr.Get(ctx, "my-org", "my-org/repo", "my-identity")
+		if err != nil {
+			t.Fatalf("Get() call %d = %v", i, err)
+		}
+		if gotID != installID {
+			t.Errorf("call %d: install ID: got = %d, wanted = %d", i, gotID, installID)
+		}
+		if got := atr.AppID(); got != primaryAppID {
+			t.Errorf("call %d: app ID: got = %d, wanted primary = %d", i, got, primaryAppID)
+		}
+	}
+}
+
+func TestRoundRobinFallbackNotInstalled(t *testing.T) {
+	ctx := context.Background()
+	appIDs := []int64{12345678, 87654321}
+
+	// Neither app is installed for "missing-org".
+	managers := make([]Manager, 0, len(appIDs))
+	for _, appID := range appIDs {
+		atr := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/app/installations":
+				json.NewEncoder(w).Encode([]github.Installation{})
+			default:
+				w.WriteHeader(http.StatusNotImplemented)
+			}
+		}), appID)
+		m, err := New(atr)
+		if err != nil {
+			t.Fatalf("New() = %v", err)
+		}
+		managers = append(managers, m)
+	}
+
+	rr := NewRoundRobin(managers)
+
+	for i := range 2 {
+		_, _, err := rr.Get(ctx, "missing-org", "missing-org/repo", "my-identity")
+		if err == nil {
+			t.Fatalf("Get() call %d: expected error, got nil", i)
+		}
+		st, ok := status.FromError(err)
+		if !ok {
+			t.Fatalf("Get() call %d: expected gRPC status error, got %T", i, err)
+		}
+		if st.Code() != codes.NotFound {
+			t.Errorf("Get() call %d: code: got = %v, wanted = %v", i, st.Code(), codes.NotFound)
+		}
+	}
+}
+
 func newTestClient(t *testing.T, h http.Handler, appIDs ...int64) *ghinstallation.AppsTransport {
 	t.Helper()
 

--- a/pkg/octosts/octosts.go
+++ b/pkg/octosts/octosts.go
@@ -40,9 +40,10 @@ const (
 	maxRetry   = 3
 )
 
-func NewSecurityTokenServiceServer(im ghinstall.Manager, ceclient cloudevents.Client, domain string, metrics bool) pboidc.SecurityTokenServiceServer {
+func NewSecurityTokenServiceServer(im, rrm ghinstall.Manager, ceclient cloudevents.Client, domain string, metrics bool) pboidc.SecurityTokenServiceServer {
 	return &sts{
 		im:       im,
+		rrm:      rrm,
 		ceclient: ceclient,
 		domain:   domain,
 		metrics:  metrics,
@@ -54,7 +55,14 @@ var trustPolicies = expirablelru.NewLRU[cacheTrustPolicyKey, string](200, nil, t
 type sts struct {
 	pboidc.UnimplementedSecurityTokenServiceServer
 
-	im       ghinstall.Manager
+	// im is the consistent-hash manager used when the trust policy requires
+	// checks:write. Consistent hashing ensures the same GitHub App always
+	// handles a given (scope, identity), which is required because GitHub
+	// check runs can only be updated by the app that created them.
+	im ghinstall.Manager
+	// rrm is the round-robin manager used when the trust policy does NOT
+	// require checks:write. If nil, im is used for all requests.
+	rrm      ghinstall.Manager
 	ceclient cloudevents.Client
 	domain   string
 	metrics  bool
@@ -224,6 +232,39 @@ func (s *sts) Exchange(ctx context.Context, request *pboidc.ExchangeRequest) (_ 
 	}, nil
 }
 
+// managerFor returns the appropriate Manager for the given trust policy key.
+//
+// If the trust policy is already cached and does NOT require checks:write,
+// round-robin is used to distribute load across apps. Otherwise consistent
+// hashing is used, which guarantees that the same (scope, identity) always
+// routes to the same GitHub App — a requirement for updating check runs.
+//
+// On a cache miss we cannot know the required permissions yet, so we default
+// to consistent hashing (the safe choice: it is always correct for
+// checks:write policies and merely suboptimal for others on the first call).
+func (s *sts) managerFor(key cacheTrustPolicyKey) ghinstall.Manager {
+	if s.rrm == nil {
+		return s.im
+	}
+	raw, ok := trustPolicies.Get(key)
+	if !ok {
+		return s.im
+	}
+	var tp OrgTrustPolicy
+	if err := yaml.UnmarshalStrict([]byte(raw), &tp); err != nil {
+		return s.im
+	}
+	if hasChecksWrite(tp.Permissions) {
+		return s.im
+	}
+	return s.rrm
+}
+
+// hasChecksWrite reports whether the given permissions include checks:write.
+func hasChecksWrite(perms github.InstallationPermissions) bool {
+	return perms.Checks != nil && *perms.Checks == "write"
+}
+
 func (s *sts) lookupInstallAndTrustPolicy(ctx context.Context, scope, identity string) (*ghinstallation.AppsTransport, int64, *OrgTrustPolicy, error) {
 	otp := &OrgTrustPolicy{}
 	var tp trustPolicy = &otp.TrustPolicy
@@ -242,15 +283,19 @@ func (s *sts) lookupInstallAndTrustPolicy(ctx context.Context, scope, identity s
 		tp = otp
 	}
 
-	atr, id, err := s.im.Get(ctx, owner, scope, identity)
-	if err != nil {
-		return nil, 0, nil, err
-	}
-
 	trustPolicyKey := cacheTrustPolicyKey{
 		owner:    owner,
 		repo:     repo,
 		identity: identity,
+	}
+
+	// Choose routing strategy before fetching the installation. managerFor
+	// peeks the trust policy cache so that, after the first call, policies
+	// without checks:write use round-robin instead of consistent hashing.
+	im := s.managerFor(trustPolicyKey)
+	atr, id, err := im.Get(ctx, owner, scope, identity)
+	if err != nil {
+		return nil, 0, nil, err
 	}
 
 	if err := s.lookupTrustPolicy(ctx, atr, id, trustPolicyKey, tp); err != nil {

--- a/pkg/octosts/octosts_test.go
+++ b/pkg/octosts/octosts_test.go
@@ -383,6 +383,77 @@ func TestExchangeRateLimit(t *testing.T) {
 	}
 }
 
+func TestManagerFor(t *testing.T) {
+	im := &fakeInstallMgr{}
+	rrm := &fakeInstallMgr{}
+	s := &sts{im: im, rrm: rrm}
+
+	key := cacheTrustPolicyKey{owner: "org", repo: "repo", identity: "ci"}
+
+	t.Run("cache miss uses consistent hashing", func(t *testing.T) {
+		trustPolicies.Remove(key)
+		if got := s.managerFor(key); got != im {
+			t.Error("expected consistent-hash manager on cache miss, got round-robin")
+		}
+	})
+
+	t.Run("cached policy with checks write uses consistent hashing", func(t *testing.T) {
+		trustPolicies.Add(key, `
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: "repo:org/repo:.*"
+permissions:
+  checks: write
+`)
+		if got := s.managerFor(key); got != im {
+			t.Error("expected consistent-hash manager for checks:write policy, got round-robin")
+		}
+	})
+
+	t.Run("cached policy without checks write uses round-robin", func(t *testing.T) {
+		trustPolicies.Add(key, `
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: "repo:org/repo:.*"
+permissions:
+  contents: read
+`)
+		if got := s.managerFor(key); got != rrm {
+			t.Error("expected round-robin manager for non-checks:write policy, got consistent-hash")
+		}
+	})
+
+	t.Run("cached policy with checks read uses round-robin", func(t *testing.T) {
+		trustPolicies.Add(key, `
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: "repo:org/repo:.*"
+permissions:
+  checks: read
+`)
+		if got := s.managerFor(key); got != rrm {
+			t.Error("expected round-robin manager for checks:read policy, got consistent-hash")
+		}
+	})
+
+	t.Run("malformed cached policy uses consistent hashing", func(t *testing.T) {
+		trustPolicies.Add(key, `{not valid yaml: [`)
+		if got := s.managerFor(key); got != im {
+			t.Error("expected consistent-hash manager on parse error, got round-robin")
+		}
+	})
+
+	t.Run("nil rrm always uses consistent hashing", func(t *testing.T) {
+		sNoRRM := &sts{im: im}
+		trustPolicies.Add(key, `
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: "repo:org/repo:.*"
+permissions:
+  contents: read
+`)
+		if got := sNoRRM.managerFor(key); got != im {
+			t.Error("expected consistent-hash manager when rrm is nil, got something else")
+		}
+	})
+}
+
 func newGitHubClient(t *testing.T, h http.Handler) *ghinstallation.AppsTransport {
 	t.Helper()
 


### PR DESCRIPTION
## What

Restore a real round-robin Manager (`NewRoundRobin`) backed by an atomic counter, distinct from the consistent-hash `MultiManager`. Add a `managerFor` helper to `sts` that peeks the trust policy LRU cache before each Exchange call: if the cached policy lacks `checks: write`, the round-robin manager is used; otherwise the consistent-hash manager is used. On a cache miss the consistent-hash manager is always chosen as a safe default.

`NewRoundRobin` and `NewMultiManager` now panic at construction time with a clear message if called with an empty slice, converting a silent divide-by-zero into an explicit programming error.

## Why

Consistent hashing on `(scope, identity)` was introduced to prevent 403 errors when a GitHub App tried to update a check run it did not create. That constraint only applies to policies with `checks: write`. Policies that only read contents, trigger deployments, or perform other non-check operations were being unnecessarily pinned to a single app, concentrating their GitHub API quota on one app while the other sat underutilised. Round-robin restores balanced load distribution for those callers.

## Notes

- The first Exchange call for any `(scope, identity)` always uses consistent hashing because the trust policy is not yet cached; round-robin kicks in from the second call onward (within the 5-minute TTL). This is safe: a fresh call creates new check runs, so there is no prior ownership to violate.
- `managerFor` re-parses the cached raw YAML on every routing decision (no compiled `TrustPolicy` in the cache). This is intentionally lightweight — the parse is bounded by policy file size — but reviewers should confirm this is acceptable under load.
- If `rrm` is nil (e.g. in tests that construct `&sts{im: ...}` directly), `managerFor` falls back to `im`, preserving backwards-compatible behaviour for all existing tests.
- Adding or removing a GitHub App from the pool reshuffles the consistent-hash modulo for some `(scope, identity)` pairs; the round-robin pool size change has no such invariant to break.
- Security review: routing is not an authorization boundary — token permissions are validated post-routing by the trust policy regardless of which app is selected. `managerFor` re-parses the same YAML already in cache using the same strict unmarshaler, introducing no new deserialization surface. All error paths (cache miss, parse failure, nil `rrm`) fall back to consistent hashing.
- The constructor panics protect future callers outside `main.go`; `main.go` already guards against empty managers at startup so the panics will not fire in production.

## Testing

- `TestRoundRobin`: verifies distribution across all apps for the same `(scope, identity)` — contrasting the consistent-hash behaviour.
- `TestRoundRobinFallback`: verifies fallback to an installed app when the selected app is not installed for an owner.
- `TestRoundRobinFallbackNotInstalled`: verifies `NotFound` error when no app is installed.
- `TestNewRoundRobinPanicsOnEmpty` / `TestNewMultiManagerPanicsOnEmpty`: verifies constructor panics on empty slice.
- `TestManagerFor`: six sub-cases covering cache miss, `checks: write`, no `checks: write`, `checks: read`, malformed YAML, and nil `rrm`.