### PR TITLE
feat(octosts): round-robin policy reads with rate-limit retry

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -99,7 +99,7 @@ func main() {
 		}
 	}
 
-	pboidc.RegisterSecurityTokenServiceServer(d.Server, octosts.NewSecurityTokenServiceServer(im, rrm, ceclient, appConfig.Domain, baseCfg.Metrics))
+	pboidc.RegisterSecurityTokenServiceServer(d.Server, octosts.NewSecurityTokenServiceServer(im, rrm, len(managers), ceclient, appConfig.Domain, baseCfg.Metrics))
 	if err := d.RegisterHandler(ctx, pboidc.RegisterSecurityTokenServiceHandlerFromEndpoint); err != nil {
 		log.Panicf("failed to register gateway endpoint: %v", err)
 	}

--- a/pkg/octosts/octosts.go
+++ b/pkg/octosts/octosts.go
@@ -40,10 +40,11 @@ const (
 	maxRetry   = 3
 )
 
-func NewSecurityTokenServiceServer(im, rrm ghinstall.Manager, ceclient cloudevents.Client, domain string, metrics bool) pboidc.SecurityTokenServiceServer {
+func NewSecurityTokenServiceServer(im, rrm ghinstall.Manager, appCount int, ceclient cloudevents.Client, domain string, metrics bool) pboidc.SecurityTokenServiceServer {
 	return &sts{
 		im:       im,
 		rrm:      rrm,
+		appCount: appCount,
 		ceclient: ceclient,
 		domain:   domain,
 		metrics:  metrics,
@@ -60,9 +61,12 @@ type sts struct {
 	// handles a given (scope, identity), which is required because GitHub
 	// check runs can only be updated by the app that created them.
 	im ghinstall.Manager
-	// rrm is the round-robin manager used when the trust policy does NOT
-	// require checks:write. If nil, im is used for all requests.
-	rrm      ghinstall.Manager
+	// rrm is the round-robin manager used for all trust policy reads and for
+	// token exchanges when the trust policy does NOT require checks:write.
+	rrm ghinstall.Manager
+	// appCount is the number of underlying GitHub App managers. Used to cap
+	// rate-limit retries so that each app is tried at most once.
+	appCount int
 	ceclient cloudevents.Client
 	domain   string
 	metrics  bool
@@ -243,9 +247,6 @@ func (s *sts) Exchange(ctx context.Context, request *pboidc.ExchangeRequest) (_ 
 // to consistent hashing (the safe choice: it is always correct for
 // checks:write policies and merely suboptimal for others on the first call).
 func (s *sts) managerFor(key cacheTrustPolicyKey) ghinstall.Manager {
-	if s.rrm == nil {
-		return s.im
-	}
 	raw, ok := trustPolicies.Get(key)
 	if !ok {
 		return s.im
@@ -289,19 +290,59 @@ func (s *sts) lookupInstallAndTrustPolicy(ctx context.Context, scope, identity s
 		identity: identity,
 	}
 
-	// Choose routing strategy before fetching the installation. managerFor
-	// peeks the trust policy cache so that, after the first call, policies
-	// without checks:write use round-robin instead of consistent hashing.
+	// Choose exchange routing strategy. managerFor peeks the trust policy
+	// cache so that, after the first call, policies without checks:write use
+	// round-robin instead of consistent hashing for the exchange.
 	im := s.managerFor(trustPolicyKey)
 	atr, id, err := im.Get(ctx, owner, scope, identity)
 	if err != nil {
 		return nil, 0, nil, err
 	}
 
-	if err := s.lookupTrustPolicy(ctx, atr, id, trustPolicyKey, tp); err != nil {
+	// Policy reads always use round-robin to spread GitHub API calls across
+	// apps. Any installed app can read the policy file — there is no
+	// state dependency between which app reads the policy and which app
+	// performs the exchange. The exchange transport (atr, id) is returned
+	// to the caller unchanged.
+	readAtr, readId := atr, id
+	if rAtr, rId, rErr := s.rrm.Get(ctx, owner, scope, identity); rErr == nil {
+		readAtr, readId = rAtr, rId
+	}
+
+	err = s.lookupTrustPolicy(ctx, readAtr, readId, trustPolicyKey, tp)
+
+	// If the policy read was rate-limited and there are multiple apps,
+	// retry with the remaining apps in the round-robin rotation.
+	// Cap retries at maxRetry to avoid hammering all apps on a broad outage.
+	if isRateLimit(err) && s.appCount > 1 {
+		retries := min(maxRetry, s.appCount-1)
+		for i := 0; i < retries; i++ {
+			clog.InfoContextf(ctx, "policy read rate-limited, trying next app (%d/%d)", i+1, retries)
+			rAtr, rId, rErr := s.rrm.Get(ctx, owner, scope, identity)
+			if rErr != nil {
+				continue
+			}
+			err = s.lookupTrustPolicy(ctx, rAtr, rId, trustPolicyKey, tp)
+			if !isRateLimit(err) {
+				break
+			}
+		}
+	}
+
+	if err != nil {
 		return atr, id, nil, err
 	}
 	return atr, id, otp, nil
+}
+
+// isRateLimit reports whether err is a gRPC ResourceExhausted error,
+// indicating a GitHub API rate limit (403 secondary or 429 primary).
+func isRateLimit(err error) bool {
+	if err == nil {
+		return false
+	}
+	st, ok := status.FromError(err)
+	return ok && st.Code() == codes.ResourceExhausted
 }
 
 type trustPolicy interface {

--- a/pkg/octosts/octosts_test.go
+++ b/pkg/octosts/octosts_test.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -137,7 +138,9 @@ func TestExchange(t *testing.T) {
 	ctx = metadata.NewIncomingContext(ctx, metadata.MD{"authorization": []string{"Bearer " + token}})
 
 	sts := &sts{
-		im: &fakeInstallMgr{atr: atr},
+		im:       &fakeInstallMgr{atr: atr},
+		rrm:      &fakeInstallMgr{atr: atr},
+		appCount: 1,
 	}
 	for _, tc := range []struct {
 		name string
@@ -223,7 +226,9 @@ func TestExchangeValidation(t *testing.T) {
 	ctx = metadata.NewIncomingContext(ctx, metadata.MD{"authorization": []string{"Bearer " + token}})
 
 	sts := &sts{
-		im: &fakeInstallMgr{atr: atr},
+		im:       &fakeInstallMgr{atr: atr},
+		rrm:      &fakeInstallMgr{atr: atr},
+		appCount: 1,
 	}
 
 	tests := []struct {
@@ -363,7 +368,9 @@ func TestExchangeRateLimit(t *testing.T) {
 			ctx = metadata.NewIncomingContext(ctx, metadata.MD{"authorization": []string{"Bearer " + token}})
 
 			s := &sts{
-				im: &fakeInstallMgr{atr: atr},
+				im:       &fakeInstallMgr{atr: atr},
+				rrm:      &fakeInstallMgr{atr: atr},
+				appCount: 1,
 			}
 			_, err = s.Exchange(ctx, &v1.ExchangeRequest{
 				Identity: tc.identity,
@@ -439,19 +446,271 @@ permissions:
 			t.Error("expected consistent-hash manager on parse error, got round-robin")
 		}
 	})
+}
 
-	t.Run("nil rrm always uses consistent hashing", func(t *testing.T) {
-		sNoRRM := &sts{im: im}
-		trustPolicies.Add(key, `
-issuer: https://token.actions.githubusercontent.com
-subject_pattern: "repo:org/repo:.*"
-permissions:
-  contents: read
-`)
-		if got := sNoRRM.managerFor(key); got != im {
-			t.Error("expected consistent-hash manager when rrm is nil, got something else")
-		}
+// failInstallMgr is a Manager whose Get always returns an error.
+type failInstallMgr struct{}
+
+func (f *failInstallMgr) Get(_ context.Context, _, _, _ string) (*ghinstallation.AppsTransport, int64, error) {
+	return nil, 0, fmt.Errorf("not installed")
+}
+
+var _ ghinstall.Manager = (*failInstallMgr)(nil)
+
+// sequentialInstallMgr returns transports in order on successive Get calls.
+// Used to test retry behaviour where the first app is rate-limited and the
+// second succeeds.
+type sequentialInstallMgr struct {
+	transports []*ghinstallation.AppsTransport
+	idx        atomic.Int32
+}
+
+func (s *sequentialInstallMgr) Get(_ context.Context, _, _, _ string) (*ghinstallation.AppsTransport, int64, error) {
+	i := int(s.idx.Add(1) - 1)
+	if i >= len(s.transports) {
+		return nil, 0, fmt.Errorf("no more transports")
+	}
+	return s.transports[i], 1234, nil
+}
+
+var _ ghinstall.Manager = (*sequentialInstallMgr)(nil)
+
+// newFakeGitHubNoContents returns a fake GitHub server that handles
+// installations and access_tokens but returns 404 for all content requests.
+// Used to prove that a given transport was NOT used for the policy read.
+func newFakeGitHubNoContents() *fakeGitHub {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/app/installations", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]github.Installation{{
+			ID:      github.Ptr(int64(1234)),
+			Account: &github.User{Login: github.Ptr("org")},
+		}})
 	})
+	mux.HandleFunc("/app/installations/{appID}/access_tokens", func(w http.ResponseWriter, r *http.Request) {
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		json.NewEncoder(w).Encode(github.InstallationToken{
+			Token:     github.Ptr(base64.StdEncoding.EncodeToString(b)),
+			ExpiresAt: &github.Timestamp{Time: time.Now().Add(10 * time.Minute)},
+		})
+	})
+	mux.HandleFunc("/repos/{org}/{repo}/contents/.github/chainguard/{identity}", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotImplemented)
+		fmt.Fprintf(io.MultiWriter(w, os.Stdout), "%s %s not implemented\n", r.Method, r.URL.Path)
+	})
+	return &fakeGitHub{mux: mux}
+}
+
+// TestPolicyReadUsesRoundRobin verifies that trust policy reads use the rrm
+// transport, not the im transport. im points to a server with no contents
+// handler; rrm points to a server with the policy file. Exchange succeeds
+// only if rrm was used for the read.
+func TestPolicyReadUsesRoundRobin(t *testing.T) {
+	key := cacheTrustPolicyKey{owner: "org", repo: "repo", identity: "foo"}
+	trustPolicies.Remove(key)
+	t.Cleanup(func() { trustPolicies.Remove(key) })
+
+	ctx := context.Background()
+	imAtr := newGitHubClient(t, newFakeGitHubNoContents())
+	rrmAtr := newGitHubClient(t, newFakeGitHub())
+
+	pk, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("cannot generate RSA key %v", err)
+	}
+	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.RS256, Key: pk}, nil)
+	if err != nil {
+		t.Fatalf("jose.NewSigner() = %v", err)
+	}
+
+	iss := "https://token.actions.githubusercontent.com"
+	token, err := josejwt.Signed(signer).Claims(josejwt.Claims{
+		Subject:  "foo",
+		Issuer:   iss,
+		Audience: josejwt.Audience{"octosts"},
+		Expiry:   josejwt.NewNumericDate(time.Now().Add(10 * time.Minute)),
+	}).Serialize()
+	if err != nil {
+		t.Fatalf("CompactSerialize failed: %v", err)
+	}
+	provider.AddTestKeySetVerifier(t, iss, &oidc.StaticKeySet{PublicKeys: []crypto.PublicKey{pk.Public()}})
+	ctx = metadata.NewIncomingContext(ctx, metadata.MD{"authorization": []string{"Bearer " + token}})
+
+	s := &sts{
+		im:       &fakeInstallMgr{atr: imAtr},
+		rrm:      &fakeInstallMgr{atr: rrmAtr},
+		appCount: 2,
+	}
+	// Trust policy lives on the rrm server. If im were used for the read it
+	// would 404 and the exchange would fail.
+	_, err = s.Exchange(ctx, &v1.ExchangeRequest{
+		Identity: "foo",
+		Scope:    "org/repo",
+	})
+	if err != nil {
+		t.Fatalf("Exchange failed: %v — policy read did not use rrm transport", err)
+	}
+}
+
+// TestPolicyReadFallsBackToIM verifies that when rrm.Get fails the policy
+// read falls back to the im transport so that single-app deployments and
+// transient installation-lookup failures are handled gracefully.
+func TestPolicyReadFallsBackToIM(t *testing.T) {
+	key := cacheTrustPolicyKey{owner: "org", repo: "repo", identity: "foo"}
+	trustPolicies.Remove(key)
+	t.Cleanup(func() { trustPolicies.Remove(key) })
+
+	ctx := context.Background()
+	imAtr := newGitHubClient(t, newFakeGitHub())
+
+	pk, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("cannot generate RSA key %v", err)
+	}
+	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.RS256, Key: pk}, nil)
+	if err != nil {
+		t.Fatalf("jose.NewSigner() = %v", err)
+	}
+
+	iss := "https://token.actions.githubusercontent.com"
+	token, err := josejwt.Signed(signer).Claims(josejwt.Claims{
+		Subject:  "foo",
+		Issuer:   iss,
+		Audience: josejwt.Audience{"octosts"},
+		Expiry:   josejwt.NewNumericDate(time.Now().Add(10 * time.Minute)),
+	}).Serialize()
+	if err != nil {
+		t.Fatalf("CompactSerialize failed: %v", err)
+	}
+	provider.AddTestKeySetVerifier(t, iss, &oidc.StaticKeySet{PublicKeys: []crypto.PublicKey{pk.Public()}})
+	ctx = metadata.NewIncomingContext(ctx, metadata.MD{"authorization": []string{"Bearer " + token}})
+
+	s := &sts{
+		im:       &fakeInstallMgr{atr: imAtr},
+		rrm:      &failInstallMgr{},
+		appCount: 1,
+	}
+	// rrm.Get() always errors; exchange must still succeed via im fallback.
+	_, err = s.Exchange(ctx, &v1.ExchangeRequest{
+		Identity: "foo",
+		Scope:    "org/repo",
+	})
+	if err != nil {
+		t.Fatalf("Exchange failed: %v — fallback to im transport did not work", err)
+	}
+}
+
+// TestPolicyReadRetriesOnRateLimit verifies that when the first rrm app is
+// rate-limited, the retry loop picks the next app and the exchange succeeds.
+func TestPolicyReadRetriesOnRateLimit(t *testing.T) {
+	key := cacheTrustPolicyKey{owner: "org", repo: "repo", identity: "foo"}
+	trustPolicies.Remove(key)
+	t.Cleanup(func() { trustPolicies.Remove(key) })
+
+	ctx := context.Background()
+	rateLimitedAtr := newGitHubClient(t, newFakeGitHubRateLimit(http.StatusForbidden))
+	workingAtr := newGitHubClient(t, newFakeGitHub())
+
+	pk, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("cannot generate RSA key %v", err)
+	}
+	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.RS256, Key: pk}, nil)
+	if err != nil {
+		t.Fatalf("jose.NewSigner() = %v", err)
+	}
+
+	iss := "https://token.actions.githubusercontent.com"
+	token, err := josejwt.Signed(signer).Claims(josejwt.Claims{
+		Subject:  "foo",
+		Issuer:   iss,
+		Audience: josejwt.Audience{"octosts"},
+		Expiry:   josejwt.NewNumericDate(time.Now().Add(10 * time.Minute)),
+	}).Serialize()
+	if err != nil {
+		t.Fatalf("CompactSerialize failed: %v", err)
+	}
+	provider.AddTestKeySetVerifier(t, iss, &oidc.StaticKeySet{PublicKeys: []crypto.PublicKey{pk.Public()}})
+	ctx = metadata.NewIncomingContext(ctx, metadata.MD{"authorization": []string{"Bearer " + token}})
+
+	s := &sts{
+		im: &fakeInstallMgr{atr: workingAtr},
+		rrm: &sequentialInstallMgr{
+			transports: []*ghinstallation.AppsTransport{rateLimitedAtr, workingAtr},
+		},
+		appCount: 2,
+	}
+	// First rrm.Get returns the rate-limited transport; retry picks the
+	// working transport. Exchange should succeed.
+	_, err = s.Exchange(ctx, &v1.ExchangeRequest{
+		Identity: "foo",
+		Scope:    "org/repo",
+	})
+	if err != nil {
+		t.Fatalf("Exchange failed: %v — rate-limit retry did not recover", err)
+	}
+}
+
+// TestPolicyReadAllRateLimitedReturnsError verifies that when every app is
+// rate-limited the error is surfaced to the caller (not retried indefinitely).
+func TestPolicyReadAllRateLimitedReturnsError(t *testing.T) {
+	key := cacheTrustPolicyKey{owner: "org", repo: "repo", identity: "foo"}
+	trustPolicies.Remove(key)
+	t.Cleanup(func() { trustPolicies.Remove(key) })
+
+	ctx := context.Background()
+	rl1 := newGitHubClient(t, newFakeGitHubRateLimit(http.StatusForbidden))
+	rl2 := newGitHubClient(t, newFakeGitHubRateLimit(http.StatusTooManyRequests))
+
+	pk, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("cannot generate RSA key %v", err)
+	}
+	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.RS256, Key: pk}, nil)
+	if err != nil {
+		t.Fatalf("jose.NewSigner() = %v", err)
+	}
+
+	iss := "https://token.actions.githubusercontent.com"
+	token, err := josejwt.Signed(signer).Claims(josejwt.Claims{
+		Subject:  "foo",
+		Issuer:   iss,
+		Audience: josejwt.Audience{"octosts"},
+		Expiry:   josejwt.NewNumericDate(time.Now().Add(10 * time.Minute)),
+	}).Serialize()
+	if err != nil {
+		t.Fatalf("CompactSerialize failed: %v", err)
+	}
+	provider.AddTestKeySetVerifier(t, iss, &oidc.StaticKeySet{PublicKeys: []crypto.PublicKey{pk.Public()}})
+	ctx = metadata.NewIncomingContext(ctx, metadata.MD{"authorization": []string{"Bearer " + token}})
+
+	s := &sts{
+		im: &fakeInstallMgr{atr: rl1},
+		rrm: &sequentialInstallMgr{
+			transports: []*ghinstallation.AppsTransport{rl1, rl2},
+		},
+		appCount: 2,
+	}
+	_, err = s.Exchange(ctx, &v1.ExchangeRequest{
+		Identity: "foo",
+		Scope:    "org/repo",
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil — all apps are rate-limited")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %T", err)
+	}
+	if st.Code() != codes.ResourceExhausted {
+		t.Errorf("expected code ResourceExhausted, got %v", st.Code())
+	}
 }
 
 func newGitHubClient(t *testing.T, h http.Handler) *ghinstallation.AppsTransport {


### PR DESCRIPTION
## What

Decouple the trust policy read transport from the exchange transport so that policy reads always use round-robin across all app installations, while the exchange continues to use consistent hashing for checks:write policies. When a policy read is rate-limited (403/429), retry with the next app in the rotation, capped at 3 attempts.

## Why

All policy reads were funneling through a single app selected by consistent hashing on cache miss, causing that app to hit GitHub's secondary rate limit. Round-robin spreading reduces per-app request rate proportionally to the number of apps deployed (e.g. ~10x with 10 apps).

## Notes

- The `rrm` nil guard in `managerFor` was dead code (`main.go` always initializes `rrm`) and has been removed. Existing tests updated to always provide `rrm`.
- Retry cap uses the existing `maxRetry` (3) constant, bounded by `appCount-1`. Single-app deployments skip the retry loop entirely.
- Each retry attempt creates and revokes a separate short-lived installation token. Revocation failures are warnings, not errors.
- `NewSecurityTokenServiceServer` signature changed (added `appCount int` parameter) — callers outside this repo will need updating.

## Testing

- `TestPolicyReadUsesRoundRobin` — proves `rrm` transport is used for reads by pointing `im` at a server that 404s on contents; exchange only succeeds if `rrm` served the policy.
- `TestPolicyReadFallsBackToIM` — `rrm.Get()` always errors; exchange succeeds via `im` fallback, validating single-app and transient-failure paths.
- `TestPolicyReadRetriesOnRateLimit` — first app returns 403 rate limit, retry picks a working app, exchange succeeds.
- `TestPolicyReadAllRateLimitedReturnsError` — all apps rate-limited, verifies `ResourceExhausted` is surfaced (not retried indefinitely).
- Existing `TestExchange`, `TestExchangeValidation`, `TestExchangeRateLimit`, and `TestManagerFor` updated and passing.