### PR TITLE
chore(README): update org-level roles scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,9 +180,9 @@ The following permissions are the currently enabled in octo-Sts and will be avai
 - **API Insights**: `Read-only`
 - **Administration**: `Read/Write`
 - **Blocking users**: `No Access`
-- **Custom organizations roles**: `No Access`
+- **Custom organizations roles**: `Read and write`
 - **Custom properties**: `No Access`
-- **Custom repository roles**: `No Access`
+- **Custom repository roles**: `Read and write`
 - **Events**: `Read-only`
 - **GitHub Copilot Business**: `No Access`
 - **Knowledge bases**: `No Access`


### PR DESCRIPTION
This PR updates the README to reflect the additional changes noted in #1303.

We're expanding the permissions for `octo-sts` to allow for custom organization and repository roles to be managed.