### PR TITLE
feat(metrics): populate app_id and installation_id on GitHub rate-limit metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.18.0
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/chainguard-dev/clog v1.8.0
-	github.com/chainguard-dev/terraform-infra-common v1.0.2
+	github.com/chainguard-dev/terraform-infra-common v1.0.4
 	github.com/cloudevents/sdk-go/v2 v2.16.2
 	github.com/coreos/go-oidc/v3 v3.18.0
 	github.com/golang-jwt/jwt/v4 v4.5.2
@@ -88,9 +88,9 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.67.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 // indirect
 	go.opentelemetry.io/otel v1.43.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.42.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.42.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.40.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chainguard-dev/clog v1.8.0 h1:frlTMEdg3XQR+ioQ6O9i92uigY8GTUcWKpuCFkhcCHA=
 github.com/chainguard-dev/clog v1.8.0/go.mod h1:5MQOZi+Iu7fV7GcJG8ag8rCB5elEOpqRMKEASgnGVdo=
-github.com/chainguard-dev/terraform-infra-common v1.0.2 h1:kG6uWuSfBUDRTb8tOLZ7C92ilST5dkj/E7uTizaTxTc=
-github.com/chainguard-dev/terraform-infra-common v1.0.2/go.mod h1:ML5SAtGeFZ5eKhTQgGBVHVAImC2WGMtQibECoKXJrlk=
+github.com/chainguard-dev/terraform-infra-common v1.0.4 h1:UX4/VCHlnhOY2Ya/6t/ZWjvqtFt4pp6yOY0Ylaj28Ig=
+github.com/chainguard-dev/terraform-infra-common v1.0.4/go.mod h1:rpM8SrnmAQBArwQfqUtUp3LMrOJtSLX6YAC/H4KpzL4=
 github.com/cloudevents/sdk-go/v2 v2.16.2 h1:ZYDFrYke4FD+jM8TZTJJO6JhKHzOQl2oqpFK1D+NnQM=
 github.com/cloudevents/sdk-go/v2 v2.16.2/go.mod h1:laOcGImm4nVJEU+PHnUrKL56CKmRL65RlQF0kRmW/kg=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/Tv1FZd4SCg8axKApyNyRsAt/w=
@@ -180,12 +180,12 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 h1:Oyrsyzu
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0/go.mod h1:C2NGBr+kAB4bk3xtMXfZ94gqFDtg/GkI7e9zqGh5Beg=
 go.opentelemetry.io/otel v1.43.0 h1:mYIM03dnh5zfN7HautFE4ieIig9amkNANT+xcVxAj9I=
 go.opentelemetry.io/otel v1.43.0/go.mod h1:JuG+u74mvjvcm8vj8pI5XiHy1zDeoCS2LB1spIq7Ay0=
-go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.42.0 h1:THuZiwpQZuHPul65w4WcwEnkX2QIuMT+UFoOrygtoJw=
-go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.42.0/go.mod h1:J2pvYM5NGHofZ2/Ru6zw/TNWnEQp5crgyDeSrYpXkAw=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 h1:88Y4s2C8oTui1LGM6bTWkw0ICGcOLCAI5l6zsD1j20k=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0/go.mod h1:Vl1/iaggsuRlrHf/hfPJPvVag77kKyvrLeD10kpMl+A=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.42.0 h1:zWWrB1U6nqhS/k6zYB74CjRpuiitRtLLi68VcgmOEto=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.42.0/go.mod h1:2qXPNBX1OVRC0IwOnfo1ljoid+RD0QK3443EaqVlsOU=
-go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.40.0 h1:wVZXIWjQSeSmMoxF74LzAnpVQOAFDo3pPji9Y4SOFKc=
-go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.40.0/go.mod h1:khvBS2IggMFNwZK/6lEeHg/W57h/IX6J4URh57fuI40=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0 h1:3iZJKlCZufyRzPzlQhUIWVmfltrXuGyfjREgGP3UUjc=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0/go.mod h1:/G+nUPfhq2e+qiXMGxMwumDrP5jtzU+mWN7/sjT2rak=
 go.opentelemetry.io/otel/exporters/prometheus v0.64.0 h1:g0LRDXMX/G1SEZtK8zl8Chm4K6GBwRkjPKE36LxiTYs=
 go.opentelemetry.io/otel/exporters/prometheus v0.64.0/go.mod h1:UrgcjnarfdlBDP3GjDIJWe6HTprwSazNjwsI+Ru6hro=
 go.opentelemetry.io/otel/metric v1.43.0 h1:d7638QeInOnuwOONPp4JAOGfbCEpYb+K6DVWvdxGzgM=

--- a/pkg/ghtransport/ghtransport.go
+++ b/pkg/ghtransport/ghtransport.go
@@ -10,9 +10,19 @@ import (
 
 	kms "cloud.google.com/go/kms/apiv1"
 	"github.com/bradleyfalzon/ghinstallation/v2"
+	metrics "github.com/chainguard-dev/terraform-infra-common/pkg/httpmetrics"
 	envConfig "github.com/octo-sts/app/pkg/envconfig"
 	"github.com/octo-sts/app/pkg/gcpkms"
 )
+
+// EnrichContext adds GitHub App and installation ID values to the context so
+// that the httpmetrics transport can label rate-limit metrics with the specific
+// installation consuming quota.
+func EnrichContext(ctx context.Context, appID, installationID int64) context.Context {
+	ctx = metrics.WithGitHubAppID(ctx, appID)
+	ctx = metrics.WithGitHubInstallationID(ctx, installationID)
+	return ctx
+}
 
 func New(ctx context.Context, appID int64, kmsKey string, env *envConfig.EnvConfig, kmsClient *kms.KeyManagementClient) (*ghinstallation.AppsTransport, error) {
 	switch {

--- a/pkg/octosts/octosts.go
+++ b/pkg/octosts/octosts.go
@@ -31,6 +31,7 @@ import (
 	pboidc "chainguard.dev/sdk/proto/platform/oidc/v1"
 	"github.com/chainguard-dev/clog"
 	"github.com/octo-sts/app/pkg/ghinstall"
+	"github.com/octo-sts/app/pkg/ghtransport"
 	"github.com/octo-sts/app/pkg/oidcvalidate"
 	"github.com/octo-sts/app/pkg/provider"
 )
@@ -198,6 +199,9 @@ func (s *sts) Exchange(ctx context.Context, request *pboidc.ExchangeRequest) (_ 
 		Repositories: e.TrustPolicy.Repositories,
 		Permissions:  &e.TrustPolicy.Permissions,
 	}
+	// Enrich context so the httpmetrics transport labels the token exchange
+	// rate limit metrics with the specific installation consuming quota.
+	ctx = ghtransport.EnrichContext(ctx, base.AppID(), e.InstallationID)
 	token, err := atr.Token(ctx)
 	if err != nil {
 		var herr *ghinstallation.HTTPError
@@ -350,6 +354,10 @@ type trustPolicy interface {
 }
 
 func (s *sts) lookupTrustPolicy(ctx context.Context, base *ghinstallation.AppsTransport, install int64, trustPolicyKey cacheTrustPolicyKey, tp trustPolicy) error {
+	// Enrich context with app/installation IDs so the httpmetrics transport
+	// can label rate limit metrics with the specific installation consuming quota.
+	ctx = ghtransport.EnrichContext(ctx, base.AppID(), install)
+
 	raw := ""
 	// check the LRU cache for the TrustPolicy
 	if cachedRawPolicy, ok := trustPolicies.Get(trustPolicyKey); ok {


### PR DESCRIPTION
## What

Wire GitHub App and installation IDs into the request context before every outgoing GitHub API call so that the httpmetrics transport can attach `app_id` and `installation_id` labels to the `github_rate_limit_remaining` and `github_rate_limit` gauges. Bump `terraform-infra-common` to v1.0.4 which introduces the `WithGitHubAppID` and `WithGitHubInstallationID` context helpers.

## Why

Rate limits on the GitHub API are scoped per installation (app × org), not per app. Without these labels the existing rate-limit dashboards cannot distinguish which installation is consuming quota, making it impossible to identify which app or org is being throttled across a multi-app deployment.

## Notes

- Context enrichment is placed in `pkg/ghtransport` rather than `octosts` to keep transport-layer concerns out of the STS business logic.
- The OTel exporter version bumps in go.mod are transitive dependencies pulled in by the terraform-infra-common v1.0.4 upgrade.

## Testing

- `TestPolicyReadUsesRoundRobin`: verifies the policy read uses the `rrm` transport, not the `im` transport.
- `TestPolicyReadFallsBackToIM`: verifies fallback to `im` when `rrm.Get()` fails, ensuring single-app deployments are unaffected.
- Companion tests in `terraform-infra-common` (`TestGitHubRateLimitContextLabels`, `TestGitHubRateLimitContextLabels_NoContext`) verify the label propagation end-to-end and backward compatibility for callers that do not set context values.