### PR TITLE
feat: multi-org github app routing with yaml config

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,65 @@ Only mappings unused for the TTL duration are automatically cleaned up.
 Single-app deployments (`GITHUB_APP_IDS` has one entry) do not need sticky
 routing and can ignore these settings.
 
+#### Multi-Org Routing (`APP_CONFIG_FILE`)
+
+By default the Apps in `GITHUB_APP_IDS` / `KMS_KEYS` form a single flat pool
+that serves every org. To assign dedicated Apps to specific GitHub
+organizations — e.g. to use different credential types per org — point
+`APP_CONFIG_FILE` at a YAML file that maps orgs to their App pools:
+
+```yaml
+orgs:
+  # A dedicated pool for org-a (two Apps, KMS credentials).
+  - name: org-a
+    apps:
+      - app_id: 111
+        kms_key: projects/p/locations/l/keyRings/r/cryptoKeys/k/cryptoKeyVersions/1
+      - app_id: 112
+        kms_key: projects/p/locations/l/keyRings/r/cryptoKeys/k/cryptoKeyVersions/2
+
+  # A dedicated pool for org-b using an injected PEM instead of KMS.
+  - name: org-b
+    apps:
+      - app_id: 222
+        private_key: ${ORG_B_APP_PEM}
+
+  # Optional catch-all: "*" serves any org not listed above.
+  - name: "*"
+    apps:
+      - app_id: 999
+        private_key_file: /etc/octo-sts/keys/fallback.pem
+```
+
+Each app sets **exactly one** credential source:
+
+| Field | Description |
+|-------|-------------|
+| `kms_key` | KMS key identifier, interpreted per `KMS_PROVIDER` (default `gcp`; also `aws`, `akv`) |
+| `private_key` | An inline PEM |
+| `private_key_file` | Path to a PEM file |
+
+String values support `${VAR}` expansion from the process environment. Only
+the braced form expands — bare `$VAR` references and literal `$` characters
+pass through unchanged (so PEMs and values containing `$` are safe).
+
+Notes:
+
+- When `APP_CONFIG_FILE` is set, the legacy `GITHUB_APP_IDS` / `KMS_KEYS` env
+  vars are ignored.
+- A request for an org with no matching pool and no `"*"` fallback is rejected
+  (fail closed), not served by an arbitrary App.
+- With `APP_CONFIG_FILE` unset, behavior is unchanged (a single flat pool
+  serving every org).
+- Each org's pool does its own capacity-aware routing, and the sticky store
+  settings above apply across all pools — configure the sticky store if any
+  org has more than one App and uses `checks: write` policies.
+- If you deploy with the bundled terraform module, set `org_name` on each
+  entry in `github_apps` and the module generates this config for you. Setting
+  `org_name` on any app requires it on all of them (use `"*"` for a fallback
+  pool), and every app needs a KMS key (`key_version > 0`); both are enforced
+  at `terraform plan` time.
+
 ### GitHub Enterprise Server (GHES)
 
 OctoSTS can be deployed against a GitHub Enterprise Server instance by setting

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log"
 	"log/slog"
@@ -24,6 +25,7 @@ import (
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 
+	"github.com/octo-sts/app/pkg/appconfig"
 	envConfig "github.com/octo-sts/app/pkg/envconfig"
 	"github.com/octo-sts/app/pkg/ghinstall"
 	"github.com/octo-sts/app/pkg/ghtransport"
@@ -40,25 +42,14 @@ func main() {
 	if err != nil {
 		log.Panicf("failed to process env var: %s", err)
 	}
-	appConfig, err := envConfig.AppConfig()
+	appCfg, err := envConfig.AppConfig()
 	if err != nil {
 		log.Panicf("failed to process env var: %s", err)
 	}
 
 	if baseCfg.Metrics {
 		go metrics.ServeMetrics()
-
-		// Setup tracing.
 		defer metrics.SetupTracer(ctx)()
-	}
-
-	var client *kms.KeyManagementClient
-
-	if len(baseCfg.KMSKeys) > 0 {
-		client, err = kms.NewKeyManagementClient(ctx)
-		if err != nil {
-			log.Panicf("could not create kms client: %v", err)
-		}
 	}
 
 	// Capacity-aware routing: a shared QuotaStore is populated by the
@@ -73,38 +64,26 @@ func main() {
 		HardFloor: baseCfg.QuotaFloorHard,
 	}
 
-	managers := make([]ghinstall.Manager, 0, len(baseCfg.AppIDs))
-	for i, appID := range baseCfg.AppIDs {
-		var kmsKey string
-		if len(baseCfg.KMSKeys) > 0 {
-			kmsKey = baseCfg.KMSKeys[i]
-			if kmsKey == "" {
-				log.Printf("skipping app %d: no KMS key configured", appID)
-				continue
-			}
-		}
-		atr, err := ghtransport.New(ctx, appID, kmsKey, baseCfg, client, quotaStore)
+	var router *ghinstall.OrgRouter
+	var totalApps int
+	if baseCfg.AppConfigFile != "" {
+		router, totalApps, err = buildRouterFromYAML(ctx, baseCfg.AppConfigFile, quotaStore, quotaCfg)
 		if err != nil {
-			log.Panicf("error creating GitHub App transport for app %d: %v", appID, err)
+			log.Panicf("failed to build router from YAML config: %v", err)
 		}
-		m, err := ghinstall.New(atr)
+	} else {
+		router, totalApps, err = buildRouterFromEnv(ctx, baseCfg, quotaStore, quotaCfg)
 		if err != nil {
-			log.Panicf("error creating install manager for app %d: %v", appID, err)
+			log.Panicf("failed to build router from env vars: %v", err)
 		}
-		managers = append(managers, m)
-	}
-	if len(managers) == 0 {
-		log.Panic("no apps with valid KMS keys configured")
 	}
 
-	var rrm ghinstall.Manager
+	// Sticky store is shared across all org pools. Installation IDs are
+	// globally unique within GitHub, so a single store has no key collisions
+	// across orgs. Only enable when there are multiple apps in flight; with
+	// one app there is nothing to balance.
 	var sticky stickystore.Store
-	if len(managers) == 1 {
-		rrm = ghinstall.NewRoundRobin(managers)
-	} else {
-		rrm = ghinstall.NewRoundRobinWithQuota(managers, quotaCfg)
-	}
-	if len(managers) > 1 && baseCfg.StickyStore != "" {
+	if totalApps > 1 && baseCfg.StickyStore != "" {
 		var closer io.Closer
 		sticky, closer, err = stickystore.New(ctx, baseCfg)
 		if err != nil {
@@ -120,13 +99,13 @@ func main() {
 
 	var ceclient cloudevents.Client
 	if baseCfg.Metrics {
-		ceclient, err = mce.NewClientHTTP("octo-sts", mce.WithTarget(ctx, appConfig.EventingIngress)...)
+		ceclient, err = mce.NewClientHTTP("octo-sts", mce.WithTarget(ctx, appCfg.EventingIngress)...)
 		if err != nil {
 			log.Panicf("failed to create cloudevents client: %v", err)
 		}
 	}
 
-	pboidc.RegisterSecurityTokenServiceServer(d.Server, octosts.NewSecurityTokenServiceServer(rrm, sticky, len(managers), ceclient, appConfig.Domain, baseCfg.Metrics))
+	pboidc.RegisterSecurityTokenServiceServer(d.Server, octosts.NewSecurityTokenServiceServer(router, sticky, ceclient, appCfg.Domain, baseCfg.Metrics))
 	if err := d.RegisterHandler(ctx, pboidc.RegisterSecurityTokenServiceHandlerFromEndpoint); err != nil {
 		log.Panicf("failed to register gateway endpoint: %v", err)
 	}
@@ -152,4 +131,117 @@ func main() {
 
 	// This will block until a signal arrives.
 	<-ctx.Done()
+}
+
+// buildPool builds an OrgPool from a slice of managers, choosing
+// quota-aware round-robin when multiple apps are present and plain
+// round-robin otherwise (no quota data to consult with a single app).
+func buildPool(managers []ghinstall.Manager, quotaCfg *ghinstall.QuotaConfig) *ghinstall.OrgPool {
+	var m ghinstall.Manager
+	if len(managers) == 1 {
+		m = ghinstall.NewRoundRobin(managers)
+	} else {
+		m = ghinstall.NewRoundRobinWithQuota(managers, quotaCfg)
+	}
+	return &ghinstall.OrgPool{M: m, AppCount: len(managers)}
+}
+
+// buildRouterFromYAML loads the YAML config file and builds an OrgRouter
+// with per-org app pools. The quotaStore is shared across every pool so
+// the capacity-aware picker sees the full per-installation rate-limit
+// state regardless of which org's pool issued the request.
+func buildRouterFromYAML(ctx context.Context, configFile string, quotaStore *ghinstall.QuotaStore, quotaCfg *ghinstall.QuotaConfig) (*ghinstall.OrgRouter, int, error) {
+
+	options := []appconfig.OptionsApplier{
+		appconfig.WithConfigFilePath(configFile),
+	}
+
+	cfg, err := appconfig.Load(options...)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return nil, 0, err
+	}
+
+	// Create KMS client only if any app uses kms_key.
+	var kmsClient *kms.KeyManagementClient
+	for _, org := range cfg.Orgs {
+		for _, app := range org.Apps {
+			if app.KMSKey != "" {
+				kmsClient, err = kms.NewKeyManagementClient(ctx)
+				if err != nil {
+					return nil, 0, err
+				}
+				break
+			}
+		}
+		if kmsClient != nil {
+			break
+		}
+	}
+
+	pools := make(map[string]*ghinstall.OrgPool, len(cfg.Orgs))
+	totalApps := 0
+	for _, org := range cfg.Orgs {
+		managers := make([]ghinstall.Manager, 0, len(org.Apps))
+		for _, app := range org.Apps {
+			atr, err := ghtransport.NewFromAppConfig(ctx, app, kmsClient, quotaStore)
+			if err != nil {
+				return nil, 0, err
+			}
+			m, err := ghinstall.New(atr)
+			if err != nil {
+				return nil, 0, err
+			}
+			managers = append(managers, m)
+		}
+		pools[org.Name] = buildPool(managers, quotaCfg)
+		totalApps += len(managers)
+	}
+
+	return ghinstall.NewOrgRouter(pools), totalApps, nil
+}
+
+// buildRouterFromEnv creates an OrgRouter from legacy environment variables.
+// All apps are placed in a wildcard pool that serves any org.
+func buildRouterFromEnv(ctx context.Context, baseCfg *envConfig.EnvConfig, quotaStore *ghinstall.QuotaStore, quotaCfg *ghinstall.QuotaConfig) (*ghinstall.OrgRouter, int, error) {
+	var kmsClient *kms.KeyManagementClient
+	var err error
+
+	if len(baseCfg.KMSKeys) > 0 {
+		kmsClient, err = kms.NewKeyManagementClient(ctx)
+		if err != nil {
+			return nil, 0, err
+		}
+	}
+
+	managers := make([]ghinstall.Manager, 0, len(baseCfg.AppIDs))
+	for i, appID := range baseCfg.AppIDs {
+		var kmsKey string
+		if len(baseCfg.KMSKeys) > 0 {
+			kmsKey = baseCfg.KMSKeys[i]
+			if kmsKey == "" {
+				log.Printf("skipping app %d: no KMS key configured", appID)
+				continue
+			}
+		}
+		atr, err := ghtransport.New(ctx, appID, kmsKey, baseCfg, kmsClient, quotaStore)
+		if err != nil {
+			return nil, 0, err
+		}
+		m, err := ghinstall.New(atr)
+		if err != nil {
+			return nil, 0, err
+		}
+		managers = append(managers, m)
+	}
+	if len(managers) == 0 {
+		return nil, 0, fmt.Errorf("no apps with valid KMS keys configured")
+	}
+
+	return ghinstall.NewOrgRouter(map[string]*ghinstall.OrgPool{
+		ghinstall.WildcardOrg: buildPool(managers, quotaCfg),
+	}), len(managers), nil
 }

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log"
 	"log/slog"
@@ -23,6 +24,7 @@ import (
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 
+	"github.com/octo-sts/app/pkg/appconfig"
 	envConfig "github.com/octo-sts/app/pkg/envconfig"
 	"github.com/octo-sts/app/pkg/ghinstall"
 	"github.com/octo-sts/app/pkg/ghtransport"
@@ -40,15 +42,13 @@ func main() {
 	if err != nil {
 		log.Panicf("failed to process env var: %s", err)
 	}
-	appConfig, err := envConfig.AppConfig()
+	appCfg, err := envConfig.AppConfig()
 	if err != nil {
 		log.Panicf("failed to process env var: %s", err)
 	}
 
 	if baseCfg.Metrics {
 		go metrics.ServeMetrics()
-
-		// Setup tracing.
 		defer metrics.SetupTracer(ctx)()
 	}
 
@@ -64,44 +64,30 @@ func main() {
 		HardFloor: baseCfg.QuotaFloorHard,
 	}
 
-	managers := make([]ghinstall.Manager, 0, len(baseCfg.AppIDs))
-	for i, appID := range baseCfg.AppIDs {
-		var kmsKey string
-		var kmsClient kms.KMS
-		if len(baseCfg.KMSKeys) > 0 {
-			kmsKey = baseCfg.KMSKeys[i]
-			if kmsKey == "" {
-				log.Printf("skipping app %d: no KMS key configured", appID)
-				continue
-			}
-			kmsClient, err = kms.NewKMS(ctx, baseCfg.KMSProvider, kmsKey)
-			if err != nil {
-				log.Panicf("could not create kms client for app %d: %v", appID, err)
-			}
-			defer kmsClient.Close() //nolint:errcheck // released at process shutdown
-		}
-		atr, err := ghtransport.New(ctx, appID, kmsKey, baseCfg, kmsClient, quotaStore)
+	var router *ghinstall.OrgRouter
+	var totalApps int
+	var kmsClosers []io.Closer
+	if baseCfg.AppConfigFile != "" {
+		router, totalApps, kmsClosers, err = buildRouterFromYAML(ctx, baseCfg, quotaStore, quotaCfg)
 		if err != nil {
-			log.Panicf("error creating GitHub App transport for app %d: %v", appID, err)
+			log.Panicf("failed to build router from YAML config: %v", err)
 		}
-		m, err := ghinstall.NewWithBaseURL(atr, baseCfg.GitHubBaseURL)
+	} else {
+		router, totalApps, kmsClosers, err = buildRouterFromEnv(ctx, baseCfg, quotaStore, quotaCfg)
 		if err != nil {
-			log.Panicf("error creating install manager for app %d: %v", appID, err)
+			log.Panicf("failed to build router from env vars: %v", err)
 		}
-		managers = append(managers, m)
 	}
-	if len(managers) == 0 {
-		log.Panic("no apps with valid KMS keys configured")
+	for _, c := range kmsClosers {
+		defer c.Close() //nolint:errcheck // released at process shutdown
 	}
 
-	var rrm ghinstall.Manager
+	// Sticky store is shared across all org pools. Installation IDs are
+	// globally unique within GitHub, so a single store has no key collisions
+	// across orgs. Only enable when there are multiple apps in flight; with
+	// one app there is nothing to balance.
 	var sticky stickystore.Store
-	if len(managers) == 1 {
-		rrm = ghinstall.NewRoundRobin(managers)
-	} else {
-		rrm = ghinstall.NewRoundRobinWithQuota(managers, quotaCfg)
-	}
-	if len(managers) > 1 && baseCfg.StickyStore != "" {
+	if totalApps > 1 && baseCfg.StickyStore != "" {
 		var closer io.Closer
 		sticky, closer, err = stickystore.New(ctx, baseCfg)
 		if err != nil {
@@ -116,8 +102,8 @@ func main() {
 	)
 
 	var ceclient cloudevents.Client
-	if baseCfg.Metrics && appConfig.EventingIngress != "" {
-		ceclient, err = mce.NewClientHTTP("octo-sts", mce.WithTarget(ctx, appConfig.EventingIngress)...)
+	if baseCfg.Metrics && appCfg.EventingIngress != "" {
+		ceclient, err = mce.NewClientHTTP("octo-sts", mce.WithTarget(ctx, appCfg.EventingIngress)...)
 		if err != nil {
 			log.Panicf("failed to create cloudevents client: %v", err)
 		}
@@ -125,7 +111,7 @@ func main() {
 		clog.FromContext(ctx).Warn("EVENT_INGRESS_URI unset; exchange events will not be emitted")
 	}
 
-	pboidc.RegisterSecurityTokenServiceServer(d.Server, octosts.NewSecurityTokenServiceServer(rrm, sticky, len(managers), ceclient, appConfig.Domain, baseCfg.Metrics, baseCfg.GitHubBaseURL, appConfig.OrgPolicyRepo))
+	pboidc.RegisterSecurityTokenServiceServer(d.Server, octosts.NewSecurityTokenServiceServer(router, sticky, ceclient, appCfg.Domain, baseCfg.Metrics, baseCfg.GitHubBaseURL, appCfg.OrgPolicyRepo))
 	if err := d.RegisterHandler(ctx, pboidc.RegisterSecurityTokenServiceHandlerFromEndpoint); err != nil {
 		log.Panicf("failed to register gateway endpoint: %v", err)
 	}
@@ -151,4 +137,104 @@ func main() {
 
 	// This will block until a signal arrives.
 	<-ctx.Done()
+}
+
+// buildPool builds an OrgPool from a slice of managers, choosing
+// quota-aware round-robin when multiple apps are present and plain
+// round-robin otherwise (no quota data to consult with a single app).
+func buildPool(managers []ghinstall.Manager, quotaCfg *ghinstall.QuotaConfig) *ghinstall.OrgPool {
+	var m ghinstall.Manager
+	if len(managers) == 1 {
+		m = ghinstall.NewRoundRobin(managers)
+	} else {
+		m = ghinstall.NewRoundRobinWithQuota(managers, quotaCfg)
+	}
+	return &ghinstall.OrgPool{M: m, AppCount: len(managers)}
+}
+
+// buildRouterFromYAML loads the YAML config file and builds an OrgRouter
+// with per-org app pools. The quotaStore is shared across every pool so
+// the capacity-aware picker sees the full per-installation rate-limit
+// state regardless of which org's pool issued the request. The returned
+// closers release per-app KMS clients and must be closed at shutdown.
+func buildRouterFromYAML(ctx context.Context, baseCfg *envConfig.EnvConfig, quotaStore *ghinstall.QuotaStore, quotaCfg *ghinstall.QuotaConfig) (*ghinstall.OrgRouter, int, []io.Closer, error) {
+	cfg, err := appconfig.Load(appconfig.WithConfigFilePath(baseCfg.AppConfigFile))
+	if err != nil {
+		return nil, 0, nil, err
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return nil, 0, nil, err
+	}
+
+	var closers []io.Closer
+	pools := make(map[string]*ghinstall.OrgPool, len(cfg.Orgs))
+	totalApps := 0
+	for _, org := range cfg.Orgs {
+		managers := make([]ghinstall.Manager, 0, len(org.Apps))
+		for _, app := range org.Apps {
+			var kmsClient kms.KMS
+			if app.KMSKey != "" {
+				kmsClient, err = kms.NewKMS(ctx, baseCfg.KMSProvider, app.KMSKey)
+				if err != nil {
+					return nil, 0, closers, fmt.Errorf("could not create kms client for app %d: %w", app.AppID, err)
+				}
+				closers = append(closers, kmsClient)
+			}
+			atr, err := ghtransport.NewFromAppConfig(ctx, app, baseCfg, kmsClient, quotaStore)
+			if err != nil {
+				return nil, 0, closers, err
+			}
+			m, err := ghinstall.NewWithBaseURL(atr, baseCfg.GitHubBaseURL)
+			if err != nil {
+				return nil, 0, closers, err
+			}
+			managers = append(managers, m)
+		}
+		pools[org.Name] = buildPool(managers, quotaCfg)
+		totalApps += len(managers)
+	}
+
+	return ghinstall.NewOrgRouter(pools), totalApps, closers, nil
+}
+
+// buildRouterFromEnv creates an OrgRouter from legacy environment variables.
+// All apps are placed in a wildcard pool that serves any org. The returned
+// closers release per-app KMS clients and must be closed at shutdown.
+func buildRouterFromEnv(ctx context.Context, baseCfg *envConfig.EnvConfig, quotaStore *ghinstall.QuotaStore, quotaCfg *ghinstall.QuotaConfig) (*ghinstall.OrgRouter, int, []io.Closer, error) {
+	var closers []io.Closer
+	managers := make([]ghinstall.Manager, 0, len(baseCfg.AppIDs))
+	for i, appID := range baseCfg.AppIDs {
+		var kmsKey string
+		var kmsClient kms.KMS
+		if len(baseCfg.KMSKeys) > 0 {
+			kmsKey = baseCfg.KMSKeys[i]
+			if kmsKey == "" {
+				log.Printf("skipping app %d: no KMS key configured", appID)
+				continue
+			}
+			var err error
+			kmsClient, err = kms.NewKMS(ctx, baseCfg.KMSProvider, kmsKey)
+			if err != nil {
+				return nil, 0, closers, fmt.Errorf("could not create kms client for app %d: %w", appID, err)
+			}
+			closers = append(closers, kmsClient)
+		}
+		atr, err := ghtransport.New(ctx, appID, kmsKey, baseCfg, kmsClient, quotaStore)
+		if err != nil {
+			return nil, 0, closers, err
+		}
+		m, err := ghinstall.NewWithBaseURL(atr, baseCfg.GitHubBaseURL)
+		if err != nil {
+			return nil, 0, closers, err
+		}
+		managers = append(managers, m)
+	}
+	if len(managers) == 0 {
+		return nil, 0, closers, fmt.Errorf("no apps with valid KMS keys configured")
+	}
+
+	return ghinstall.NewOrgRouter(map[string]*ghinstall.OrgPool{
+		ghinstall.WildcardOrg: buildPool(managers, quotaCfg),
+	}), len(managers), closers, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/chainguard-dev/terraform-infra-common v1.0.10
 	github.com/cloudevents/sdk-go/v2 v2.16.2
 	github.com/coreos/go-oidc/v3 v3.18.0
+	github.com/go-viper/mapstructure/v2 v2.4.0
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-github/v84 v84.0.0
@@ -21,6 +22,9 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/invopop/jsonschema v0.14.0
 	github.com/kelseyhightower/envconfig v1.4.0
+	github.com/knadh/koanf/parsers/yaml v1.1.0
+	github.com/knadh/koanf/providers/file v1.2.1
+	github.com/knadh/koanf/v2 v2.3.4
 	golang.org/x/oauth2 v0.36.0
 	google.golang.org/api v0.280.0
 	google.golang.org/grpc v1.81.1
@@ -39,10 +43,14 @@ require (
 	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
+	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3 // indirect
+	github.com/knadh/koanf/maps v0.1.2 // indirect
 	github.com/mileusna/useragent v1.3.5 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
@@ -56,6 +64,7 @@ require (
 	go.opentelemetry.io/otel/exporters/prometheus v0.64.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
+	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/chainguard-dev/terraform-infra-common v1.28.7
 	github.com/cloudevents/sdk-go/v2 v2.16.2
 	github.com/coreos/go-oidc/v3 v3.20.0
+	github.com/go-viper/mapstructure/v2 v2.4.0
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-github/v88 v88.0.0
@@ -30,6 +31,9 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/invopop/jsonschema v0.14.0
 	github.com/kelseyhightower/envconfig v1.4.0
+	github.com/knadh/koanf/parsers/yaml v1.1.0
+	github.com/knadh/koanf/providers/file v1.2.1
+	github.com/knadh/koanf/v2 v2.3.4
 	golang.org/x/oauth2 v0.36.0
 	google.golang.org/api v0.292.0
 	google.golang.org/grpc v1.83.0
@@ -62,12 +66,16 @@ require (
 	github.com/buger/jsonparser v1.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/ebitengine/purego v0.10.2 // indirect
+	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3 // indirect
+	github.com/knadh/koanf/maps v0.1.2 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mileusna/useragent v1.3.5 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
@@ -82,6 +90,7 @@ require (
 	go.opentelemetry.io/otel/exporters/prometheus v0.66.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.45.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
+	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.6 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ github.com/envoyproxy/protoc-gen-validate v1.3.3 h1:MVQghNeW+LZcmXe7SY1V36Z+WFMD
 github.com/envoyproxy/protoc-gen-validate v1.3.3/go.mod h1:TsndJ/ngyIdQRhMcVVGDDHINPLWB7C82oDArY51KfB0=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -79,6 +81,8 @@ github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-ole/go-ole v1.3.0 h1:Dt6ye7+vXGIKZ7Xtk4s6/xVdGDQynvom7xCFEdWr6uE=
 github.com/go-ole/go-ole v1.3.0/go.mod h1:5LS6F96DhAwUc7C+1HLexzMXY1xGRSryjyPPKW6zv78=
+github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
+github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
 github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
@@ -120,6 +124,14 @@ github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dv
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
 github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+github.com/knadh/koanf/maps v0.1.2 h1:RBfmAW5CnZT+PJ1CVc1QSJKf4Xu9kxfQgYVQSu8hpbo=
+github.com/knadh/koanf/maps v0.1.2/go.mod h1:npD/QZY3V6ghQDdcQzl1W4ICNVTkohC8E73eI2xW4yI=
+github.com/knadh/koanf/parsers/yaml v1.1.0 h1:3ltfm9ljprAHt4jxgeYLlFPmUaunuCgu1yILuTXRdM4=
+github.com/knadh/koanf/parsers/yaml v1.1.0/go.mod h1:HHmcHXUrp9cOPcuC+2wrr44GTUB0EC+PyfN3HZD9tFg=
+github.com/knadh/koanf/providers/file v1.2.1 h1:bEWbtQwYrA+W2DtdBrQWyXqJaJSG3KrP3AESOJYp9wM=
+github.com/knadh/koanf/providers/file v1.2.1/go.mod h1:bp1PM5f83Q+TOUu10J/0ApLBd9uIzg+n9UgthfY+nRA=
+github.com/knadh/koanf/v2 v2.3.4 h1:fnynNSDlujWE+v83hAp8wKr/cdoxHLO0629SN+U8Urc=
+github.com/knadh/koanf/v2 v2.3.4/go.mod h1:gRb40VRAbd4iJMYYD5IxZ6hfuopFcXBpc9bbQpZwo28=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -128,6 +140,10 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/mileusna/useragent v1.3.5 h1:SJM5NzBmh/hO+4LGeATKpaEX9+b4vcGg2qXGLiNGDws=
 github.com/mileusna/useragent v1.3.5/go.mod h1:3d8TOmwL/5I8pJjyVDteHtgDGcefrFUX4ccGOMKNYYc=
+github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
+github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
+github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
+github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/go.sum
+++ b/go.sum
@@ -119,6 +119,8 @@ github.com/envoyproxy/protoc-gen-validate v1.3.3 h1:MVQghNeW+LZcmXe7SY1V36Z+WFMD
 github.com/envoyproxy/protoc-gen-validate v1.3.3/go.mod h1:TsndJ/ngyIdQRhMcVVGDDHINPLWB7C82oDArY51KfB0=
 github.com/felixge/httpsnoop v1.1.0 h1:3YtUj32ZZkqZtt3sZZsClsymw/QDuVfpNhoA31zeORc=
 github.com/felixge/httpsnoop v1.1.0/go.mod h1:Zqxgdd+1Rkcz8euOqdr7lqgCRJztwr5hp9vDSi5UZCE=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -129,6 +131,8 @@ github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-ole/go-ole v1.3.0 h1:Dt6ye7+vXGIKZ7Xtk4s6/xVdGDQynvom7xCFEdWr6uE=
 github.com/go-ole/go-ole v1.3.0/go.mod h1:5LS6F96DhAwUc7C+1HLexzMXY1xGRSryjyPPKW6zv78=
+github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
+github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
 github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
@@ -174,6 +178,14 @@ github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRt
 github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
 github.com/klauspost/compress v1.19.1 h1:VsB4HPswih7mmZ8WleSFQ75c/Ui1M4trX5oAsJnhSlk=
 github.com/klauspost/compress v1.19.1/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+github.com/knadh/koanf/maps v0.1.2 h1:RBfmAW5CnZT+PJ1CVc1QSJKf4Xu9kxfQgYVQSu8hpbo=
+github.com/knadh/koanf/maps v0.1.2/go.mod h1:npD/QZY3V6ghQDdcQzl1W4ICNVTkohC8E73eI2xW4yI=
+github.com/knadh/koanf/parsers/yaml v1.1.0 h1:3ltfm9ljprAHt4jxgeYLlFPmUaunuCgu1yILuTXRdM4=
+github.com/knadh/koanf/parsers/yaml v1.1.0/go.mod h1:HHmcHXUrp9cOPcuC+2wrr44GTUB0EC+PyfN3HZD9tFg=
+github.com/knadh/koanf/providers/file v1.2.1 h1:bEWbtQwYrA+W2DtdBrQWyXqJaJSG3KrP3AESOJYp9wM=
+github.com/knadh/koanf/providers/file v1.2.1/go.mod h1:bp1PM5f83Q+TOUu10J/0ApLBd9uIzg+n9UgthfY+nRA=
+github.com/knadh/koanf/v2 v2.3.4 h1:fnynNSDlujWE+v83hAp8wKr/cdoxHLO0629SN+U8Urc=
+github.com/knadh/koanf/v2 v2.3.4/go.mod h1:gRb40VRAbd4iJMYYD5IxZ6hfuopFcXBpc9bbQpZwo28=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -182,6 +194,10 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/mileusna/useragent v1.3.5 h1:SJM5NzBmh/hO+4LGeATKpaEX9+b4vcGg2qXGLiNGDws=
 github.com/mileusna/useragent v1.3.5/go.mod h1:3d8TOmwL/5I8pJjyVDteHtgDGcefrFUX4ccGOMKNYYc=
+github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
+github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
+github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
+github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/modules/app/main.tf
+++ b/modules/app/main.tf
@@ -60,6 +60,35 @@ locals {
   #     --algorithm rsa-sign-pkcs1-2048-sha256 \
   #     --target-key-file key.data
   kms_keys = [for app in var.github_apps : app.key_version > 0 ? "${google_kms_crypto_key.app-keys[tostring(app.app_id)].id}/cryptoKeyVersions/${app.key_version}" : ""]
+
+  # Whether multi-org routing is enabled (at least one app has org_name set).
+  multi_org_enabled = anytrue([for app in var.github_apps : app.org_name != ""])
+
+  # Group apps by org_name for YAML config generation. Org names are
+  # lowercased here so that mixed-case entries (e.g. "Octo-STS" vs
+  # "octo-sts") fail at `terraform plan` if duplicated, instead of
+  # crashing the server at startup when appconfig.Validate rejects the
+  # generated YAML.
+  org_names = distinct([for app in var.github_apps : lower(app.org_name) if app.org_name != ""])
+  apps_by_org = {
+    for org in local.org_names : org => [
+      for app in var.github_apps : {
+        app_id  = app.app_id
+        kms_key = app.key_version > 0 ? "${google_kms_crypto_key.app-keys[tostring(app.app_id)].id}/cryptoKeyVersions/${app.key_version}" : ""
+      } if lower(app.org_name) == org
+    ]
+  }
+
+  # YAML config for multi-org routing.
+  app_config_yaml = local.multi_org_enabled ? yamlencode({
+    orgs = [for org in local.org_names : {
+      name = org
+      apps = [for app in local.apps_by_org[org] : {
+        app_id  = app.app_id
+        kms_key = app.kms_key
+      } if app.kms_key != ""]
+    }]
+  }) : ""
 }
 
 // Create a dedicated GSA for the IAM datastore service.
@@ -107,7 +136,16 @@ module "this" {
     "sts" = {
       image = var.images.app
       ports = [{ container_port = 8080 }]
-      env = [
+      env = local.multi_org_enabled ? [
+        {
+          name  = "APP_CONFIG_FILE"
+          value = "/etc/octo-sts/config.yaml"
+        },
+        {
+          name  = "STS_DOMAIN",
+          value = var.domain,
+        }
+        ] : [
         {
           name  = "GITHUB_APP_IDS"
           value = join(",", [for app in var.github_apps : app.app_id])
@@ -141,10 +179,53 @@ module "this" {
         name  = "EVENT_INGRESS_URI"
         value = { for k, v in module.sts-emits-events : k => v.uri }
       }]
+      volume_mounts = local.multi_org_enabled ? [{
+        name       = "app-config"
+        mount_path = "/etc/octo-sts"
+      }] : []
     }
   }
 
+  volumes = local.multi_org_enabled ? [{
+    name = "app-config"
+    secret = {
+      secret = google_secret_manager_secret.app-config[0].secret_id
+      items = [{
+        version = "latest"
+        path    = "config.yaml"
+      }]
+    }
+  }] : []
+
   notification_channels = var.notification_channels
+}
+
+// Store the multi-org YAML config in Secret Manager (only when multi-org is enabled).
+resource "google_secret_manager_secret" "app-config" {
+  count = local.multi_org_enabled ? 1 : 0
+
+  project   = var.project_id
+  secret_id = "${var.name}-app-config"
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "app-config" {
+  count = local.multi_org_enabled ? 1 : 0
+
+  secret      = google_secret_manager_secret.app-config[0].id
+  secret_data = local.app_config_yaml
+}
+
+resource "google_secret_manager_secret_iam_member" "app-config-accessor" {
+  count = local.multi_org_enabled ? 1 : 0
+
+  project   = var.project_id
+  secret_id = google_secret_manager_secret.app-config[0].secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.octo-sts.email}"
 }
 
 // Allow the STS service to call the sign method on the keys in the keyring.

--- a/modules/app/main.tf
+++ b/modules/app/main.tf
@@ -60,6 +60,62 @@ locals {
   #     --algorithm rsa-sign-pkcs1-2048-sha256 \
   #     --target-key-file key.data
   kms_keys = [for app in var.github_apps : app.key_version > 0 ? "${google_kms_crypto_key.app-keys[tostring(app.app_id)].id}/cryptoKeyVersions/${app.key_version}" : ""]
+
+  # Whether multi-org routing is enabled (at least one app has org_name set).
+  multi_org_enabled = anytrue([for app in var.github_apps : app.org_name != ""])
+
+  # Group apps by org_name for YAML config generation. Org names are
+  # lowercased here so that mixed-case entries (e.g. "Octo-STS" vs
+  # "octo-sts") fail at `terraform plan` if duplicated, instead of
+  # crashing the server at startup when appconfig.Validate rejects the
+  # generated YAML.
+  org_names = distinct([for app in var.github_apps : lower(app.org_name) if app.org_name != ""])
+  apps_by_org = {
+    for org in local.org_names : org => [
+      for app in var.github_apps : {
+        app_id  = app.app_id
+        kms_key = app.key_version > 0 ? "${google_kms_crypto_key.app-keys[tostring(app.app_id)].id}/cryptoKeyVersions/${app.key_version}" : ""
+      } if lower(app.org_name) == org
+    ]
+  }
+
+  # YAML config for multi-org routing.
+  app_config_yaml = local.multi_org_enabled ? yamlencode({
+    orgs = [for org in local.org_names : {
+      name = org
+      apps = [for app in local.apps_by_org[org] : {
+        app_id  = app.app_id
+        kms_key = app.kms_key
+      } if app.kms_key != ""]
+    }]
+  }) : ""
+
+  # Env vars shared by both config modes. The sticky-store settings apply
+  # regardless of how the app pools are configured — in multi-org mode the
+  # sticky store is what preserves check-run ownership across each org's
+  # multi-app pool.
+  common_env = [
+    {
+      name  = "STS_DOMAIN"
+      value = var.domain
+    },
+    {
+      name  = "OCTOSTS_STICKY_STORE"
+      value = var.sticky_store
+    },
+    {
+      name  = "OCTOSTS_STICKY_STORE_FIRESTORE_PROJECT"
+      value = var.sticky_store == "firestore" ? var.project_id : ""
+    },
+    {
+      name  = "OCTOSTS_STICKY_STORE_FIRESTORE_COLLECTION"
+      value = var.sticky_store_firestore_collection
+    },
+    {
+      name  = "OCTOSTS_STICKY_STORE_FIRESTORE_TTL"
+      value = var.sticky_store_firestore_ttl
+    },
+  ]
 }
 
 // Create a dedicated GSA for the IAM datastore service.
@@ -107,7 +163,12 @@ module "this" {
     "sts" = {
       image = var.images.app
       ports = [{ container_port = 8080 }]
-      env = [
+      env = concat(local.multi_org_enabled ? [
+        {
+          name  = "APP_CONFIG_FILE"
+          value = "/etc/octo-sts/config.yaml"
+        },
+        ] : [
         {
           name  = "GITHUB_APP_IDS"
           value = join(",", [for app in var.github_apps : app.app_id])
@@ -116,35 +177,72 @@ module "this" {
           name  = "KMS_KEYS"
           value = join(",", local.kms_keys)
         },
-        {
-          name  = "STS_DOMAIN",
-          value = var.domain,
-        },
-        {
-          name  = "OCTOSTS_STICKY_STORE"
-          value = var.sticky_store
-        },
-        {
-          name  = "OCTOSTS_STICKY_STORE_FIRESTORE_PROJECT"
-          value = var.sticky_store == "firestore" ? var.project_id : ""
-        },
-        {
-          name  = "OCTOSTS_STICKY_STORE_FIRESTORE_COLLECTION"
-          value = var.sticky_store_firestore_collection
-        },
-        {
-          name  = "OCTOSTS_STICKY_STORE_FIRESTORE_TTL"
-          value = var.sticky_store_firestore_ttl
-        },
-      ]
+      ], local.common_env)
       regional-env = [{
         name  = "EVENT_INGRESS_URI"
         value = { for k, v in module.sts-emits-events : k => v.uri }
       }]
+      volume_mounts = local.multi_org_enabled ? [{
+        name       = "app-config"
+        mount_path = "/etc/octo-sts"
+      }] : []
     }
   }
 
+  volumes = local.multi_org_enabled ? [{
+    name = "app-config"
+    secret = {
+      secret = google_secret_manager_secret.app-config[0].secret_id
+      items = [{
+        version = "latest"
+        path    = "config.yaml"
+      }]
+    }
+  }] : []
+
   notification_channels = var.notification_channels
+}
+
+// Store the multi-org YAML config in Secret Manager (only when multi-org is enabled).
+resource "google_secret_manager_secret" "app-config" {
+  count = local.multi_org_enabled ? 1 : 0
+
+  project   = var.project_id
+  secret_id = "${var.name}-app-config"
+
+  replication {
+    auto {}
+  }
+
+  lifecycle {
+    // Multi-org migration guards: both of these are silent runtime outages
+    // if they slip past plan (see the env rendering above and the
+    // `if app.kms_key != ""` filter in local.app_config_yaml).
+    precondition {
+      condition     = alltrue([for app in var.github_apps : app.org_name != ""])
+      error_message = "When any app sets org_name, every app must set org_name: multi-org mode stops rendering the legacy GITHUB_APP_IDS/KMS_KEYS env vars, so apps without an org_name silently stop serving. Use org_name = \"*\" for a fallback pool that serves any org."
+    }
+    precondition {
+      condition     = alltrue([for app in var.github_apps : app.key_version > 0])
+      error_message = "Every app needs key_version > 0 in multi-org mode: apps without a KMS key are dropped from the generated YAML, and an org left with no apps is rejected by config validation at startup (crash loop)."
+    }
+  }
+}
+
+resource "google_secret_manager_secret_version" "app-config" {
+  count = local.multi_org_enabled ? 1 : 0
+
+  secret      = google_secret_manager_secret.app-config[0].id
+  secret_data = local.app_config_yaml
+}
+
+resource "google_secret_manager_secret_iam_member" "app-config-accessor" {
+  count = local.multi_org_enabled ? 1 : 0
+
+  project   = var.project_id
+  secret_id = google_secret_manager_secret.app-config[0].secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.octo-sts.email}"
 }
 
 // Allow the STS service to call the sign method on the keys in the keyring.

--- a/modules/app/variables.tf
+++ b/modules/app/variables.tf
@@ -48,10 +48,11 @@ variable "images" {
 }
 
 variable "github_apps" {
-  description = "The GitHub Apps, each with an app_id and key_version for KMS signing."
+  description = "The GitHub Apps, each with an app_id, key_version for KMS signing, and org_name for multi-org routing."
   type = list(object({
     app_id      = number
     key_version = number
+    org_name    = optional(string, "")
   }))
 }
 

--- a/pkg/appconfig/appconfig.go
+++ b/pkg/appconfig/appconfig.go
@@ -1,0 +1,175 @@
+// Copyright 2024 Chainguard, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package appconfig
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/go-viper/mapstructure/v2"
+	"github.com/knadh/koanf/parsers/yaml"
+	"github.com/knadh/koanf/providers/file"
+	"github.com/knadh/koanf/v2"
+)
+
+// Config is the top-level YAML configuration for multi-org GitHub App routing.
+type Config struct {
+	Orgs []OrgConfig `mapstructure:"orgs"`
+}
+
+// OrgConfig binds a GitHub organization to one or more GitHub Apps.
+type OrgConfig struct {
+	Name string      `mapstructure:"name"`
+	Apps []AppConfig `mapstructure:"apps"`
+}
+
+// AppConfig describes a single GitHub App and its credential source.
+// Exactly one of KMSKey, PrivateKeyFile, or PrivateKey must be set.
+type AppConfig struct {
+	AppID          int64  `mapstructure:"app_id"`
+	KMSKey         string `mapstructure:"kms_key,omitempty"`
+	PrivateKeyFile string `mapstructure:"private_key_file,omitempty"`
+	PrivateKey     string `mapstructure:"private_key,omitempty"`
+}
+
+// Load reads YAML config from one or more files and returns the parsed
+// Config. When multiple files are supplied, later files override earlier
+// ones (koanf merge semantics).
+func Load(appliers ...OptionsApplier) (*Config, error) {
+	options := NewOptions(appliers...)
+	if len(options.ConfigFilePath) == 0 {
+		return nil, errors.New("config files are missing")
+	}
+
+	k := koanf.New(options.ConfigKeyDelimiter)
+
+	parser := envExpandingParser{inner: yaml.Parser()}
+
+	for _, filename := range options.ConfigFilePath {
+		if filename == "" {
+			continue
+		}
+		if err := k.Load(file.Provider(filename), parser); err != nil {
+			return nil, fmt.Errorf("error reading config file %q: %w", filename, err)
+		}
+	}
+
+	var cfg *Config
+	if err := k.UnmarshalWithConf("", &cfg, koanf.UnmarshalConf{
+		Tag: options.TagName,
+		DecoderConfig: &mapstructure.DecoderConfig{
+			ErrorUnused: true,
+		},
+	}); err != nil {
+		return nil, fmt.Errorf("error unmarshalling config: %w", err)
+	}
+	if cfg == nil {
+		return nil, errors.New("config is empty")
+	}
+	return cfg, nil
+}
+
+// envExpandingParser wraps a koanf Parser and substitutes ${VAR} env
+// references in every string leaf of the parsed map. Done post-parse so
+// multi-line env values (e.g. PEMs) aren't subject to YAML line-folding
+// or block-scalar indentation rules.
+type envExpandingParser struct {
+	inner koanf.Parser
+}
+
+func (p envExpandingParser) Unmarshal(b []byte) (map[string]any, error) {
+	m, err := p.inner.Unmarshal(b)
+	if err != nil {
+		return nil, err
+	}
+	expandEnvInPlace(m)
+	return m, nil
+}
+
+func (p envExpandingParser) Marshal(m map[string]any) ([]byte, error) {
+	return p.inner.Marshal(m)
+}
+
+func expandEnvInPlace(v any) {
+	switch x := v.(type) {
+	case map[string]any:
+		for k, val := range x {
+			if s, ok := val.(string); ok {
+				x[k] = os.ExpandEnv(s)
+			} else {
+				expandEnvInPlace(val)
+			}
+		}
+	case []any:
+		for i, val := range x {
+			if s, ok := val.(string); ok {
+				x[i] = os.ExpandEnv(s)
+			} else {
+				expandEnvInPlace(val)
+			}
+		}
+	}
+}
+
+// Validate checks the config for structural errors:
+//   - at least one org
+//   - no duplicate org names (case-insensitive)
+//   - no duplicate app IDs (globally)
+//   - at least one app per org
+//   - exactly one credential source per app
+//
+// Org names are normalized to lowercase since GitHub organization names
+// are case-insensitive.
+func (c *Config) Validate() error {
+	if len(c.Orgs) == 0 {
+		return fmt.Errorf("config must have at least one org")
+	}
+
+	orgNames := make(map[string]bool)
+	appIDs := make(map[int64]bool)
+
+	for i := range c.Orgs {
+		c.Orgs[i].Name = strings.ToLower(c.Orgs[i].Name)
+		org := c.Orgs[i]
+		if org.Name == "" {
+			return fmt.Errorf("org name must not be empty")
+		}
+		if orgNames[org.Name] {
+			return fmt.Errorf("duplicate org name: %q", org.Name)
+		}
+		orgNames[org.Name] = true
+
+		if len(org.Apps) == 0 {
+			return fmt.Errorf("org %q must have at least one app", org.Name)
+		}
+
+		for _, app := range org.Apps {
+			if app.AppID == 0 {
+				return fmt.Errorf("org %q: app_id must not be zero", org.Name)
+			}
+			if appIDs[app.AppID] {
+				return fmt.Errorf("duplicate app_id: %d", app.AppID)
+			}
+			appIDs[app.AppID] = true
+
+			sources := 0
+			if app.KMSKey != "" {
+				sources++
+			}
+			if app.PrivateKeyFile != "" {
+				sources++
+			}
+			if app.PrivateKey != "" {
+				sources++
+			}
+			if sources != 1 {
+				return fmt.Errorf("org %q, app %d: exactly one of kms_key, private_key_file, or private_key must be set", org.Name, app.AppID)
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/appconfig/appconfig.go
+++ b/pkg/appconfig/appconfig.go
@@ -1,0 +1,184 @@
+// Copyright 2024 Chainguard, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package appconfig
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/go-viper/mapstructure/v2"
+	"github.com/knadh/koanf/parsers/yaml"
+	"github.com/knadh/koanf/providers/file"
+	"github.com/knadh/koanf/v2"
+)
+
+// Config is the top-level YAML configuration for multi-org GitHub App routing.
+type Config struct {
+	Orgs []OrgConfig `mapstructure:"orgs"`
+}
+
+// OrgConfig binds a GitHub organization to one or more GitHub Apps.
+type OrgConfig struct {
+	Name string      `mapstructure:"name"`
+	Apps []AppConfig `mapstructure:"apps"`
+}
+
+// AppConfig describes a single GitHub App and its credential source.
+// Exactly one of KMSKey, PrivateKeyFile, or PrivateKey must be set.
+type AppConfig struct {
+	AppID          int64  `mapstructure:"app_id"`
+	KMSKey         string `mapstructure:"kms_key,omitempty"`
+	PrivateKeyFile string `mapstructure:"private_key_file,omitempty"`
+	PrivateKey     string `mapstructure:"private_key,omitempty"`
+}
+
+// Load reads YAML config from one or more files and returns the parsed
+// Config. When multiple files are supplied, later files override earlier
+// ones (koanf merge semantics).
+func Load(appliers ...OptionsApplier) (*Config, error) {
+	options := NewOptions(appliers...)
+	if len(options.ConfigFilePath) == 0 {
+		return nil, errors.New("config files are missing")
+	}
+
+	k := koanf.New(options.ConfigKeyDelimiter)
+
+	parser := envExpandingParser{inner: yaml.Parser()}
+
+	for _, filename := range options.ConfigFilePath {
+		if filename == "" {
+			continue
+		}
+		if err := k.Load(file.Provider(filename), parser); err != nil {
+			return nil, fmt.Errorf("error reading config file %q: %w", filename, err)
+		}
+	}
+
+	var cfg *Config
+	if err := k.UnmarshalWithConf("", &cfg, koanf.UnmarshalConf{
+		Tag: options.TagName,
+		DecoderConfig: &mapstructure.DecoderConfig{
+			ErrorUnused: true,
+		},
+	}); err != nil {
+		return nil, fmt.Errorf("error unmarshalling config: %w", err)
+	}
+	if cfg == nil {
+		return nil, errors.New("config is empty")
+	}
+	return cfg, nil
+}
+
+// envExpandingParser wraps a koanf Parser and substitutes ${VAR} env
+// references in every string leaf of the parsed map. Done post-parse so
+// multi-line env values (e.g. PEMs) aren't subject to YAML line-folding
+// or block-scalar indentation rules.
+type envExpandingParser struct {
+	inner koanf.Parser
+}
+
+func (p envExpandingParser) Unmarshal(b []byte) (map[string]any, error) {
+	m, err := p.inner.Unmarshal(b)
+	if err != nil {
+		return nil, err
+	}
+	expandEnvInPlace(m)
+	return m, nil
+}
+
+func (p envExpandingParser) Marshal(m map[string]any) ([]byte, error) {
+	return p.inner.Marshal(m)
+}
+
+var envVarRef = regexp.MustCompile(`\$\{(\w+)\}`)
+
+func expandEnvRefs(s string) string {
+	return envVarRef.ReplaceAllStringFunc(s, func(m string) string {
+		return os.Getenv(m[2 : len(m)-1])
+	})
+}
+
+func expandEnvInPlace(v any) {
+	switch x := v.(type) {
+	case map[string]any:
+		for k, val := range x {
+			if s, ok := val.(string); ok {
+				x[k] = expandEnvRefs(s)
+			} else {
+				expandEnvInPlace(val)
+			}
+		}
+	case []any:
+		for i, val := range x {
+			if s, ok := val.(string); ok {
+				x[i] = expandEnvRefs(s)
+			} else {
+				expandEnvInPlace(val)
+			}
+		}
+	}
+}
+
+// Validate checks the config for structural errors:
+//   - at least one org
+//   - no duplicate org names (case-insensitive)
+//   - no duplicate app IDs (globally)
+//   - at least one app per org
+//   - exactly one credential source per app
+//
+// Org names are normalized to lowercase since GitHub organization names
+// are case-insensitive.
+func (c *Config) Validate() error {
+	if len(c.Orgs) == 0 {
+		return fmt.Errorf("config must have at least one org")
+	}
+
+	orgNames := make(map[string]bool)
+	appIDs := make(map[int64]bool)
+
+	for i := range c.Orgs {
+		c.Orgs[i].Name = strings.ToLower(c.Orgs[i].Name)
+		org := c.Orgs[i]
+		if org.Name == "" {
+			return fmt.Errorf("org name must not be empty")
+		}
+		if orgNames[org.Name] {
+			return fmt.Errorf("duplicate org name: %q", org.Name)
+		}
+		orgNames[org.Name] = true
+
+		if len(org.Apps) == 0 {
+			return fmt.Errorf("org %q must have at least one app", org.Name)
+		}
+
+		for _, app := range org.Apps {
+			if app.AppID == 0 {
+				return fmt.Errorf("org %q: app_id must not be zero", org.Name)
+			}
+			if appIDs[app.AppID] {
+				return fmt.Errorf("duplicate app_id: %d", app.AppID)
+			}
+			appIDs[app.AppID] = true
+
+			sources := 0
+			if app.KMSKey != "" {
+				sources++
+			}
+			if app.PrivateKeyFile != "" {
+				sources++
+			}
+			if app.PrivateKey != "" {
+				sources++
+			}
+			if sources != 1 {
+				return fmt.Errorf("org %q, app %d: exactly one of kms_key, private_key_file, or private_key must be set", org.Name, app.AppID)
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/appconfig/appconfig_test.go
+++ b/pkg/appconfig/appconfig_test.go
@@ -1,0 +1,353 @@
+// Copyright 2024 Chainguard, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package appconfig
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoad(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte(`
+orgs:
+  - name: my-org
+    apps:
+      - app_id: 111
+        kms_key: projects/p/locations/global/keyRings/kr/cryptoKeys/k/cryptoKeyVersions/1
+      - app_id: 222
+        kms_key: projects/p/locations/global/keyRings/kr/cryptoKeys/k/cryptoKeyVersions/2
+  - name: other-org
+    apps:
+      - app_id: 333
+        private_key_file: /etc/secrets/key.pem
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(WithConfigFilePath(cfgPath))
+	if err != nil {
+		t.Fatalf("Load() = %v", err)
+	}
+	if len(cfg.Orgs) != 2 {
+		t.Fatalf("expected 2 orgs, got %d", len(cfg.Orgs))
+	}
+	if cfg.Orgs[0].Name != "my-org" {
+		t.Errorf("expected org name my-org, got %q", cfg.Orgs[0].Name)
+	}
+	if len(cfg.Orgs[0].Apps) != 2 {
+		t.Errorf("expected 2 apps for my-org, got %d", len(cfg.Orgs[0].Apps))
+	}
+	if cfg.Orgs[0].Apps[0].AppID != 111 {
+		t.Errorf("expected app_id 111, got %d", cfg.Orgs[0].Apps[0].AppID)
+	}
+	if cfg.Orgs[1].Apps[0].PrivateKeyFile != "/etc/secrets/key.pem" {
+		t.Errorf("expected private_key_file, got %q", cfg.Orgs[1].Apps[0].PrivateKeyFile)
+	}
+}
+
+func TestLoadExpandsEnvVars(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte(`
+orgs:
+  - name: env-org
+    apps:
+      - app_id: 999
+        private_key: "${TEST_INJECTED_PEM}"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("TEST_INJECTED_PEM", "test-pem-value-12345")
+
+	cfg, err := Load(WithConfigFilePath(cfgPath))
+	if err != nil {
+		t.Fatalf("Load() = %v", err)
+	}
+	if cfg.Orgs[0].Apps[0].PrivateKey != "test-pem-value-12345" {
+		t.Errorf("env var not expanded: %q", cfg.Orgs[0].Apps[0].PrivateKey)
+	}
+}
+
+func TestLoadFileNotFound(t *testing.T) {
+	_, err := Load(WithConfigFilePath("/nonexistent/config.yaml"))
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestLoadInvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "bad.yaml")
+	if err := os.WriteFile(cfgPath, []byte(`{not valid yaml: [`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(WithConfigFilePath(cfgPath))
+	if err == nil {
+		t.Fatal("expected error for invalid YAML")
+	}
+}
+
+func TestLoadStrictRejectsUnknownFields(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "strict.yaml")
+	if err := os.WriteFile(cfgPath, []byte(`
+orgs:
+  - name: my-org
+    apps:
+      - app_id: 111
+        kms_key: key
+        unknown_field: oops
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(WithConfigFilePath(cfgPath))
+	if err == nil {
+		t.Fatal("expected error for unknown field")
+	}
+}
+
+func TestLoadExpandsMultilinePEM(t *testing.T) {
+	// Realistic-shaped PEM: BEGIN line, several body lines, END line, trailing newline.
+	// The post-parse expansion has to preserve every internal "\n" verbatim;
+	// pre-parse os.ExpandEnv over raw YAML bytes would collapse these into spaces
+	// (YAML line-folding inside a double-quoted scalar) and break the PEM.
+	pem := strings.Join([]string{
+		"-----BEGIN RSA PRIVATE KEY-----",
+		"MIIEowIBAAKCAQEAvBfQk9F4mP1xK7Tjz+VKp1uW3v8oQa2yLNH0sZ4bI9rFcXe2",
+		"YnT5dW8mQjL3Hk0vRpB1aMxXfg7tCsZuO6yKlPwEnHjVtRoUbDpAcSdEhMkLvNfX",
+		"YwG4qS6tZpOcRhAdLnIuKbVxWmEjCrYsZf0PqTgUyMxNkVoLhBpJqWdCnAaXrEbT",
+		"FdYvKsRiUpHmNxJqLzWbCdEoAfYpQnZkRmTuPxVjShBwLqDgEnIyCkOdRpAvYxKt",
+		"-----END RSA PRIVATE KEY-----",
+		"",
+	}, "\n")
+
+	cases := []struct {
+		name    string
+		yamlVal string // value placed after `private_key:` in the YAML
+		// The YAML parser-level trailing-newline behavior differs per quoting style;
+		// each case states what it expects to see after post-parse expansion.
+		wantSuffix string
+	}{
+		{
+			name:       "block scalar (|)",
+			yamlVal:    "|\n          ${TEST_MULTILINE_PEM}",
+			wantSuffix: "\n", // | keeps a single trailing newline
+		},
+		{
+			name:       "block scalar strip (|-)",
+			yamlVal:    "|-\n          ${TEST_MULTILINE_PEM}",
+			wantSuffix: "", // |- strips the trailing newline
+		},
+		{
+			name:       "double-quoted",
+			yamlVal:    `"${TEST_MULTILINE_PEM}"`,
+			wantSuffix: "",
+		},
+		{
+			name:       "single-quoted",
+			yamlVal:    `'${TEST_MULTILINE_PEM}'`,
+			wantSuffix: "",
+		},
+		{
+			name:       "plain (unquoted)",
+			yamlVal:    "${TEST_MULTILINE_PEM}",
+			wantSuffix: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			cfgPath := filepath.Join(dir, "config.yaml")
+			yamlBody := fmt.Sprintf(`
+orgs:
+  - name: env-org
+    apps:
+      - app_id: 999
+        private_key: %s
+`, tc.yamlVal)
+			if err := os.WriteFile(cfgPath, []byte(yamlBody), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			t.Setenv("TEST_MULTILINE_PEM", pem)
+
+			cfg, err := Load(WithConfigFilePath(cfgPath))
+			if err != nil {
+				t.Fatalf("Load() = %v", err)
+			}
+
+			want := pem + tc.wantSuffix
+			got := cfg.Orgs[0].Apps[0].PrivateKey
+			if got != want {
+				t.Errorf("multi-line PEM not preserved.\n got:  %q\n want: %q", got, want)
+			}
+		})
+	}
+}
+
+func TestLoadInlinePEM(t *testing.T) {
+	// Operators who don't want env-var injection can paste the PEM directly
+	// into the YAML via a block scalar. envExpandingParser must leave strings
+	// without ${VAR} placeholders untouched.
+	pem := strings.Join([]string{
+		"-----BEGIN RSA PRIVATE KEY-----",
+		"MIIEowIBAAKCAQEAvBfQk9F4mP1xK7Tjz+VKp1uW3v8oQa2yLNH0sZ4bI9rFcXe2",
+		"YnT5dW8mQjL3Hk0vRpB1aMxXfg7tCsZuO6yKlPwEnHjVtRoUbDpAcSdEhMkLvNfX",
+		"YwG4qS6tZpOcRhAdLnIuKbVxWmEjCrYsZf0PqTgUyMxNkVoLhBpJqWdCnAaXrEbT",
+		"FdYvKsRiUpHmNxJqLzWbCdEoAfYpQnZkRmTuPxVjShBwLqDgEnIyCkOdRpAvYxKt",
+		"-----END RSA PRIVATE KEY-----",
+		"",
+	}, "\n")
+
+	cases := []struct {
+		name       string
+		blockStyle string // YAML block-scalar indicator
+		wantSuffix string // trailing newline behavior: "|" keeps one, "|-" strips it
+	}{
+		{name: "block scalar (|)", blockStyle: "|", wantSuffix: "\n"},
+		{name: "block scalar strip (|-)", blockStyle: "|-", wantSuffix: ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			cfgPath := filepath.Join(dir, "config.yaml")
+
+			// Block scalars strip the common leading indent from each body line.
+			// Indent the PEM body 10 spaces (under "private_key:" at 8 spaces).
+			var indented strings.Builder
+			for line := range strings.SplitSeq(strings.TrimRight(pem, "\n"), "\n") {
+				indented.WriteString("          ")
+				indented.WriteString(line)
+				indented.WriteString("\n")
+			}
+
+			yamlBody := fmt.Sprintf(`
+orgs:
+  - name: inline-org
+    apps:
+      - app_id: 888
+        private_key: %s
+%s`, tc.blockStyle, indented.String())
+
+			if err := os.WriteFile(cfgPath, []byte(yamlBody), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			cfg, err := Load(WithConfigFilePath(cfgPath))
+			if err != nil {
+				t.Fatalf("Load() = %v", err)
+			}
+
+			want := strings.TrimRight(pem, "\n") + tc.wantSuffix
+			if got := cfg.Orgs[0].Apps[0].PrivateKey; got != want {
+				t.Errorf("inline PEM not preserved.\n got:  %q\n want: %q", got, want)
+			}
+		})
+	}
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     Config
+		wantErr bool
+	}{
+		{
+			name:    "empty orgs",
+			cfg:     Config{},
+			wantErr: true,
+		},
+		{
+			name: "empty org name",
+			cfg: Config{Orgs: []OrgConfig{
+				{Name: "", Apps: []AppConfig{{AppID: 1, KMSKey: "k"}}},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "duplicate org names",
+			cfg: Config{Orgs: []OrgConfig{
+				{Name: "org", Apps: []AppConfig{{AppID: 1, KMSKey: "k"}}},
+				{Name: "org", Apps: []AppConfig{{AppID: 2, KMSKey: "k"}}},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "no apps in org",
+			cfg: Config{Orgs: []OrgConfig{
+				{Name: "org", Apps: nil},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "zero app_id",
+			cfg: Config{Orgs: []OrgConfig{
+				{Name: "org", Apps: []AppConfig{{AppID: 0, KMSKey: "k"}}},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "duplicate app_id across orgs",
+			cfg: Config{Orgs: []OrgConfig{
+				{Name: "org1", Apps: []AppConfig{{AppID: 1, KMSKey: "k1"}}},
+				{Name: "org2", Apps: []AppConfig{{AppID: 1, KMSKey: "k2"}}},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "no credential source",
+			cfg: Config{Orgs: []OrgConfig{
+				{Name: "org", Apps: []AppConfig{{AppID: 1}}},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "multiple credential sources",
+			cfg: Config{Orgs: []OrgConfig{
+				{Name: "org", Apps: []AppConfig{{AppID: 1, KMSKey: "k", PrivateKey: "pk"}}},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "valid single org kms",
+			cfg: Config{Orgs: []OrgConfig{
+				{Name: "org", Apps: []AppConfig{{AppID: 1, KMSKey: "k"}}},
+			}},
+			wantErr: false,
+		},
+		{
+			name: "valid multi org mixed credentials",
+			cfg: Config{Orgs: []OrgConfig{
+				{Name: "org1", Apps: []AppConfig{
+					{AppID: 1, KMSKey: "k"},
+					{AppID: 2, KMSKey: "k2"},
+				}},
+				{Name: "org2", Apps: []AppConfig{
+					{AppID: 3, PrivateKeyFile: "/path"},
+				}},
+				{Name: "org3", Apps: []AppConfig{
+					{AppID: 4, PrivateKey: "pem"},
+				}},
+			}},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.Validate()
+			if (err != nil) != tc.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/appconfig/appconfig_test.go
+++ b/pkg/appconfig/appconfig_test.go
@@ -1,0 +1,417 @@
+// Copyright 2024 Chainguard, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package appconfig
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoad(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte(`
+orgs:
+  - name: my-org
+    apps:
+      - app_id: 111
+        kms_key: projects/p/locations/global/keyRings/kr/cryptoKeys/k/cryptoKeyVersions/1
+      - app_id: 222
+        kms_key: projects/p/locations/global/keyRings/kr/cryptoKeys/k/cryptoKeyVersions/2
+  - name: other-org
+    apps:
+      - app_id: 333
+        private_key_file: /etc/secrets/key.pem
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(WithConfigFilePath(cfgPath))
+	if err != nil {
+		t.Fatalf("Load() = %v", err)
+	}
+	if len(cfg.Orgs) != 2 {
+		t.Fatalf("expected 2 orgs, got %d", len(cfg.Orgs))
+	}
+	if cfg.Orgs[0].Name != "my-org" {
+		t.Errorf("expected org name my-org, got %q", cfg.Orgs[0].Name)
+	}
+	if len(cfg.Orgs[0].Apps) != 2 {
+		t.Errorf("expected 2 apps for my-org, got %d", len(cfg.Orgs[0].Apps))
+	}
+	if cfg.Orgs[0].Apps[0].AppID != 111 {
+		t.Errorf("expected app_id 111, got %d", cfg.Orgs[0].Apps[0].AppID)
+	}
+	if cfg.Orgs[1].Apps[0].PrivateKeyFile != "/etc/secrets/key.pem" {
+		t.Errorf("expected private_key_file, got %q", cfg.Orgs[1].Apps[0].PrivateKeyFile)
+	}
+}
+
+func TestLoadExpandsEnvVars(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte(`
+orgs:
+  - name: env-org
+    apps:
+      - app_id: 999
+        private_key: "${TEST_INJECTED_PEM}"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("TEST_INJECTED_PEM", "test-pem-value-12345")
+
+	cfg, err := Load(WithConfigFilePath(cfgPath))
+	if err != nil {
+		t.Fatalf("Load() = %v", err)
+	}
+	if cfg.Orgs[0].Apps[0].PrivateKey != "test-pem-value-12345" {
+		t.Errorf("env var not expanded: %q", cfg.Orgs[0].Apps[0].PrivateKey)
+	}
+}
+
+// TestLoadOnlyExpandsBracedRefs pins the expansion contract to the documented
+// ${VAR} form: bare $VAR references and literal $ characters pass through
+// untouched instead of being expanded (or worse, erased when unset).
+func TestLoadOnlyExpandsBracedRefs(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte(`
+orgs:
+  - name: dollar-org
+    apps:
+      - app_id: 999
+        private_key: "pa$$word $TEST_BARE_VAR ${TEST_BRACED_VAR}"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("TEST_BARE_VAR", "must-not-appear")
+	t.Setenv("TEST_BRACED_VAR", "braced-expanded")
+
+	cfg, err := Load(WithConfigFilePath(cfgPath))
+	if err != nil {
+		t.Fatalf("Load() = %v", err)
+	}
+	want := "pa$$word $TEST_BARE_VAR braced-expanded"
+	if got := cfg.Orgs[0].Apps[0].PrivateKey; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestLoadWildcardOrg locks in the fallback-pool config shape: an org named
+// "*" is valid, and ghinstall.OrgRouter routes any org without a dedicated
+// pool to it. This mirrors the flat multi-app setup from the PR discussion.
+func TestLoadWildcardOrg(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte(`
+orgs:
+  - name: "*"
+    apps:
+      - app_id: 111
+        kms_key: projects/p/locations/global/keyRings/kr/cryptoKeys/k/cryptoKeyVersions/1
+      - app_id: 112
+        kms_key: projects/p/locations/global/keyRings/kr/cryptoKeys/k/cryptoKeyVersions/2
+      - app_id: 113
+        kms_key: projects/p/locations/global/keyRings/kr/cryptoKeys/k/cryptoKeyVersions/3
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(WithConfigFilePath(cfgPath))
+	if err != nil {
+		t.Fatalf("Load() = %v", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() rejected wildcard org: %v", err)
+	}
+	if cfg.Orgs[0].Name != "*" {
+		t.Errorf("expected org name %q, got %q", "*", cfg.Orgs[0].Name)
+	}
+	if len(cfg.Orgs[0].Apps) != 3 {
+		t.Errorf("expected 3 apps, got %d", len(cfg.Orgs[0].Apps))
+	}
+}
+
+func TestLoadFileNotFound(t *testing.T) {
+	_, err := Load(WithConfigFilePath("/nonexistent/config.yaml"))
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestLoadInvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "bad.yaml")
+	if err := os.WriteFile(cfgPath, []byte(`{not valid yaml: [`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(WithConfigFilePath(cfgPath))
+	if err == nil {
+		t.Fatal("expected error for invalid YAML")
+	}
+}
+
+func TestLoadStrictRejectsUnknownFields(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "strict.yaml")
+	if err := os.WriteFile(cfgPath, []byte(`
+orgs:
+  - name: my-org
+    apps:
+      - app_id: 111
+        kms_key: key
+        unknown_field: oops
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(WithConfigFilePath(cfgPath))
+	if err == nil {
+		t.Fatal("expected error for unknown field")
+	}
+}
+
+func TestLoadExpandsMultilinePEM(t *testing.T) {
+	// Realistic-shaped PEM: BEGIN line, several body lines, END line, trailing newline.
+	// The post-parse expansion has to preserve every internal "\n" verbatim;
+	// pre-parse os.ExpandEnv over raw YAML bytes would collapse these into spaces
+	// (YAML line-folding inside a double-quoted scalar) and break the PEM.
+	pem := strings.Join([]string{
+		"-----BEGIN RSA PRIVATE KEY-----",
+		"MIIEowIBAAKCAQEAvBfQk9F4mP1xK7Tjz+VKp1uW3v8oQa2yLNH0sZ4bI9rFcXe2",
+		"YnT5dW8mQjL3Hk0vRpB1aMxXfg7tCsZuO6yKlPwEnHjVtRoUbDpAcSdEhMkLvNfX",
+		"YwG4qS6tZpOcRhAdLnIuKbVxWmEjCrYsZf0PqTgUyMxNkVoLhBpJqWdCnAaXrEbT",
+		"FdYvKsRiUpHmNxJqLzWbCdEoAfYpQnZkRmTuPxVjShBwLqDgEnIyCkOdRpAvYxKt",
+		"-----END RSA PRIVATE KEY-----",
+		"",
+	}, "\n")
+
+	cases := []struct {
+		name    string
+		yamlVal string // value placed after `private_key:` in the YAML
+		// The YAML parser-level trailing-newline behavior differs per quoting style;
+		// each case states what it expects to see after post-parse expansion.
+		wantSuffix string
+	}{
+		{
+			name:       "block scalar (|)",
+			yamlVal:    "|\n          ${TEST_MULTILINE_PEM}",
+			wantSuffix: "\n", // | keeps a single trailing newline
+		},
+		{
+			name:       "block scalar strip (|-)",
+			yamlVal:    "|-\n          ${TEST_MULTILINE_PEM}",
+			wantSuffix: "", // |- strips the trailing newline
+		},
+		{
+			name:       "double-quoted",
+			yamlVal:    `"${TEST_MULTILINE_PEM}"`,
+			wantSuffix: "",
+		},
+		{
+			name:       "single-quoted",
+			yamlVal:    `'${TEST_MULTILINE_PEM}'`,
+			wantSuffix: "",
+		},
+		{
+			name:       "plain (unquoted)",
+			yamlVal:    "${TEST_MULTILINE_PEM}",
+			wantSuffix: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			cfgPath := filepath.Join(dir, "config.yaml")
+			yamlBody := fmt.Sprintf(`
+orgs:
+  - name: env-org
+    apps:
+      - app_id: 999
+        private_key: %s
+`, tc.yamlVal)
+			if err := os.WriteFile(cfgPath, []byte(yamlBody), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			t.Setenv("TEST_MULTILINE_PEM", pem)
+
+			cfg, err := Load(WithConfigFilePath(cfgPath))
+			if err != nil {
+				t.Fatalf("Load() = %v", err)
+			}
+
+			want := pem + tc.wantSuffix
+			got := cfg.Orgs[0].Apps[0].PrivateKey
+			if got != want {
+				t.Errorf("multi-line PEM not preserved.\n got:  %q\n want: %q", got, want)
+			}
+		})
+	}
+}
+
+func TestLoadInlinePEM(t *testing.T) {
+	// Operators who don't want env-var injection can paste the PEM directly
+	// into the YAML via a block scalar. envExpandingParser must leave strings
+	// without ${VAR} placeholders untouched.
+	pem := strings.Join([]string{
+		"-----BEGIN RSA PRIVATE KEY-----",
+		"MIIEowIBAAKCAQEAvBfQk9F4mP1xK7Tjz+VKp1uW3v8oQa2yLNH0sZ4bI9rFcXe2",
+		"YnT5dW8mQjL3Hk0vRpB1aMxXfg7tCsZuO6yKlPwEnHjVtRoUbDpAcSdEhMkLvNfX",
+		"YwG4qS6tZpOcRhAdLnIuKbVxWmEjCrYsZf0PqTgUyMxNkVoLhBpJqWdCnAaXrEbT",
+		"FdYvKsRiUpHmNxJqLzWbCdEoAfYpQnZkRmTuPxVjShBwLqDgEnIyCkOdRpAvYxKt",
+		"-----END RSA PRIVATE KEY-----",
+		"",
+	}, "\n")
+
+	cases := []struct {
+		name       string
+		blockStyle string // YAML block-scalar indicator
+		wantSuffix string // trailing newline behavior: "|" keeps one, "|-" strips it
+	}{
+		{name: "block scalar (|)", blockStyle: "|", wantSuffix: "\n"},
+		{name: "block scalar strip (|-)", blockStyle: "|-", wantSuffix: ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			cfgPath := filepath.Join(dir, "config.yaml")
+
+			// Block scalars strip the common leading indent from each body line.
+			// Indent the PEM body 10 spaces (under "private_key:" at 8 spaces).
+			var indented strings.Builder
+			for line := range strings.SplitSeq(strings.TrimRight(pem, "\n"), "\n") {
+				indented.WriteString("          ")
+				indented.WriteString(line)
+				indented.WriteString("\n")
+			}
+
+			yamlBody := fmt.Sprintf(`
+orgs:
+  - name: inline-org
+    apps:
+      - app_id: 888
+        private_key: %s
+%s`, tc.blockStyle, indented.String())
+
+			if err := os.WriteFile(cfgPath, []byte(yamlBody), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			cfg, err := Load(WithConfigFilePath(cfgPath))
+			if err != nil {
+				t.Fatalf("Load() = %v", err)
+			}
+
+			want := strings.TrimRight(pem, "\n") + tc.wantSuffix
+			if got := cfg.Orgs[0].Apps[0].PrivateKey; got != want {
+				t.Errorf("inline PEM not preserved.\n got:  %q\n want: %q", got, want)
+			}
+		})
+	}
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     Config
+		wantErr bool
+	}{
+		{
+			name:    "empty orgs",
+			cfg:     Config{},
+			wantErr: true,
+		},
+		{
+			name: "empty org name",
+			cfg: Config{Orgs: []OrgConfig{
+				{Name: "", Apps: []AppConfig{{AppID: 1, KMSKey: "k"}}},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "duplicate org names",
+			cfg: Config{Orgs: []OrgConfig{
+				{Name: "org", Apps: []AppConfig{{AppID: 1, KMSKey: "k"}}},
+				{Name: "org", Apps: []AppConfig{{AppID: 2, KMSKey: "k"}}},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "no apps in org",
+			cfg: Config{Orgs: []OrgConfig{
+				{Name: "org", Apps: nil},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "zero app_id",
+			cfg: Config{Orgs: []OrgConfig{
+				{Name: "org", Apps: []AppConfig{{AppID: 0, KMSKey: "k"}}},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "duplicate app_id across orgs",
+			cfg: Config{Orgs: []OrgConfig{
+				{Name: "org1", Apps: []AppConfig{{AppID: 1, KMSKey: "k1"}}},
+				{Name: "org2", Apps: []AppConfig{{AppID: 1, KMSKey: "k2"}}},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "no credential source",
+			cfg: Config{Orgs: []OrgConfig{
+				{Name: "org", Apps: []AppConfig{{AppID: 1}}},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "multiple credential sources",
+			cfg: Config{Orgs: []OrgConfig{
+				{Name: "org", Apps: []AppConfig{{AppID: 1, KMSKey: "k", PrivateKey: "pk"}}},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "valid single org kms",
+			cfg: Config{Orgs: []OrgConfig{
+				{Name: "org", Apps: []AppConfig{{AppID: 1, KMSKey: "k"}}},
+			}},
+			wantErr: false,
+		},
+		{
+			name: "valid multi org mixed credentials",
+			cfg: Config{Orgs: []OrgConfig{
+				{Name: "org1", Apps: []AppConfig{
+					{AppID: 1, KMSKey: "k"},
+					{AppID: 2, KMSKey: "k2"},
+				}},
+				{Name: "org2", Apps: []AppConfig{
+					{AppID: 3, PrivateKeyFile: "/path"},
+				}},
+				{Name: "org3", Apps: []AppConfig{
+					{AppID: 4, PrivateKey: "pem"},
+				}},
+			}},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.Validate()
+			if (err != nil) != tc.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/appconfig/options.go
+++ b/pkg/appconfig/options.go
@@ -1,0 +1,37 @@
+// Copyright 2024 Chainguard, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package appconfig
+
+type Options struct {
+	TagName            string
+	ConfigKeyDelimiter string
+	ConfigFilePath     []string
+}
+
+type OptionsApplier func(o *Options)
+
+func WithConfigKeyDelimiter(v string) OptionsApplier {
+	return func(o *Options) {
+		o.ConfigKeyDelimiter = v
+	}
+}
+
+func WithConfigFilePath(v ...string) OptionsApplier {
+	return func(o *Options) {
+		o.ConfigFilePath = v
+	}
+}
+
+func NewOptions(appliers ...OptionsApplier) *Options {
+	options := &Options{
+		TagName:            "mapstructure",
+		ConfigKeyDelimiter: ".",
+	}
+
+	for _, applier := range appliers {
+		applier(options)
+	}
+
+	return options
+}

--- a/pkg/envconfig/envconfig.go
+++ b/pkg/envconfig/envconfig.go
@@ -14,10 +14,16 @@ import (
 type EnvConfig struct {
 	Port                       int      `envconfig:"PORT" required:"true"`
 	KMSKeys                    []string `envconfig:"KMS_KEYS" required:"false"`
-	AppIDs                     []int64  `envconfig:"GITHUB_APP_IDS" required:"true"`
+	AppIDs                     []int64  `envconfig:"GITHUB_APP_IDS" required:"false"`
 	AppSecretCertificateFile   string   `envconfig:"APP_SECRET_CERTIFICATE_FILE" required:"false"`
 	AppSecretCertificateEnvVar string   `envconfig:"APP_SECRET_CERTIFICATE_ENV_VAR" required:"false"`
 	Metrics                    bool     `envconfig:"METRICS" required:"false" default:"true"`
+
+	// AppConfigFile, when set, points to a YAML file describing per-org GitHub
+	// App pools. When set, the legacy GITHUB_APP_IDS / KMS_KEYS env vars are
+	// not required.
+	AppConfigFile string `envconfig:"APP_CONFIG_FILE" required:"false"`
+
 	// QuotaFloorHard / QuotaFloorSoft tune the three-tier capacity-aware
 	// picker in pkg/ghinstall. Defaults target GitHub's default 15,000/hr
 	// installation rate-limit cap: drop out of the preferred pool below
@@ -76,22 +82,29 @@ func BaseConfig() (*EnvConfig, error) {
 		return nil, err
 	}
 
-	sources := 0
-	if len(cfg.KMSKeys) > 0 {
-		sources++
-	}
-	if cfg.AppSecretCertificateFile != "" {
-		sources++
-	}
-	if cfg.AppSecretCertificateEnvVar != "" {
-		sources++
-	}
-	if sources > 1 {
-		return nil, errors.New("only one of KMS_KEYS, APP_SECRET_CERTIFICATE_FILE, APP_SECRET_CERTIFICATE_ENV_VAR may be set")
-	}
+	// Legacy env-var validation only applies when APP_CONFIG_FILE is not set.
+	if cfg.AppConfigFile == "" {
+		if len(cfg.AppIDs) == 0 {
+			return nil, errors.New("GITHUB_APP_IDS is required when APP_CONFIG_FILE is not set")
+		}
 
-	if len(cfg.KMSKeys) > 0 && len(cfg.KMSKeys) != len(cfg.AppIDs) {
-		return nil, fmt.Errorf("KMS_KEYS length (%d) must match GITHUB_APP_IDS length (%d)", len(cfg.KMSKeys), len(cfg.AppIDs))
+		sources := 0
+		if len(cfg.KMSKeys) > 0 {
+			sources++
+		}
+		if cfg.AppSecretCertificateFile != "" {
+			sources++
+		}
+		if cfg.AppSecretCertificateEnvVar != "" {
+			sources++
+		}
+		if sources > 1 {
+			return nil, errors.New("only one of KMS_KEYS, APP_SECRET_CERTIFICATE_FILE, APP_SECRET_CERTIFICATE_ENV_VAR may be set")
+		}
+
+		if len(cfg.KMSKeys) > 0 && len(cfg.KMSKeys) != len(cfg.AppIDs) {
+			return nil, fmt.Errorf("KMS_KEYS length (%d) must match GITHUB_APP_IDS length (%d)", len(cfg.KMSKeys), len(cfg.AppIDs))
+		}
 	}
 
 	if cfg.QuotaFloorHard < 0 || cfg.QuotaFloorSoft < 0 {

--- a/pkg/envconfig/envconfig.go
+++ b/pkg/envconfig/envconfig.go
@@ -16,10 +16,16 @@ type EnvConfig struct {
 	Port                       int      `envconfig:"PORT" required:"true"`
 	KMSKeys                    []string `envconfig:"KMS_KEYS" required:"false"`
 	KMSProvider                string   `envconfig:"KMS_PROVIDER" required:"false" default:"gcp"`
-	AppIDs                     []int64  `envconfig:"GITHUB_APP_IDS" required:"true"`
+	AppIDs                     []int64  `envconfig:"GITHUB_APP_IDS" required:"false"`
 	AppSecretCertificateFile   string   `envconfig:"APP_SECRET_CERTIFICATE_FILE" required:"false"`
 	AppSecretCertificateEnvVar string   `envconfig:"APP_SECRET_CERTIFICATE_ENV_VAR" required:"false"`
 	Metrics                    bool     `envconfig:"METRICS" required:"false" default:"true"`
+
+	// AppConfigFile, when set, points to a YAML file describing per-org GitHub
+	// App pools. When set, the legacy GITHUB_APP_IDS / KMS_KEYS env vars are
+	// not required.
+	AppConfigFile string `envconfig:"APP_CONFIG_FILE" required:"false"`
+
 	// QuotaFloorHard / QuotaFloorSoft tune the three-tier capacity-aware
 	// picker in pkg/ghinstall. Defaults target GitHub's default 15,000/hr
 	// installation rate-limit cap: drop out of the preferred pool below
@@ -100,23 +106,29 @@ func BaseConfig() (*EnvConfig, error) {
 		return nil, err
 	}
 
-	sources := 0
-	if len(cfg.KMSKeys) > 0 {
-		sources++
-	}
-	if cfg.AppSecretCertificateFile != "" {
-		sources++
-	}
-	if cfg.AppSecretCertificateEnvVar != "" {
-		sources++
-	}
+	// Legacy env-var validation only applies when APP_CONFIG_FILE is not set.
+	if cfg.AppConfigFile == "" {
+		if len(cfg.AppIDs) == 0 {
+			return nil, errors.New("GITHUB_APP_IDS is required when APP_CONFIG_FILE is not set")
+		}
 
-	if sources > 1 {
-		return nil, errors.New("only one of KMS_KEYS, APP_SECRET_CERTIFICATE_FILE, APP_SECRET_CERTIFICATE_ENV_VAR may be set")
-	}
+		sources := 0
+		if len(cfg.KMSKeys) > 0 {
+			sources++
+		}
+		if cfg.AppSecretCertificateFile != "" {
+			sources++
+		}
+		if cfg.AppSecretCertificateEnvVar != "" {
+			sources++
+		}
+		if sources > 1 {
+			return nil, errors.New("only one of KMS_KEYS, APP_SECRET_CERTIFICATE_FILE, APP_SECRET_CERTIFICATE_ENV_VAR may be set")
+		}
 
-	if len(cfg.KMSKeys) > 0 && len(cfg.KMSKeys) != len(cfg.AppIDs) {
-		return nil, fmt.Errorf("KMS_KEYS length (%d) must match GITHUB_APP_IDS length (%d)", len(cfg.KMSKeys), len(cfg.AppIDs))
+		if len(cfg.KMSKeys) > 0 && len(cfg.KMSKeys) != len(cfg.AppIDs) {
+			return nil, fmt.Errorf("KMS_KEYS length (%d) must match GITHUB_APP_IDS length (%d)", len(cfg.KMSKeys), len(cfg.AppIDs))
+		}
 	}
 
 	if cfg.QuotaFloorHard < 0 || cfg.QuotaFloorSoft < 0 {

--- a/pkg/envconfig/envconfig_test.go
+++ b/pkg/envconfig/envconfig_test.go
@@ -245,6 +245,37 @@ func TestBaseConfig(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			// BaseConfig only records the path; the file is read later by
+			// pkg/appconfig, so it doesn't need to exist here.
+			name: "APP_CONFIG_FILE set bypasses GITHUB_APP_IDS requirement",
+			envVars: map[string]string{
+				"PORT":            "8080",
+				"APP_CONFIG_FILE": "/etc/octo-sts/config.yaml",
+			},
+			wantErr: false,
+		},
+		{
+			name: "GITHUB_APP_IDS required when APP_CONFIG_FILE unset",
+			envVars: map[string]string{
+				"PORT": "8080",
+			},
+			wantErr: true,
+		},
+		{
+			// Legacy credential validation is skipped by design when the
+			// YAML config is in use: credentials come from the config file,
+			// so conflicting legacy env vars are ignored rather than fatal.
+			name: "APP_CONFIG_FILE skips legacy credential validation",
+			envVars: map[string]string{
+				"PORT":                        "8080",
+				"APP_CONFIG_FILE":             "/etc/octo-sts/config.yaml",
+				"GITHUB_APP_IDS":              "12345678,87654321",
+				"KMS_KEYS":                    "only-one-key",
+				"APP_SECRET_CERTIFICATE_FILE": "some-file-path",
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/ghinstall/org_router.go
+++ b/pkg/ghinstall/org_router.go
@@ -1,0 +1,49 @@
+// Copyright 2024 Chainguard, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package ghinstall
+
+import (
+	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// WildcardOrg is the key used for a fallback pool that serves any org.
+// Used by the legacy env-var code path where all apps serve all orgs.
+const WildcardOrg = "*"
+
+// OrgPool holds the Manager that serves a single organization, plus the
+// number of underlying apps so callers can cap rate-limit retries.
+type OrgPool struct {
+	M        Manager
+	AppCount int
+}
+
+// OrgRouter maps GitHub organization names to their dedicated app pools.
+// A wildcard entry (WildcardOrg) serves as a fallback for any org not
+// explicitly configured — used by the legacy env-var code path.
+type OrgRouter struct {
+	orgs map[string]*OrgPool
+}
+
+// NewOrgRouter creates an OrgRouter from the given org-to-pool mapping.
+func NewOrgRouter(orgs map[string]*OrgPool) *OrgRouter {
+	return &OrgRouter{orgs: orgs}
+}
+
+// GetPool returns the OrgPool for the given owner. If owner is not explicitly
+// configured, it falls back to the WildcardOrg entry. Returns a NotFound
+// gRPC error if no pool is available. The lookup is case-insensitive since
+// GitHub organization names are case-insensitive.
+func (r *OrgRouter) GetPool(owner string) (*OrgPool, error) {
+	owner = strings.ToLower(owner)
+	if pool, ok := r.orgs[owner]; ok {
+		return pool, nil
+	}
+	if pool, ok := r.orgs[WildcardOrg]; ok {
+		return pool, nil
+	}
+	return nil, status.Errorf(codes.NotFound, "no GitHub App configured for org %q", owner)
+}

--- a/pkg/ghinstall/org_router_test.go
+++ b/pkg/ghinstall/org_router_test.go
@@ -1,0 +1,92 @@
+// Copyright 2024 Chainguard, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package ghinstall
+
+import (
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestGetPoolExactMatch(t *testing.T) {
+	pool := &OrgPool{AppCount: 2}
+	router := NewOrgRouter(map[string]*OrgPool{"my-org": pool})
+
+	got, err := router.GetPool("my-org")
+	if err != nil {
+		t.Fatalf("GetPool() = %v", err)
+	}
+	if got != pool {
+		t.Error("expected exact-match pool")
+	}
+}
+
+func TestGetPoolWildcardFallback(t *testing.T) {
+	wildcard := &OrgPool{AppCount: 1}
+	router := NewOrgRouter(map[string]*OrgPool{WildcardOrg: wildcard})
+
+	got, err := router.GetPool("unknown-org")
+	if err != nil {
+		t.Fatalf("GetPool() = %v", err)
+	}
+	if got != wildcard {
+		t.Error("expected wildcard pool")
+	}
+}
+
+func TestGetPoolExactTakesPrecedenceOverWildcard(t *testing.T) {
+	exact := &OrgPool{AppCount: 2}
+	wildcard := &OrgPool{AppCount: 1}
+	router := NewOrgRouter(map[string]*OrgPool{
+		"my-org": exact,
+		WildcardOrg: wildcard,
+	})
+
+	got, err := router.GetPool("my-org")
+	if err != nil {
+		t.Fatalf("GetPool() = %v", err)
+	}
+	if got != exact {
+		t.Error("expected exact pool, got wildcard")
+	}
+}
+
+func TestGetPoolNotFound(t *testing.T) {
+	router := NewOrgRouter(map[string]*OrgPool{"other-org": {AppCount: 1}})
+
+	_, err := router.GetPool("missing-org")
+	if err == nil {
+		t.Fatal("expected error for unconfigured org")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %T", err)
+	}
+	if st.Code() != codes.NotFound {
+		t.Errorf("expected NotFound, got %v", st.Code())
+	}
+}
+
+func TestGetPoolCaseInsensitive(t *testing.T) {
+	pool := &OrgPool{AppCount: 1}
+	router := NewOrgRouter(map[string]*OrgPool{"my-org": pool})
+
+	got, err := router.GetPool("My-Org")
+	if err != nil {
+		t.Fatalf("GetPool() = %v", err)
+	}
+	if got != pool {
+		t.Error("expected case-insensitive match")
+	}
+}
+
+func TestGetPoolEmptyRouter(t *testing.T) {
+	router := NewOrgRouter(map[string]*OrgPool{})
+
+	_, err := router.GetPool("any-org")
+	if err == nil {
+		t.Fatal("expected error for empty router")
+	}
+}

--- a/pkg/ghinstall/org_router_test.go
+++ b/pkg/ghinstall/org_router_test.go
@@ -1,0 +1,92 @@
+// Copyright 2024 Chainguard, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package ghinstall
+
+import (
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestGetPoolExactMatch(t *testing.T) {
+	pool := &OrgPool{AppCount: 2}
+	router := NewOrgRouter(map[string]*OrgPool{"my-org": pool})
+
+	got, err := router.GetPool("my-org")
+	if err != nil {
+		t.Fatalf("GetPool() = %v", err)
+	}
+	if got != pool {
+		t.Error("expected exact-match pool")
+	}
+}
+
+func TestGetPoolWildcardFallback(t *testing.T) {
+	wildcard := &OrgPool{AppCount: 1}
+	router := NewOrgRouter(map[string]*OrgPool{WildcardOrg: wildcard})
+
+	got, err := router.GetPool("unknown-org")
+	if err != nil {
+		t.Fatalf("GetPool() = %v", err)
+	}
+	if got != wildcard {
+		t.Error("expected wildcard pool")
+	}
+}
+
+func TestGetPoolExactTakesPrecedenceOverWildcard(t *testing.T) {
+	exact := &OrgPool{AppCount: 2}
+	wildcard := &OrgPool{AppCount: 1}
+	router := NewOrgRouter(map[string]*OrgPool{
+		"my-org":    exact,
+		WildcardOrg: wildcard,
+	})
+
+	got, err := router.GetPool("my-org")
+	if err != nil {
+		t.Fatalf("GetPool() = %v", err)
+	}
+	if got != exact {
+		t.Error("expected exact pool, got wildcard")
+	}
+}
+
+func TestGetPoolNotFound(t *testing.T) {
+	router := NewOrgRouter(map[string]*OrgPool{"other-org": {AppCount: 1}})
+
+	_, err := router.GetPool("missing-org")
+	if err == nil {
+		t.Fatal("expected error for unconfigured org")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %T", err)
+	}
+	if st.Code() != codes.NotFound {
+		t.Errorf("expected NotFound, got %v", st.Code())
+	}
+}
+
+func TestGetPoolCaseInsensitive(t *testing.T) {
+	pool := &OrgPool{AppCount: 1}
+	router := NewOrgRouter(map[string]*OrgPool{"my-org": pool})
+
+	got, err := router.GetPool("My-Org")
+	if err != nil {
+		t.Fatalf("GetPool() = %v", err)
+	}
+	if got != pool {
+		t.Error("expected case-insensitive match")
+	}
+}
+
+func TestGetPoolEmptyRouter(t *testing.T) {
+	router := NewOrgRouter(map[string]*OrgPool{})
+
+	_, err := router.GetPool("any-org")
+	if err == nil {
+		t.Fatal("expected error for empty router")
+	}
+}

--- a/pkg/ghtransport/ghtransport.go
+++ b/pkg/ghtransport/ghtransport.go
@@ -13,6 +13,7 @@ import (
 	kms "cloud.google.com/go/kms/apiv1"
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	metrics "github.com/chainguard-dev/terraform-infra-common/pkg/httpmetrics"
+	"github.com/octo-sts/app/pkg/appconfig"
 	envConfig "github.com/octo-sts/app/pkg/envconfig"
 	"github.com/octo-sts/app/pkg/gcpkms"
 	"github.com/octo-sts/app/pkg/ghinstall"
@@ -66,48 +67,47 @@ func (q *quotaTap) RoundTrip(req *http.Request) (*http.Response, error) {
 	return resp, err
 }
 
-// New creates a GitHub AppsTransport. If quota is non-nil, response headers
-// are also tapped into the QuotaStore for capacity-aware routing decisions.
-func New(ctx context.Context, appID int64, kmsKey string, env *envConfig.EnvConfig, kmsClient *kms.KeyManagementClient, quota *ghinstall.QuotaStore) (*ghinstallation.AppsTransport, error) {
-	// Wrap the base HTTP transport so every GitHub response's X-RateLimit-*
-	// headers populate the github_rate_limit_* metrics with the app_id and
-	// installation_id labels set on the request context by EnrichContext.
+// baseTransport returns the HTTP transport used by every AppsTransport: the
+// default transport, wrapped by the httpmetrics transport for rate-limit
+// labelling, and optionally a quotaTap if a QuotaStore is provided.
+func baseTransport(quota *ghinstall.QuotaStore) http.RoundTripper {
 	base := metrics.WrapTransport(http.DefaultTransport)
 	if quota != nil {
 		base = &quotaTap{inner: base, store: quota}
 	}
+	return base
+}
 
+// NewFromAppConfig creates an AppsTransport from an appconfig.AppConfig entry.
+// Exactly one of app.PrivateKey, app.PrivateKeyFile, or app.KMSKey must be set.
+// If quota is non-nil, response headers are tapped into the QuotaStore for
+// capacity-aware routing decisions.
+func NewFromAppConfig(ctx context.Context, app appconfig.AppConfig, kmsClient *kms.KeyManagementClient, quota *ghinstall.QuotaStore) (*ghinstallation.AppsTransport, error) {
+	base := baseTransport(quota)
 	switch {
-	case env.AppSecretCertificateEnvVar != "":
-		atr, err := ghinstallation.NewAppsTransport(base, appID, []byte(env.AppSecretCertificateEnvVar))
-
-		if err != nil {
-			return nil, err
-		}
-		return atr, nil
-
-	case env.AppSecretCertificateFile != "":
-		atr, err := ghinstallation.NewAppsTransportKeyFromFile(base, appID, env.AppSecretCertificateFile)
-
-		if err != nil {
-			return nil, err
-		}
-		return atr, nil
+	case app.PrivateKey != "":
+		return ghinstallation.NewAppsTransport(base, app.AppID, []byte(app.PrivateKey))
+	case app.PrivateKeyFile != "":
+		return ghinstallation.NewAppsTransportKeyFromFile(base, app.AppID, app.PrivateKeyFile)
 	default:
-		if kmsKey == "" {
-			return nil, fmt.Errorf("no KMS key provided for app %d", appID)
+		if app.KMSKey == "" {
+			return nil, fmt.Errorf("no credential source for app %d", app.AppID)
 		}
-
-		signer, err := gcpkms.New(ctx, kmsClient, kmsKey)
+		signer, err := gcpkms.New(ctx, kmsClient, app.KMSKey)
 		if err != nil {
 			return nil, fmt.Errorf("error creating signer: %w", err)
 		}
-
-		atr, err := ghinstallation.NewAppsTransportWithOptions(base, appID, ghinstallation.WithSigner(signer))
-		if err != nil {
-			return nil, err
-		}
-
-		return atr, nil
+		return ghinstallation.NewAppsTransportWithOptions(base, app.AppID, ghinstallation.WithSigner(signer))
 	}
+}
+
+// New creates an AppsTransport from legacy environment-variable config.
+// It delegates to NewFromAppConfig after mapping the env fields.
+func New(ctx context.Context, appID int64, kmsKey string, env *envConfig.EnvConfig, kmsClient *kms.KeyManagementClient, quota *ghinstall.QuotaStore) (*ghinstallation.AppsTransport, error) {
+	return NewFromAppConfig(ctx, appconfig.AppConfig{
+		AppID:          appID,
+		PrivateKey:     env.AppSecretCertificateEnvVar,
+		PrivateKeyFile: env.AppSecretCertificateFile,
+		KMSKey:         kmsKey,
+	}, kmsClient, quota)
 }

--- a/pkg/ghtransport/ghtransport.go
+++ b/pkg/ghtransport/ghtransport.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	metrics "github.com/chainguard-dev/terraform-infra-common/pkg/httpmetrics"
+	"github.com/octo-sts/app/pkg/appconfig"
 	envConfig "github.com/octo-sts/app/pkg/envconfig"
 	"github.com/octo-sts/app/pkg/ghinstall"
 	"github.com/octo-sts/app/pkg/kms"
@@ -65,41 +66,45 @@ func (q *quotaTap) RoundTrip(req *http.Request) (*http.Response, error) {
 	return resp, err
 }
 
-// New creates a GitHub AppsTransport. If quota is non-nil, response headers
-// are also tapped into the QuotaStore for capacity-aware routing decisions.
-func New(ctx context.Context, appID int64, kmsKey string, env *envConfig.EnvConfig, kmsClient kms.KMS, quota *ghinstall.QuotaStore) (*ghinstallation.AppsTransport, error) {
-	// Wrap the base HTTP transport so every GitHub response's X-RateLimit-*
-	// headers populate the github_rate_limit_* metrics with the app_id and
-	// installation_id labels set on the request context by EnrichContext.
+// baseTransport returns the HTTP transport used by every AppsTransport: the
+// default transport, wrapped by the httpmetrics transport for rate-limit
+// labelling, and optionally a quotaTap if a QuotaStore is provided.
+//
+// The httpmetrics wrapping ensures every GitHub response's X-RateLimit-*
+// headers populate the github_rate_limit_* metrics with the app_id and
+// installation_id labels set on the request context by EnrichContext.
+func baseTransport(quota *ghinstall.QuotaStore) http.RoundTripper {
 	base := metrics.WrapTransport(http.DefaultTransport)
 	if quota != nil {
 		base = &quotaTap{inner: base, store: quota}
 	}
+	return base
+}
+
+// NewFromAppConfig creates an AppsTransport from an appconfig.AppConfig entry.
+// Exactly one of app.PrivateKey, app.PrivateKeyFile, or app.KMSKey must be set.
+// When app.KMSKey is set, kmsClient must be a signer bound to that key
+// (constructed by the caller via kms.NewKMS so it can be closed at shutdown).
+// If quota is non-nil, response headers are tapped into the QuotaStore for
+// capacity-aware routing decisions.
+func NewFromAppConfig(_ context.Context, app appconfig.AppConfig, env *envConfig.EnvConfig, kmsClient kms.KMS, quota *ghinstall.QuotaStore) (*ghinstallation.AppsTransport, error) {
+	base := baseTransport(quota)
 
 	var atr *ghinstallation.AppsTransport
 	var err error
 	switch {
-	case env.AppSecretCertificateEnvVar != "":
-		atr, err = ghinstallation.NewAppsTransport(base, appID, []byte(env.AppSecretCertificateEnvVar))
-		if err != nil {
-			return nil, err
-		}
-
-	case env.AppSecretCertificateFile != "":
-		atr, err = ghinstallation.NewAppsTransportKeyFromFile(base, appID, env.AppSecretCertificateFile)
-		if err != nil {
-			return nil, err
-		}
-
+	case app.PrivateKey != "":
+		atr, err = ghinstallation.NewAppsTransport(base, app.AppID, []byte(app.PrivateKey))
+	case app.PrivateKeyFile != "":
+		atr, err = ghinstallation.NewAppsTransportKeyFromFile(base, app.AppID, app.PrivateKeyFile)
 	default:
-		if kmsKey == "" {
-			return nil, fmt.Errorf("no KMS key provided for app %d", appID)
+		if app.KMSKey == "" {
+			return nil, fmt.Errorf("no credential source for app %d", app.AppID)
 		}
-
-		atr, err = ghinstallation.NewAppsTransportWithOptions(base, appID, ghinstallation.WithSigner(kmsClient))
-		if err != nil {
-			return nil, err
-		}
+		atr, err = ghinstallation.NewAppsTransportWithOptions(base, app.AppID, ghinstallation.WithSigner(kmsClient))
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	if env.GitHubBaseURL != "" {
@@ -107,4 +112,15 @@ func New(ctx context.Context, appID int64, kmsKey string, env *envConfig.EnvConf
 	}
 
 	return atr, nil
+}
+
+// New creates an AppsTransport from legacy environment-variable config.
+// It delegates to NewFromAppConfig after mapping the env fields.
+func New(ctx context.Context, appID int64, kmsKey string, env *envConfig.EnvConfig, kmsClient kms.KMS, quota *ghinstall.QuotaStore) (*ghinstallation.AppsTransport, error) {
+	return NewFromAppConfig(ctx, appconfig.AppConfig{
+		AppID:          appID,
+		PrivateKey:     env.AppSecretCertificateEnvVar,
+		PrivateKeyFile: env.AppSecretCertificateFile,
+		KMSKey:         kmsKey,
+	}, env, kmsClient, quota)
 }

--- a/pkg/ghtransport/ghtransport_test.go
+++ b/pkg/ghtransport/ghtransport_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	kms "cloud.google.com/go/kms/apiv1"
+	"github.com/octo-sts/app/pkg/appconfig"
 	"github.com/octo-sts/app/pkg/envconfig"
 	"github.com/octo-sts/app/pkg/ghinstall"
 	"github.com/stretchr/testify/assert"
@@ -164,6 +165,49 @@ func TestCertFile(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, transport)
 	}
+}
+
+func TestNewFromAppConfigKMS(t *testing.T) {
+	ctx := context.Background()
+	credsFile := createGCPKMSCredsFile(t)
+	defer os.Remove(credsFile)
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", credsFile)
+
+	kmsClient := generateKMSClient(ctx, t)
+	transport, err := NewFromAppConfig(ctx, appconfig.AppConfig{
+		AppID:  12345678,
+		KMSKey: "test-kms-key",
+	}, kmsClient, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, transport)
+}
+
+func TestNewFromAppConfigPrivateKey(t *testing.T) {
+	ctx := context.Background()
+	transport, err := NewFromAppConfig(ctx, appconfig.AppConfig{
+		AppID:      12345678,
+		PrivateKey: generateTestCertificateString(),
+	}, nil, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, transport)
+}
+
+func TestNewFromAppConfigPrivateKeyFile(t *testing.T) {
+	ctx := context.Background()
+	transport, err := NewFromAppConfig(ctx, appconfig.AppConfig{
+		AppID:          12345678,
+		PrivateKeyFile: generateTestCertificateFile(t),
+	}, nil, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, transport)
+}
+
+func TestNewFromAppConfigNoCredential(t *testing.T) {
+	ctx := context.Background()
+	_, err := NewFromAppConfig(ctx, appconfig.AppConfig{
+		AppID: 12345678,
+	}, nil, nil)
+	assert.Error(t, err)
 }
 
 func generateKMSClient(ctx context.Context, t *testing.T) *kms.KeyManagementClient {

--- a/pkg/ghtransport/ghtransport_test.go
+++ b/pkg/ghtransport/ghtransport_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	gkms "cloud.google.com/go/kms/apiv1"
+	"github.com/octo-sts/app/pkg/appconfig"
 	"github.com/octo-sts/app/pkg/envconfig"
 	"github.com/octo-sts/app/pkg/ghinstall"
 	"github.com/octo-sts/app/pkg/kms"
@@ -205,6 +206,49 @@ func TestGitHubBaseURLEmptyKeepsDefault(t *testing.T) {
 	assert.NotNil(t, transport)
 	// Default ghinstallation base URL when not overridden.
 	assert.Equal(t, "https://api.github.com", transport.BaseURL)
+}
+
+func TestNewFromAppConfigKMS(t *testing.T) {
+	ctx := context.Background()
+	credsFile := createGCPKMSCredsFile(t)
+	defer os.Remove(credsFile)
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", credsFile)
+
+	kmsClient := generateKMSClient(ctx, t)
+	transport, err := NewFromAppConfig(ctx, appconfig.AppConfig{
+		AppID:  12345678,
+		KMSKey: "test-kms-key",
+	}, &envconfig.EnvConfig{}, kmsClient, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, transport)
+}
+
+func TestNewFromAppConfigPrivateKey(t *testing.T) {
+	ctx := context.Background()
+	transport, err := NewFromAppConfig(ctx, appconfig.AppConfig{
+		AppID:      12345678,
+		PrivateKey: generateTestCertificateString(),
+	}, &envconfig.EnvConfig{}, nil, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, transport)
+}
+
+func TestNewFromAppConfigPrivateKeyFile(t *testing.T) {
+	ctx := context.Background()
+	transport, err := NewFromAppConfig(ctx, appconfig.AppConfig{
+		AppID:          12345678,
+		PrivateKeyFile: generateTestCertificateFile(t),
+	}, &envconfig.EnvConfig{}, nil, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, transport)
+}
+
+func TestNewFromAppConfigNoCredential(t *testing.T) {
+	ctx := context.Background()
+	_, err := NewFromAppConfig(ctx, appconfig.AppConfig{
+		AppID: 12345678,
+	}, &envconfig.EnvConfig{}, nil, nil)
+	assert.Error(t, err)
 }
 
 func generateKMSClient(ctx context.Context, t *testing.T) kms.KMS {

--- a/pkg/octosts/octosts.go
+++ b/pkg/octosts/octosts.go
@@ -45,13 +45,13 @@ const (
 )
 
 // NewSecurityTokenServiceServer creates an STS that exchanges OIDC tokens for
-// GitHub installation tokens. rrm handles installation selection; sticky (may
-// be nil) persists checks:write routing for check-run ownership.
-func NewSecurityTokenServiceServer(rrm ghinstall.Manager, sticky stickystore.Store, appCount int, ceclient cloudevents.Client, domain string, metrics bool) pboidc.SecurityTokenServiceServer {
+// GitHub installation tokens. router selects the per-org app pool; sticky (may
+// be nil) persists checks:write routing for check-run ownership across all
+// pools (installation IDs are globally unique within GitHub).
+func NewSecurityTokenServiceServer(router *ghinstall.OrgRouter, sticky stickystore.Store, ceclient cloudevents.Client, domain string, metrics bool) pboidc.SecurityTokenServiceServer {
 	return &sts{
-		rrm:      rrm,
+		router:   router,
 		sticky:   sticky,
-		appCount: appCount,
 		ceclient: ceclient,
 		domain:   domain,
 		metrics:  metrics,
@@ -63,9 +63,8 @@ var trustPolicies = expirablelru.NewLRU[cacheTrustPolicyKey, string](200, nil, t
 type sts struct {
 	pboidc.UnimplementedSecurityTokenServiceServer
 
-	rrm      ghinstall.Manager
+	router   *ghinstall.OrgRouter
 	sticky   stickystore.Store
-	appCount int
 	ceclient cloudevents.Client
 	domain   string
 	metrics  bool
@@ -247,21 +246,21 @@ func hasChecksWrite(perms github.InstallationPermissions) bool {
 // For checks:write policies it returns the persisted sticky installation,
 // or assigns a new one via capacity-aware round-robin and persists it.
 // For all other policies it returns the installation that read the policy.
-func (s *sts) getExchangeInstall(ctx context.Context, owner, scope, identity, subject string, perms github.InstallationPermissions, readAtr *ghinstallation.AppsTransport, readID int64) (*ghinstallation.AppsTransport, int64, error) {
+func (s *sts) getExchangeInstall(ctx context.Context, pool *ghinstall.OrgPool, owner, scope, identity, subject string, perms github.InstallationPermissions, readAtr *ghinstallation.AppsTransport, readID int64) (*ghinstallation.AppsTransport, int64, error) {
 	if s.sticky == nil || !hasChecksWrite(perms) {
 		return readAtr, readID, nil
 	}
 
 	key := routekey.Key(scope, identity, subject)
 	if cachedID, ok, err := s.sticky.Get(ctx, key); err == nil && ok {
-		atr, id, err := s.rrm.GetByInstallation(ctx, owner, cachedID)
+		atr, id, err := pool.M.GetByInstallation(ctx, owner, cachedID)
 		if err == nil {
 			return atr, id, nil
 		}
 		clog.FromContext(ctx).Infof("sticky install %d no longer valid for %s, reassigning", cachedID, owner)
 	}
 
-	atr, id, err := s.rrm.Get(ctx, owner, scope, identity)
+	atr, id, err := pool.M.Get(ctx, owner, scope, identity)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -287,6 +286,12 @@ func (s *sts) lookupInstallAndTrustPolicy(ctx context.Context, scope, identity, 
 		tp = otp
 	}
 
+	// Look up the org's app pool.
+	pool, err := s.router.GetPool(owner)
+	if err != nil {
+		return nil, 0, nil, err
+	}
+
 	tpKey := cacheTrustPolicyKey{owner: owner, repo: repo, identity: identity}
 
 	if cached, ok := trustPolicies.Get(tpKey); ok && cached == negativeCacheConst {
@@ -294,19 +299,19 @@ func (s *sts) lookupInstallAndTrustPolicy(ctx context.Context, scope, identity, 
 		return nil, 0, nil, status.Errorf(codes.NotFound, "unable to find trust policy for %q", tpKey.identity)
 	}
 
-	// Read the trust policy using any available installation.
-	readAtr, readID, err := s.rrm.Get(ctx, owner, scope, identity)
+	// Read the trust policy using any available installation in this org's pool.
+	readAtr, readID, err := pool.M.Get(ctx, owner, scope, identity)
 	if err != nil {
 		return nil, 0, nil, err
 	}
 
-	readAtr, readID, err = s.lookupTrustPolicyWithRetry(ctx, readAtr, readID, owner, scope, identity, tpKey, tp)
+	readAtr, readID, err = s.lookupTrustPolicyWithRetry(ctx, pool, readAtr, readID, owner, scope, identity, tpKey, tp)
 	if err != nil {
 		return nil, 0, nil, err
 	}
 
 	// Now that we know the permissions, pick the exchange installation.
-	atr, id, err := s.getExchangeInstall(ctx, owner, scope, identity, subject, otp.Permissions, readAtr, readID)
+	atr, id, err := s.getExchangeInstall(ctx, pool, owner, scope, identity, subject, otp.Permissions, readAtr, readID)
 	if err != nil {
 		return nil, 0, nil, err
 	}
@@ -315,17 +320,17 @@ func (s *sts) lookupInstallAndTrustPolicy(ctx context.Context, scope, identity, 
 }
 
 // lookupTrustPolicyWithRetry fetches the trust policy, retrying with
-// different installations if the first attempt is rate-limited.
-func (s *sts) lookupTrustPolicyWithRetry(ctx context.Context, atr *ghinstallation.AppsTransport, id int64, owner, scope, identity string, tpKey cacheTrustPolicyKey, tp trustPolicy) (*ghinstallation.AppsTransport, int64, error) {
+// different installations from the pool if the first attempt is rate-limited.
+func (s *sts) lookupTrustPolicyWithRetry(ctx context.Context, pool *ghinstall.OrgPool, atr *ghinstallation.AppsTransport, id int64, owner, scope, identity string, tpKey cacheTrustPolicyKey, tp trustPolicy) (*ghinstallation.AppsTransport, int64, error) {
 	err := s.lookupTrustPolicy(ctx, atr, id, tpKey, tp)
-	if !isRateLimit(err) || s.appCount <= 1 {
+	if !isRateLimit(err) || pool.AppCount <= 1 {
 		return atr, id, err
 	}
 
-	retries := min(maxRetry, s.appCount-1)
+	retries := min(maxRetry, pool.AppCount-1)
 	for i := range retries {
 		clog.InfoContextf(ctx, "policy read rate-limited, trying next app (%d/%d)", i+1, retries)
-		rAtr, rId, rErr := s.rrm.Get(ctx, owner, scope, identity)
+		rAtr, rId, rErr := pool.M.Get(ctx, owner, scope, identity)
 		if rErr != nil {
 			continue
 		}

--- a/pkg/octosts/octosts.go
+++ b/pkg/octosts/octosts.go
@@ -46,13 +46,13 @@ const (
 )
 
 // NewSecurityTokenServiceServer creates an STS that exchanges OIDC tokens for
-// GitHub installation tokens. rrm handles installation selection; sticky (may
-// be nil) persists checks:write routing for check-run ownership.
-func NewSecurityTokenServiceServer(rrm ghinstall.Manager, sticky stickystore.Store, appCount int, ceclient cloudevents.Client, domain string, metrics bool, baseURL string, orgPolicyRepo string) pboidc.SecurityTokenServiceServer {
+// GitHub installation tokens. router selects the per-org app pool; sticky (may
+// be nil) persists checks:write routing for check-run ownership across all
+// pools (installation IDs are globally unique within GitHub).
+func NewSecurityTokenServiceServer(router *ghinstall.OrgRouter, sticky stickystore.Store, ceclient cloudevents.Client, domain string, metrics bool, baseURL string, orgPolicyRepo string) pboidc.SecurityTokenServiceServer {
 	return &sts{
-		rrm:           rrm,
+		router:        router,
 		sticky:        sticky,
-		appCount:      appCount,
 		ceclient:      ceclient,
 		domain:        domain,
 		metrics:       metrics,
@@ -67,9 +67,8 @@ var staleTrustPolicies = expirablelru.NewLRU[cacheTrustPolicyKey, string](200, n
 type sts struct {
 	pboidc.UnimplementedSecurityTokenServiceServer
 
-	rrm           ghinstall.Manager
+	router        *ghinstall.OrgRouter
 	sticky        stickystore.Store
-	appCount      int
 	ceclient      cloudevents.Client
 	domain        string
 	metrics       bool
@@ -86,6 +85,17 @@ func (s *sts) policyRepo() string {
 		return s.orgPolicyRepo
 	}
 	return ".github"
+}
+
+// managerFor returns the installation manager for owner's app pool. The
+// error, when non-nil, is a terminal gRPC status (NotFound for an org with
+// no configured apps).
+func (s *sts) managerFor(owner string) (ghinstall.Manager, error) {
+	pool, err := s.router.GetPool(owner)
+	if err != nil {
+		return nil, err
+	}
+	return pool.M, nil
 }
 
 type cacheTrustPolicyKey struct {
@@ -265,21 +275,21 @@ func hasChecksWrite(perms github.InstallationPermissions) bool {
 // For checks:write policies it returns the persisted sticky installation,
 // or assigns a new one via capacity-aware round-robin and persists it.
 // For all other policies it returns the installation that read the policy.
-func (s *sts) getExchangeInstall(ctx context.Context, owner, scope, identity, subject string, perms github.InstallationPermissions, readAtr *ghinstallation.AppsTransport, readID int64) (*ghinstallation.AppsTransport, int64, error) {
+func (s *sts) getExchangeInstall(ctx context.Context, pool *ghinstall.OrgPool, owner, scope, identity, subject string, perms github.InstallationPermissions, readAtr *ghinstallation.AppsTransport, readID int64) (*ghinstallation.AppsTransport, int64, error) {
 	if s.sticky == nil || !hasChecksWrite(perms) {
 		return readAtr, readID, nil
 	}
 
 	key := routekey.Key(scope, identity, subject)
 	if cachedID, ok, err := s.sticky.Get(ctx, key); err == nil && ok {
-		atr, id, err := s.rrm.GetByInstallation(ctx, owner, cachedID)
+		atr, id, err := pool.M.GetByInstallation(ctx, owner, cachedID)
 		if err == nil {
 			return atr, id, nil
 		}
 		clog.FromContext(ctx).Infof("sticky install %d no longer valid for %s, reassigning", cachedID, owner)
 	}
 
-	atr, id, err := s.rrm.Get(ctx, owner, scope, identity)
+	atr, id, err := pool.M.Get(ctx, owner, scope, identity)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -319,6 +329,12 @@ func (s *sts) lookupInstallAndTrustPolicy(ctx context.Context, scope, identity, 
 		tp = otp
 	}
 
+	// Look up the org's app pool.
+	pool, err := s.router.GetPool(owner)
+	if err != nil {
+		return nil, 0, nil, nil, err
+	}
+
 	tpKey := cacheTrustPolicyKey{owner: owner, repo: repo, identity: identity}
 
 	if cached, ok := trustPolicies.Get(tpKey); ok && cached == negativeCacheConst {
@@ -326,8 +342,8 @@ func (s *sts) lookupInstallAndTrustPolicy(ctx context.Context, scope, identity, 
 		return nil, 0, nil, nil, status.Errorf(codes.NotFound, "unable to find trust policy for %q", tpKey.identity)
 	}
 
-	// Read the trust policy using any available installation.
-	readAtr, readID, err := s.rrm.Get(ctx, owner, scope, identity)
+	// Read the trust policy using any available installation in this org's pool.
+	readAtr, readID, err := pool.M.Get(ctx, owner, scope, identity)
 	if err != nil {
 		return nil, 0, nil, nil, err
 	}
@@ -335,7 +351,7 @@ func (s *sts) lookupInstallAndTrustPolicy(ctx context.Context, scope, identity, 
 	// Enforce the organization trusted-issuer allowlist before spending a policy
 	// read or a second token mint on an issuer we may reject.
 	//
-	// This runs AFTER s.rrm.Get even though it ignores its return values: Get's
+	// This runs AFTER pool.M.Get even though it ignores its return values: Get's
 	// negative install cache rejects an owner the App is not installed on before
 	// we do any allowlist work, which bounds the API amplification an arbitrary
 	// caller-supplied scope can drive.
@@ -344,13 +360,13 @@ func (s *sts) lookupInstallAndTrustPolicy(ctx context.Context, scope, identity, 
 		return nil, 0, nil, decision, err
 	}
 
-	readAtr, readID, err = s.lookupTrustPolicyWithRetry(ctx, readAtr, readID, owner, scope, identity, tpKey, tp)
+	readAtr, readID, err = s.lookupTrustPolicyWithRetry(ctx, pool, readAtr, readID, owner, scope, identity, tpKey, tp)
 	if err != nil {
 		return nil, 0, nil, decision, err
 	}
 
 	// Now that we know the permissions, pick the exchange installation.
-	atr, id, err := s.getExchangeInstall(ctx, owner, scope, identity, subject, otp.Permissions, readAtr, readID)
+	atr, id, err := s.getExchangeInstall(ctx, pool, owner, scope, identity, subject, otp.Permissions, readAtr, readID)
 	if err != nil {
 		return nil, 0, nil, decision, err
 	}
@@ -359,17 +375,17 @@ func (s *sts) lookupInstallAndTrustPolicy(ctx context.Context, scope, identity, 
 }
 
 // lookupTrustPolicyWithRetry fetches the trust policy, retrying with
-// different installations if the first attempt is rate-limited.
-func (s *sts) lookupTrustPolicyWithRetry(ctx context.Context, atr *ghinstallation.AppsTransport, id int64, owner, scope, identity string, tpKey cacheTrustPolicyKey, tp trustPolicy) (*ghinstallation.AppsTransport, int64, error) {
+// different installations from the pool if the first attempt is rate-limited.
+func (s *sts) lookupTrustPolicyWithRetry(ctx context.Context, pool *ghinstall.OrgPool, atr *ghinstallation.AppsTransport, id int64, owner, scope, identity string, tpKey cacheTrustPolicyKey, tp trustPolicy) (*ghinstallation.AppsTransport, int64, error) {
 	err := s.lookupTrustPolicy(ctx, atr, id, tpKey, tp)
-	if !isRateLimit(err) || s.appCount <= 1 {
+	if !isRateLimit(err) || pool.AppCount <= 1 {
 		return atr, id, err
 	}
 
-	retries := min(maxRetry, s.appCount-1)
+	retries := min(maxRetry, pool.AppCount-1)
 	for i := range retries {
 		clog.InfoContextf(ctx, "policy read rate-limited, trying next app (%d/%d)", i+1, retries)
-		rAtr, rId, rErr := s.rrm.Get(ctx, owner, scope, identity)
+		rAtr, rId, rErr := pool.M.Get(ctx, owner, scope, identity)
 		if rErr != nil {
 			continue
 		}

--- a/pkg/octosts/octosts_test.go
+++ b/pkg/octosts/octosts_test.go
@@ -113,6 +113,38 @@ func (f *fakeGitHub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	f.mux.ServeHTTP(w, r)
 }
 
+// newFakeGitHubNoContents returns a fake GitHub server that handles
+// installations and access_tokens but returns 404 for all content requests.
+// Used to isolate orgs in the multi-org routing tests.
+func newFakeGitHubNoContents() *fakeGitHub {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/app/installations", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]github.Installation{{
+			ID:      github.Ptr(int64(1234)),
+			Account: &github.User{Login: github.Ptr("other-org")},
+		}})
+	})
+	mux.HandleFunc("/app/installations/{appID}/access_tokens", func(w http.ResponseWriter, r *http.Request) {
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		json.NewEncoder(w).Encode(github.InstallationToken{
+			Token:     github.Ptr(base64.StdEncoding.EncodeToString(b)),
+			ExpiresAt: &github.Timestamp{Time: time.Now().Add(10 * time.Minute)},
+		})
+	})
+	mux.HandleFunc("/repos/{org}/{repo}/contents/.github/chainguard/{identity}", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotImplemented)
+		fmt.Fprintf(io.MultiWriter(w, os.Stdout), "%s %s not implemented\n", r.Method, r.URL.Path)
+	})
+	return &fakeGitHub{mux: mux}
+}
+
 func TestExchange(t *testing.T) {
 	ctx := context.Background()
 	atr := newGitHubClient(t, newFakeGitHub())
@@ -144,10 +176,12 @@ func TestExchange(t *testing.T) {
 	})
 	ctx = metadata.NewIncomingContext(ctx, metadata.MD{"authorization": []string{"Bearer " + token}})
 
-	sts := &sts{
-		rrm:      &fakeInstallMgr{atr: atr},
-		appCount: 1,
+	pool := &ghinstall.OrgPool{
+		M:        &fakeInstallMgr{atr: atr},
+		AppCount: 1,
 	}
+	router := ghinstall.NewOrgRouter(map[string]*ghinstall.OrgPool{"org": pool})
+	sts := &sts{router: router}
 	for _, tc := range []struct {
 		name string
 		req  *v1.ExchangeRequest
@@ -231,10 +265,12 @@ func TestExchangeValidation(t *testing.T) {
 	})
 	ctx = metadata.NewIncomingContext(ctx, metadata.MD{"authorization": []string{"Bearer " + token}})
 
-	sts := &sts{
-		rrm:      &fakeInstallMgr{atr: atr},
-		appCount: 1,
+	pool := &ghinstall.OrgPool{
+		M:        &fakeInstallMgr{atr: atr},
+		AppCount: 1,
 	}
+	router := ghinstall.NewOrgRouter(map[string]*ghinstall.OrgPool{"org": pool})
+	sts := &sts{router: router}
 
 	tests := []struct {
 		name string
@@ -372,10 +408,12 @@ func TestExchangeRateLimit(t *testing.T) {
 			})
 			ctx = metadata.NewIncomingContext(ctx, metadata.MD{"authorization": []string{"Bearer " + token}})
 
-			s := &sts{
-				rrm:      &fakeInstallMgr{atr: atr},
-				appCount: 1,
+			pool := &ghinstall.OrgPool{
+				M:        &fakeInstallMgr{atr: atr},
+				AppCount: 1,
 			}
+			router := ghinstall.NewOrgRouter(map[string]*ghinstall.OrgPool{"org": pool})
+			s := &sts{router: router}
 			_, err = s.Exchange(ctx, &v1.ExchangeRequest{
 				Identity: tc.identity,
 				Scope:    "org/repo",
@@ -462,10 +500,12 @@ func TestPolicyReadUsesRoundRobin(t *testing.T) {
 	provider.AddTestKeySetVerifier(t, iss, &oidc.StaticKeySet{PublicKeys: []crypto.PublicKey{pk.Public()}})
 	ctx = metadata.NewIncomingContext(ctx, metadata.MD{"authorization": []string{"Bearer " + token}})
 
-	s := &sts{
-		rrm:      &fakeInstallMgr{atr: rrmAtr},
-		appCount: 2,
+	pool := &ghinstall.OrgPool{
+		M:        &fakeInstallMgr{atr: rrmAtr},
+		AppCount: 2,
 	}
+	router := ghinstall.NewOrgRouter(map[string]*ghinstall.OrgPool{"org": pool})
+	s := &sts{router: router}
 	// Trust policy lives on the rrm server.
 	_, err = s.Exchange(ctx, &v1.ExchangeRequest{
 		Identity: "foo",
@@ -509,12 +549,14 @@ func TestPolicyReadRetriesOnRateLimit(t *testing.T) {
 	provider.AddTestKeySetVerifier(t, iss, &oidc.StaticKeySet{PublicKeys: []crypto.PublicKey{pk.Public()}})
 	ctx = metadata.NewIncomingContext(ctx, metadata.MD{"authorization": []string{"Bearer " + token}})
 
-	s := &sts{
-		rrm: &sequentialInstallMgr{
+	pool := &ghinstall.OrgPool{
+		M: &sequentialInstallMgr{
 			transports: []*ghinstallation.AppsTransport{rateLimitedAtr, workingAtr},
 		},
-		appCount: 2,
+		AppCount: 2,
 	}
+	router := ghinstall.NewOrgRouter(map[string]*ghinstall.OrgPool{"org": pool})
+	s := &sts{router: router}
 	// First rrm.Get returns the rate-limited transport; retry picks the
 	// working transport. Exchange should succeed.
 	_, err = s.Exchange(ctx, &v1.ExchangeRequest{
@@ -559,12 +601,14 @@ func TestPolicyReadAllRateLimitedReturnsError(t *testing.T) {
 	provider.AddTestKeySetVerifier(t, iss, &oidc.StaticKeySet{PublicKeys: []crypto.PublicKey{pk.Public()}})
 	ctx = metadata.NewIncomingContext(ctx, metadata.MD{"authorization": []string{"Bearer " + token}})
 
-	s := &sts{
-		rrm: &sequentialInstallMgr{
+	pool := &ghinstall.OrgPool{
+		M: &sequentialInstallMgr{
 			transports: []*ghinstallation.AppsTransport{rl1, rl2},
 		},
-		appCount: 2,
+		AppCount: 2,
 	}
+	router := ghinstall.NewOrgRouter(map[string]*ghinstall.OrgPool{"org": pool})
+	s := &sts{router: router}
 	_, err = s.Exchange(ctx, &v1.ExchangeRequest{
 		Identity: "foo",
 		Scope:    "org/repo",
@@ -630,10 +674,9 @@ func TestNegativeCachePreventsRepeatedGitHubCalls(t *testing.T) {
 	gh, counter := newFakeGitHubNotFoundCounter()
 	atr := newGitHubClient(t, gh)
 
-	s := &sts{
-		rrm:      &fakeInstallMgr{atr: atr},
-		appCount: 1,
-	}
+	// lookupTrustPolicy doesn't consult the router, but populate it for safety.
+	pool := &ghinstall.OrgPool{M: &fakeInstallMgr{atr: atr}, AppCount: 1}
+	s := &sts{router: ghinstall.NewOrgRouter(map[string]*ghinstall.OrgPool{"org": pool})}
 
 	otp := &OrgTrustPolicy{}
 	otp.Repositories = []string{"repo"}
@@ -670,10 +713,8 @@ func TestNegativeCacheSkipsInstallationTokenCreation(t *testing.T) {
 	trustPolicies.Add(key, negativeCacheConst)
 	t.Cleanup(func() { trustPolicies.Remove(key) })
 
-	s := &sts{
-		rrm:      &failInstallMgr{},
-		appCount: 1,
-	}
+	pool := &ghinstall.OrgPool{M: &failInstallMgr{}, AppCount: 1}
+	s := &sts{router: ghinstall.NewOrgRouter(map[string]*ghinstall.OrgPool{"org": pool})}
 
 	_, _, _, err := s.lookupInstallAndTrustPolicy(context.Background(), "org/repo", "cached-missing", "some-subject")
 	if err == nil {
@@ -682,6 +723,130 @@ func TestNegativeCacheSkipsInstallationTokenCreation(t *testing.T) {
 	st, ok := status.FromError(err)
 	if !ok || st.Code() != codes.NotFound {
 		t.Fatalf("expected gRPC NotFound from negative cache, got %v (managers should not have been called)", err)
+	}
+}
+
+// TestExchangeOrgNotConfigured verifies that a request for an org with no
+// configured apps returns NotFound.
+func TestExchangeOrgNotConfigured(t *testing.T) {
+	ctx := context.Background()
+	atr := newGitHubClient(t, newFakeGitHub())
+
+	pk, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("cannot generate RSA key %v", err)
+	}
+	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.RS256, Key: pk}, nil)
+	if err != nil {
+		t.Fatalf("jose.NewSigner() = %v", err)
+	}
+
+	iss := "https://token.actions.githubusercontent.com"
+	token, err := josejwt.Signed(signer).Claims(josejwt.Claims{
+		Subject:  "foo",
+		Issuer:   iss,
+		Audience: josejwt.Audience{"octosts"},
+		Expiry:   josejwt.NewNumericDate(time.Now().Add(10 * time.Minute)),
+	}).Serialize()
+	if err != nil {
+		t.Fatalf("CompactSerialize failed: %v", err)
+	}
+	provider.AddTestKeySetVerifier(t, iss, &oidc.StaticKeySet{PublicKeys: []crypto.PublicKey{pk.Public()}})
+	ctx = metadata.NewIncomingContext(ctx, metadata.MD{"authorization": []string{"Bearer " + token}})
+
+	// Only "org" is configured — "other-org" is not.
+	pool := &ghinstall.OrgPool{
+		M:        &fakeInstallMgr{atr: atr},
+		AppCount: 1,
+	}
+	router := ghinstall.NewOrgRouter(map[string]*ghinstall.OrgPool{"org": pool})
+	s := &sts{router: router}
+
+	_, err = s.Exchange(ctx, &v1.ExchangeRequest{
+		Identity: "foo",
+		Scope:    "other-org/repo",
+	})
+	if err == nil {
+		t.Fatal("expected error for unconfigured org")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %T", err)
+	}
+	if st.Code() != codes.NotFound {
+		t.Errorf("expected code NotFound, got %v", st.Code())
+	}
+}
+
+// TestExchangeOrgIsolation verifies that requests for different orgs route
+// to their respective app pools.
+func TestExchangeOrgIsolation(t *testing.T) {
+	ctx := context.Background()
+
+	// org1 points to a working server, org2 points to one with no contents.
+	org1Atr := newGitHubClient(t, newFakeGitHub())
+	org2Atr := newGitHubClient(t, newFakeGitHubNoContents())
+
+	pk, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("cannot generate RSA key %v", err)
+	}
+	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.RS256, Key: pk}, nil)
+	if err != nil {
+		t.Fatalf("jose.NewSigner() = %v", err)
+	}
+
+	iss := "https://token.actions.githubusercontent.com"
+	token, err := josejwt.Signed(signer).Claims(josejwt.Claims{
+		Subject:  "foo",
+		Issuer:   iss,
+		Audience: josejwt.Audience{"octosts"},
+		Expiry:   josejwt.NewNumericDate(time.Now().Add(10 * time.Minute)),
+	}).Serialize()
+	if err != nil {
+		t.Fatalf("CompactSerialize failed: %v", err)
+	}
+	provider.AddTestKeySetVerifier(t, iss, &oidc.StaticKeySet{PublicKeys: []crypto.PublicKey{pk.Public()}})
+	ctx = metadata.NewIncomingContext(ctx, metadata.MD{"authorization": []string{"Bearer " + token}})
+
+	pool1 := &ghinstall.OrgPool{
+		M:        &fakeInstallMgr{atr: org1Atr},
+		AppCount: 1,
+	}
+	pool2 := &ghinstall.OrgPool{
+		M:        &fakeInstallMgr{atr: org2Atr},
+		AppCount: 1,
+	}
+	router := ghinstall.NewOrgRouter(map[string]*ghinstall.OrgPool{
+		"org":       pool1,
+		"other-org": pool2,
+	})
+	s := &sts{router: router}
+
+	// org1 should succeed (has trust policy files).
+	key := cacheTrustPolicyKey{owner: "org", repo: "repo", identity: "foo"}
+	trustPolicies.Remove(key)
+	t.Cleanup(func() { trustPolicies.Remove(key) })
+
+	_, err = s.Exchange(ctx, &v1.ExchangeRequest{
+		Identity: "foo",
+		Scope:    "org/repo",
+	})
+	if err != nil {
+		t.Fatalf("Exchange for org failed: %v", err)
+	}
+
+	// org2 should fail because its server has no contents.
+	key2 := cacheTrustPolicyKey{owner: "other-org", repo: "repo", identity: "foo"}
+	trustPolicies.Remove(key2)
+	t.Cleanup(func() { trustPolicies.Remove(key2) })
+
+	_, err = s.Exchange(ctx, &v1.ExchangeRequest{
+		Identity: "foo",
+		Scope:    "other-org/repo",
+	})
+	if err == nil {
+		t.Fatal("expected error for other-org (no contents), got nil")
 	}
 }
 

--- a/pkg/octosts/octosts_test.go
+++ b/pkg/octosts/octosts_test.go
@@ -170,6 +170,38 @@ func (f *fakeGitHub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	f.mux.ServeHTTP(w, r)
 }
 
+// newFakeGitHubNoContents returns a fake GitHub server that handles
+// installations and access_tokens but returns 404 for all content requests.
+// Used to isolate orgs in the multi-org routing tests.
+func newFakeGitHubNoContents() *fakeGitHub {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/app/installations", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]github.Installation{{
+			ID:      github.Ptr(int64(1234)),
+			Account: &github.User{Login: github.Ptr("other-org")},
+		}})
+	})
+	mux.HandleFunc("/app/installations/{appID}/access_tokens", func(w http.ResponseWriter, r *http.Request) {
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		json.NewEncoder(w).Encode(github.InstallationToken{
+			Token:     github.Ptr(base64.StdEncoding.EncodeToString(b)),
+			ExpiresAt: &github.Timestamp{Time: time.Now().Add(10 * time.Minute)},
+		})
+	})
+	mux.HandleFunc("/repos/{org}/{repo}/contents/.github/chainguard/{identity}", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotImplemented)
+		fmt.Fprintf(io.MultiWriter(w, os.Stdout), "%s %s not implemented\n", r.Method, r.URL.Path)
+	})
+	return &fakeGitHub{mux: mux}
+}
+
 func TestExchange(t *testing.T) {
 	ctx := context.Background()
 	atr := newAppsTransport(t, newFakeGitHub())
@@ -201,11 +233,12 @@ func TestExchange(t *testing.T) {
 	})
 	ctx = metadata.NewIncomingContext(ctx, metadata.MD{"authorization": []string{"Bearer " + token}})
 
-	sts := &sts{
-		rrm:           &fakeInstallMgr{atr: atr},
-		appCount:      1,
-		orgPolicyRepo: ".github",
+	pool := &ghinstall.OrgPool{
+		M:        &fakeInstallMgr{atr: atr},
+		AppCount: 1,
 	}
+	router := ghinstall.NewOrgRouter(map[string]*ghinstall.OrgPool{"org": pool})
+	sts := &sts{router: router}
 	for _, tc := range []struct {
 		name string
 		req  *v1.ExchangeRequest
@@ -296,11 +329,12 @@ func TestExchangeCustomOrgPolicyRepo(t *testing.T) {
 	})
 	ctx = metadata.NewIncomingContext(ctx, metadata.MD{"authorization": []string{"Bearer " + token}})
 
-	sts := &sts{
-		rrm:           &fakeInstallMgr{atr: atr},
-		appCount:      1,
-		orgPolicyRepo: "my-policies",
+	pool := &ghinstall.OrgPool{
+		M:        &fakeInstallMgr{atr: atr},
+		AppCount: 1,
 	}
+	router := ghinstall.NewOrgRouter(map[string]*ghinstall.OrgPool{"org": pool})
+	sts := &sts{router: router, orgPolicyRepo: "my-policies"}
 
 	tok, err := sts.Exchange(ctx, &v1.ExchangeRequest{
 		Identity: "foo",
@@ -361,11 +395,12 @@ func TestExchangeValidation(t *testing.T) {
 	})
 	ctx = metadata.NewIncomingContext(ctx, metadata.MD{"authorization": []string{"Bearer " + token}})
 
-	sts := &sts{
-		rrm:           &fakeInstallMgr{atr: atr},
-		appCount:      1,
-		orgPolicyRepo: ".github",
+	pool := &ghinstall.OrgPool{
+		M:        &fakeInstallMgr{atr: atr},
+		AppCount: 1,
 	}
+	router := ghinstall.NewOrgRouter(map[string]*ghinstall.OrgPool{"org": pool})
+	sts := &sts{router: router}
 
 	tests := []struct {
 		name string
@@ -527,11 +562,12 @@ func TestExchangeRateLimit(t *testing.T) {
 			})
 			ctx = metadata.NewIncomingContext(ctx, metadata.MD{"authorization": []string{"Bearer " + token}})
 
-			s := &sts{
-				rrm:           &fakeInstallMgr{atr: atr},
-				appCount:      1,
-				orgPolicyRepo: ".github",
+			pool := &ghinstall.OrgPool{
+				M:        &fakeInstallMgr{atr: atr},
+				AppCount: 1,
 			}
+			router := ghinstall.NewOrgRouter(map[string]*ghinstall.OrgPool{"org": pool})
+			s := &sts{router: router}
 			_, err = s.Exchange(ctx, &v1.ExchangeRequest{
 				Identity: tc.identity,
 				Scope:    "org/repo",
@@ -647,10 +683,12 @@ func TestPolicyReadUsesRoundRobin(t *testing.T) {
 	provider.AddTestKeySetVerifier(t, iss, &oidc.StaticKeySet{PublicKeys: []crypto.PublicKey{pk.Public()}})
 	ctx = metadata.NewIncomingContext(ctx, metadata.MD{"authorization": []string{"Bearer " + token}})
 
-	s := &sts{
-		rrm:      &fakeInstallMgr{atr: rrmAtr},
-		appCount: 2,
+	pool := &ghinstall.OrgPool{
+		M:        &fakeInstallMgr{atr: rrmAtr},
+		AppCount: 2,
 	}
+	router := ghinstall.NewOrgRouter(map[string]*ghinstall.OrgPool{"org": pool})
+	s := &sts{router: router}
 	// Trust policy lives on the rrm server.
 	_, err = s.Exchange(ctx, &v1.ExchangeRequest{
 		Identity: "foo",
@@ -704,12 +742,14 @@ func TestPolicyReadRetriesOnRateLimit(t *testing.T) {
 	provider.AddTestKeySetVerifier(t, iss, &oidc.StaticKeySet{PublicKeys: []crypto.PublicKey{pk.Public()}})
 	ctx = metadata.NewIncomingContext(ctx, metadata.MD{"authorization": []string{"Bearer " + token}})
 
-	s := &sts{
-		rrm: &sequentialInstallMgr{
+	pool := &ghinstall.OrgPool{
+		M: &sequentialInstallMgr{
 			transports: []*ghinstallation.AppsTransport{rateLimitedAtr, workingAtr},
 		},
-		appCount: 2,
+		AppCount: 2,
 	}
+	router := ghinstall.NewOrgRouter(map[string]*ghinstall.OrgPool{"org": pool})
+	s := &sts{router: router}
 	// First rrm.Get returns the rate-limited transport; retry picks the
 	// working transport. Exchange should succeed.
 	_, err = s.Exchange(ctx, &v1.ExchangeRequest{
@@ -764,12 +804,14 @@ func TestPolicyReadAllRateLimitedReturnsError(t *testing.T) {
 	provider.AddTestKeySetVerifier(t, iss, &oidc.StaticKeySet{PublicKeys: []crypto.PublicKey{pk.Public()}})
 	ctx = metadata.NewIncomingContext(ctx, metadata.MD{"authorization": []string{"Bearer " + token}})
 
-	s := &sts{
-		rrm: &sequentialInstallMgr{
+	pool := &ghinstall.OrgPool{
+		M: &sequentialInstallMgr{
 			transports: []*ghinstallation.AppsTransport{rl1, rl2},
 		},
-		appCount: 2,
+		AppCount: 2,
 	}
+	router := ghinstall.NewOrgRouter(map[string]*ghinstall.OrgPool{"org": pool})
+	s := &sts{router: router}
 	_, err = s.Exchange(ctx, &v1.ExchangeRequest{
 		Identity: "foo",
 		Scope:    "org/repo",
@@ -835,10 +877,9 @@ func TestNegativeCachePreventsRepeatedGitHubCalls(t *testing.T) {
 	gh, counter := newFakeGitHubNotFoundCounter()
 	atr := newAppsTransport(t, gh)
 
-	s := &sts{
-		rrm:      &fakeInstallMgr{atr: atr},
-		appCount: 1,
-	}
+	// lookupTrustPolicy doesn't consult the router, but populate it for safety.
+	pool := &ghinstall.OrgPool{M: &fakeInstallMgr{atr: atr}, AppCount: 1}
+	s := &sts{router: ghinstall.NewOrgRouter(map[string]*ghinstall.OrgPool{"org": pool})}
 
 	otp := &OrgTrustPolicy{}
 	otp.Repositories = []string{"repo"}
@@ -875,10 +916,8 @@ func TestNegativeCacheSkipsInstallationTokenCreation(t *testing.T) {
 	trustPolicies.Add(key, negativeCacheConst)
 	t.Cleanup(func() { trustPolicies.Remove(key) })
 
-	s := &sts{
-		rrm:      &failInstallMgr{},
-		appCount: 1,
-	}
+	pool := &ghinstall.OrgPool{M: &failInstallMgr{}, AppCount: 1}
+	s := &sts{router: ghinstall.NewOrgRouter(map[string]*ghinstall.OrgPool{"org": pool})}
 
 	_, _, _, _, err := s.lookupInstallAndTrustPolicy(context.Background(), "org/repo", "cached-missing", "some-subject", testGitHubIssuer)
 	if err == nil {
@@ -903,10 +942,11 @@ func TestRateLimitServesStaleCache(t *testing.T) {
 	workingGH := newFakeGitHub()
 	workingAtr := newAppsTransport(t, workingGH)
 
-	s := &sts{
-		rrm:      &fakeInstallMgr{atr: workingAtr},
-		appCount: 1,
+	pool := &ghinstall.OrgPool{
+		M:        &fakeInstallMgr{atr: workingAtr},
+		AppCount: 1,
 	}
+	s := &sts{router: ghinstall.NewOrgRouter(map[string]*ghinstall.OrgPool{"org": pool})}
 
 	// First call: populates both caches.
 	otp := &OrgTrustPolicy{}
@@ -926,7 +966,7 @@ func TestRateLimitServesStaleCache(t *testing.T) {
 
 	// Switch to a rate-limited GitHub backend.
 	rateLimitedAtr := newAppsTransport(t, newFakeGitHubRateLimit(http.StatusForbidden))
-	s.rrm = &fakeInstallMgr{atr: rateLimitedAtr}
+	pool.M = &fakeInstallMgr{atr: rateLimitedAtr}
 
 	// Second call: primary cache miss, GitHub 403, should fall back to stale cache.
 	otp2 := &OrgTrustPolicy{}
@@ -940,6 +980,130 @@ func TestRateLimitServesStaleCache(t *testing.T) {
 	// exchanges during the rate-limit window skip the GitHub round-trip.
 	if _, ok := trustPolicies.Get(key); !ok {
 		t.Error("primary cache should be seeded after serving stale on rate limit")
+	}
+}
+
+// TestExchangeOrgNotConfigured verifies that a request for an org with no
+// configured apps returns NotFound.
+func TestExchangeOrgNotConfigured(t *testing.T) {
+	ctx := context.Background()
+	atr := newAppsTransport(t, newFakeGitHub())
+
+	pk, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("cannot generate RSA key %v", err)
+	}
+	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.RS256, Key: pk}, nil)
+	if err != nil {
+		t.Fatalf("jose.NewSigner() = %v", err)
+	}
+
+	iss := "https://token.actions.githubusercontent.com"
+	token, err := josejwt.Signed(signer).Claims(josejwt.Claims{
+		Subject:  "foo",
+		Issuer:   iss,
+		Audience: josejwt.Audience{"octosts"},
+		Expiry:   josejwt.NewNumericDate(time.Now().Add(10 * time.Minute)),
+	}).Serialize()
+	if err != nil {
+		t.Fatalf("CompactSerialize failed: %v", err)
+	}
+	provider.AddTestKeySetVerifier(t, iss, &oidc.StaticKeySet{PublicKeys: []crypto.PublicKey{pk.Public()}})
+	ctx = metadata.NewIncomingContext(ctx, metadata.MD{"authorization": []string{"Bearer " + token}})
+
+	// Only "org" is configured — "other-org" is not.
+	pool := &ghinstall.OrgPool{
+		M:        &fakeInstallMgr{atr: atr},
+		AppCount: 1,
+	}
+	router := ghinstall.NewOrgRouter(map[string]*ghinstall.OrgPool{"org": pool})
+	s := &sts{router: router}
+
+	_, err = s.Exchange(ctx, &v1.ExchangeRequest{
+		Identity: "foo",
+		Scope:    "other-org/repo",
+	})
+	if err == nil {
+		t.Fatal("expected error for unconfigured org")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %T", err)
+	}
+	if st.Code() != codes.NotFound {
+		t.Errorf("expected code NotFound, got %v", st.Code())
+	}
+}
+
+// TestExchangeOrgIsolation verifies that requests for different orgs route
+// to their respective app pools.
+func TestExchangeOrgIsolation(t *testing.T) {
+	ctx := context.Background()
+
+	// org1 points to a working server, org2 points to one with no contents.
+	org1Atr := newAppsTransport(t, newFakeGitHub())
+	org2Atr := newAppsTransport(t, newFakeGitHubNoContents())
+
+	pk, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("cannot generate RSA key %v", err)
+	}
+	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.RS256, Key: pk}, nil)
+	if err != nil {
+		t.Fatalf("jose.NewSigner() = %v", err)
+	}
+
+	iss := "https://token.actions.githubusercontent.com"
+	token, err := josejwt.Signed(signer).Claims(josejwt.Claims{
+		Subject:  "foo",
+		Issuer:   iss,
+		Audience: josejwt.Audience{"octosts"},
+		Expiry:   josejwt.NewNumericDate(time.Now().Add(10 * time.Minute)),
+	}).Serialize()
+	if err != nil {
+		t.Fatalf("CompactSerialize failed: %v", err)
+	}
+	provider.AddTestKeySetVerifier(t, iss, &oidc.StaticKeySet{PublicKeys: []crypto.PublicKey{pk.Public()}})
+	ctx = metadata.NewIncomingContext(ctx, metadata.MD{"authorization": []string{"Bearer " + token}})
+
+	pool1 := &ghinstall.OrgPool{
+		M:        &fakeInstallMgr{atr: org1Atr},
+		AppCount: 1,
+	}
+	pool2 := &ghinstall.OrgPool{
+		M:        &fakeInstallMgr{atr: org2Atr},
+		AppCount: 1,
+	}
+	router := ghinstall.NewOrgRouter(map[string]*ghinstall.OrgPool{
+		"org":       pool1,
+		"other-org": pool2,
+	})
+	s := &sts{router: router}
+
+	// org1 should succeed (has trust policy files).
+	key := cacheTrustPolicyKey{owner: "org", repo: "repo", identity: "foo"}
+	trustPolicies.Remove(key)
+	t.Cleanup(func() { trustPolicies.Remove(key) })
+
+	_, err = s.Exchange(ctx, &v1.ExchangeRequest{
+		Identity: "foo",
+		Scope:    "org/repo",
+	})
+	if err != nil {
+		t.Fatalf("Exchange for org failed: %v", err)
+	}
+
+	// org2 should fail because its server has no contents.
+	key2 := cacheTrustPolicyKey{owner: "other-org", repo: "repo", identity: "foo"}
+	trustPolicies.Remove(key2)
+	t.Cleanup(func() { trustPolicies.Remove(key2) })
+
+	_, err = s.Exchange(ctx, &v1.ExchangeRequest{
+		Identity: "foo",
+		Scope:    "other-org/repo",
+	})
+	if err == nil {
+		t.Fatal("expected error for other-org (no contents), got nil")
 	}
 }
 

--- a/pkg/octosts/org_trusted_issuers_store.go
+++ b/pkg/octosts/org_trusted_issuers_store.go
@@ -404,7 +404,12 @@ func installsNotIn(installs, alreadyScanned []ghinstall.Installation) []ghinstal
 func (s *sts) confirmNoAccess(ctx context.Context, owner string, scanned []ghinstall.Installation, t *orgIssuerTally) (orgIssuerEntry, bool) {
 	// A confirm that earns nothing is deliberately not cached and repeats, which is
 	// how an org recovers once the API is healthy.
-	fresh, err := s.rrm.GetAllFresh(ctx, owner)
+	m, err := s.managerFor(owner)
+	if err != nil {
+		clog.WarnContextf(ctx, "confirming the installation set for %s failed: %v", owner, err)
+		return orgIssuerEntry{}, false
+	}
+	fresh, err := m.GetAllFresh(ctx, owner)
 	if err != nil {
 		clog.WarnContextf(ctx, "confirming the installation set for %s failed: %v", owner, err)
 		return orgIssuerEntry{}, false
@@ -478,7 +483,11 @@ func (s *sts) orgIssuerLookup(ctx context.Context, owner string) (orgIssuerEntry
 // orgIssuerLookupUncached performs the enumeration behind orgIssuerLookup's cache
 // and single-flight; it is the walk whose amplification the flight exists to prevent.
 func (s *sts) orgIssuerLookupUncached(ctx context.Context, owner string) (orgIssuerEntry, error) {
-	installs, enumErr := s.rrm.GetAll(ctx, owner)
+	m, err := s.managerFor(owner)
+	if err != nil {
+		return orgIssuerEntry{}, err
+	}
+	installs, enumErr := m.GetAll(ctx, owner)
 
 	var t orgIssuerTally
 	if entry, ok := s.scanInstalls(ctx, owner, installs, &t); ok {

--- a/pkg/octosts/org_trusted_issuers_store_test.go
+++ b/pkg/octosts/org_trusted_issuers_store_test.go
@@ -43,6 +43,14 @@ import (
 
 var errTestInvalid = errors.New("test: invalid config")
 
+// routerFor wraps m in a single wildcard pool so any owner resolves to it,
+// mirroring the legacy flat-pool behavior these tests were written against.
+func routerFor(m ghinstall.Manager, appCount int) *ghinstall.OrgRouter {
+	return ghinstall.NewOrgRouter(map[string]*ghinstall.OrgPool{
+		ghinstall.WildcardOrg: {M: m, AppCount: appCount},
+	})
+}
+
 // cleanupOrgIssuers removes the owner keys a test seeded. The caches are
 // package-level shared state, so leaking entries makes later tests in this
 // package order-dependent. This mirrors the existing convention for
@@ -423,7 +431,7 @@ func TestFetchOrgIssuersOnce(t *testing.T) {
 	cleanupOrgIssuers(t, "orgallow")
 
 	atr := newAppsTransport(t, newFakeGitHub())
-	s := &sts{rrm: &fakeInstallMgr{atr: atr}, appCount: 1}
+	s := &sts{router: routerFor(&fakeInstallMgr{atr: atr}, 1)}
 
 	res := s.fetchOrgIssuersOnce(t.Context(), atr, 1234, "orgallow")
 	if res.kind != fetchOK {
@@ -447,7 +455,7 @@ func TestFetchOrgIssuersOnceAbsent(t *testing.T) {
 	cleanupOrgIssuers(t, "orgnone")
 
 	atr := newAppsTransport(t, newFakeGitHub())
-	s := &sts{rrm: &fakeInstallMgr{atr: atr}, appCount: 1}
+	s := &sts{router: routerFor(&fakeInstallMgr{atr: atr}, 1)}
 
 	// No fixture for orgnone, so the fake returns a GitHub-shaped 404. A 404 is
 	// definitive: the repo was readable and the file is not there.
@@ -467,7 +475,7 @@ func TestFetchOrgIssuersOnceInvalid(t *testing.T) {
 	cleanupOrgIssuers(t, "orgbad")
 
 	atr := newAppsTransport(t, newFakeGitHub())
-	s := &sts{rrm: &fakeInstallMgr{atr: atr}, appCount: 1}
+	s := &sts{router: routerFor(&fakeInstallMgr{atr: atr}, 1)}
 
 	res := s.fetchOrgIssuersOnce(t.Context(), atr, 1234, "orgbad")
 	if res.kind != fetchOK {
@@ -543,7 +551,7 @@ func TestFetchOrgIssuersOnceMintsLeastPrivilegeToken(t *testing.T) {
 
 	capture := &scopeCapturingHandler{Handler: newFakeGitHub()}
 	atr := newAppsTransport(t, capture)
-	s := &sts{rrm: &fakeInstallMgr{atr: atr}, appCount: 1}
+	s := &sts{router: routerFor(&fakeInstallMgr{atr: atr}, 1)}
 
 	res := s.fetchOrgIssuersOnce(t.Context(), atr, 1234, "orgallow")
 	if res.kind != fetchOK {
@@ -573,7 +581,7 @@ func TestFetchOrgIssuersOnceDirectory(t *testing.T) {
 	cleanupOrgIssuers(t, "orgdir")
 
 	atr := newAppsTransport(t, newFakeGitHub())
-	s := &sts{rrm: &fakeInstallMgr{atr: atr}, appCount: 1}
+	s := &sts{router: routerFor(&fakeInstallMgr{atr: atr}, 1)}
 
 	// A different installation ID than the other tests use, so fetchOrgIssuersOnce
 	// keeps this parameter's plumbing (EnrichContext, ghinstallation.NewFromAppsTransport)
@@ -839,7 +847,7 @@ func TestLookupSurvivesOneBlindInstallation(t *testing.T) {
 		{Transport: blind, ID: 1, AppID: 10},
 		{Transport: working, ID: 2, AppID: 20},
 	}}
-	s := &sts{rrm: mgr, appCount: 2}
+	s := &sts{router: routerFor(mgr, 2)}
 
 	entry, err := s.orgIssuerLookup(t.Context(), "orgallow")
 	if err != nil {
@@ -870,7 +878,7 @@ func TestLookupAllInstallationsBlindIsAbsent(t *testing.T) {
 		{Transport: a, ID: 1, AppID: 10},
 		{Transport: b, ID: 2, AppID: 20},
 	}}
-	s := &sts{rrm: mgr, appCount: 2}
+	s := &sts{router: routerFor(mgr, 2)}
 
 	entry, err := s.orgIssuerLookup(t.Context(), "orgallow")
 	if err != nil {
@@ -917,7 +925,7 @@ func TestLookupPartialEnumerationNeverCachesAbsent(t *testing.T) {
 			{Transport: blind, ID: 2, AppID: 20},
 		},
 	}
-	s := &sts{rrm: mgr, appCount: 2}
+	s := &sts{router: routerFor(mgr, 2)}
 
 	_, err := s.orgIssuerLookup(t.Context(), "orgallow")
 	st, ok := status.FromError(err)
@@ -940,10 +948,10 @@ func TestLookupMintRateLimitRetriesNextInstallation(t *testing.T) {
 	limited := newAppsTransport(t, newOrgFakeGitHub(withMintRateLimited()))
 	working := newAppsTransport(t, newFakeGitHub())
 
-	s := &sts{rrm: &enumMgr{installs: []ghinstall.Installation{
+	s := &sts{router: routerFor(&enumMgr{installs: []ghinstall.Installation{
 		{Transport: limited, ID: 1, AppID: 10},
 		{Transport: working, ID: 2, AppID: 20},
-	}}, appCount: 2}
+	}}, 2)}
 
 	entry, err := s.orgIssuerLookup(t.Context(), "orgallow")
 	if err != nil {
@@ -966,7 +974,7 @@ func TestLookupServesStaleOnRateLimit(t *testing.T) {
 	staleOrgIssuers.Add("orgallow", presentOrgIssuerEntry(allow))
 
 	rl := newAppsTransport(t, newOrgFakeGitHub(withContentsRateLimited()))
-	s := &sts{rrm: &enumMgr{installs: []ghinstall.Installation{{Transport: rl, ID: 1, AppID: 10}}}, appCount: 1}
+	s := &sts{router: routerFor(&enumMgr{installs: []ghinstall.Installation{{Transport: rl, ID: 1, AppID: 10}}}, 1)}
 
 	entry, err := s.orgIssuerLookup(t.Context(), "orgallow")
 	if err != nil {
@@ -989,7 +997,7 @@ func TestLookupRateLimitedWithoutStaleDenies(t *testing.T) {
 	cleanupOrgIssuers(t, "orgallow")
 
 	rl := newAppsTransport(t, newOrgFakeGitHub(withContentsRateLimited()))
-	s := &sts{rrm: &enumMgr{installs: []ghinstall.Installation{{Transport: rl, ID: 1, AppID: 10}}}, appCount: 1}
+	s := &sts{router: routerFor(&enumMgr{installs: []ghinstall.Installation{{Transport: rl, ID: 1, AppID: 10}}}, 1)}
 
 	_, err := s.orgIssuerLookup(t.Context(), "orgallow")
 	st, ok := status.FromError(err)
@@ -1011,7 +1019,7 @@ func TestLookupInvalidServesLastKnownGood(t *testing.T) {
 	staleOrgIssuers.Add("orgbad", presentOrgIssuerEntry(good))
 
 	atr := newAppsTransport(t, newFakeGitHub())
-	s := &sts{rrm: &enumMgr{installs: []ghinstall.Installation{{Transport: atr, ID: 1, AppID: 10}}}, appCount: 1}
+	s := &sts{router: routerFor(&enumMgr{installs: []ghinstall.Installation{{Transport: atr, ID: 1, AppID: 10}}}, 1)}
 
 	entry, err := s.orgIssuerLookup(t.Context(), "orgbad")
 	if err != nil {
@@ -1026,7 +1034,7 @@ func TestLookupInvalidWithoutStaleReturnsInvalid(t *testing.T) {
 	cleanupOrgIssuers(t, "orgbad")
 
 	atr := newAppsTransport(t, newFakeGitHub())
-	s := &sts{rrm: &enumMgr{installs: []ghinstall.Installation{{Transport: atr, ID: 1, AppID: 10}}}, appCount: 1}
+	s := &sts{router: routerFor(&enumMgr{installs: []ghinstall.Installation{{Transport: atr, ID: 1, AppID: 10}}}, 1)}
 
 	entry, err := s.orgIssuerLookup(t.Context(), "orgbad")
 	if err != nil {
@@ -1052,7 +1060,7 @@ func TestLookupInvalidIgnoresStaleAbsent(t *testing.T) {
 	staleOrgIssuers.Add("orgbad", absentOrgIssuerEntry())
 
 	atr := newAppsTransport(t, newFakeGitHub())
-	s := &sts{rrm: &enumMgr{installs: []ghinstall.Installation{{Transport: atr, ID: 1, AppID: 10}}}, appCount: 1}
+	s := &sts{router: routerFor(&enumMgr{installs: []ghinstall.Installation{{Transport: atr, ID: 1, AppID: 10}}}, 1)}
 
 	entry, err := s.orgIssuerLookup(t.Context(), "orgbad")
 	if err != nil {
@@ -1080,10 +1088,10 @@ func TestLookupBlindPlusFailedIsNotAbsent(t *testing.T) {
 	blind := newAppsTransport(t, newOrgFakeGitHub(withNoGitHubRepoAccess()))
 	broken := newAppsTransport(t, newOrgFakeGitHub(withContentsServerError()))
 
-	s := &sts{rrm: &enumMgr{installs: []ghinstall.Installation{
+	s := &sts{router: routerFor(&enumMgr{installs: []ghinstall.Installation{
 		{Transport: blind, ID: 1, AppID: 10},
 		{Transport: broken, ID: 2, AppID: 20},
-	}}, appCount: 2}
+	}}, 2)}
 
 	_, err := s.orgIssuerLookup(t.Context(), "orgallow")
 	st, ok := status.FromError(err)
@@ -1107,7 +1115,7 @@ func TestLookupBlindPlusFailedIsNotAbsent(t *testing.T) {
 func TestLookupEmptyEnumerationIsNotAbsent(t *testing.T) {
 	cleanupOrgIssuers(t, "orgempty")
 
-	s := &sts{rrm: &enumMgr{installs: nil}, appCount: 1}
+	s := &sts{router: routerFor(&enumMgr{installs: nil}, 1)}
 
 	entry, err := s.orgIssuerLookup(t.Context(), "orgempty")
 	st, ok := status.FromError(err)
@@ -1143,7 +1151,7 @@ func TestLookupAllBlindWithStaleFallsOpen(t *testing.T) {
 	staleOrgIssuers.Add("orgallow", presentOrgIssuerEntry(allow))
 
 	blind := newAppsTransport(t, newOrgFakeGitHub(withNoGitHubRepoAccess()))
-	s := &sts{rrm: &enumMgr{installs: []ghinstall.Installation{{Transport: blind, ID: 1, AppID: 10}}}, appCount: 1}
+	s := &sts{router: routerFor(&enumMgr{installs: []ghinstall.Installation{{Transport: blind, ID: 1, AppID: 10}}}, 1)}
 
 	entry, err := s.orgIssuerLookup(t.Context(), "orgallow")
 	if err != nil {
@@ -1170,7 +1178,7 @@ func TestLookupAbsentFileIsCachedAbsent(t *testing.T) {
 	cleanupOrgIssuers(t, "orgnone")
 
 	atr := newAppsTransport(t, newFakeGitHub())
-	s := &sts{rrm: &enumMgr{installs: []ghinstall.Installation{{Transport: atr, ID: 1, AppID: 10}}}, appCount: 1}
+	s := &sts{router: routerFor(&enumMgr{installs: []ghinstall.Installation{{Transport: atr, ID: 1, AppID: 10}}}, 1)}
 
 	entry, err := s.orgIssuerLookup(t.Context(), "orgnone")
 	if err != nil {
@@ -1253,10 +1261,10 @@ func TestCheckOrgTrustedIssuers(t *testing.T) {
 			cleanupOrgIssuers(t, owner)
 			orgIssuers.Add(owner, tc.entry)
 
-			// rrm is deliberately nil: every row pre-seeds the primary cache, so
+			// The pool manager is deliberately nil: every row pre-seeds the primary cache, so
 			// orgIssuerLookup must return on its cache hit without enumerating.
 			// A nil-pointer panic here means the check is doing more than it should.
-			s := &sts{appCount: 1}
+			s := &sts{router: routerFor(nil, 1)}
 			decision, err := s.checkOrgTrustedIssuers(t.Context(), owner, tc.issuer)
 
 			if tc.wantCode == codes.OK {
@@ -1299,7 +1307,7 @@ func TestCheckOrgTrustedIssuersPropagatesLookupError(t *testing.T) {
 	cleanupOrgIssuers(t, "orgallow")
 
 	rl := newAppsTransport(t, newOrgFakeGitHub(withContentsRateLimited()))
-	s := &sts{rrm: &enumMgr{installs: []ghinstall.Installation{{Transport: rl, ID: 1, AppID: 10}}}, appCount: 1}
+	s := &sts{router: routerFor(&enumMgr{installs: []ghinstall.Installation{{Transport: rl, ID: 1, AppID: 10}}}, 1)}
 
 	decision, err := s.checkOrgTrustedIssuers(t.Context(), "orgallow", testGitHubIssuer)
 	st, ok := status.FromError(err)
@@ -1323,7 +1331,7 @@ func TestDeniedMessagesLeakNothing(t *testing.T) {
 	}
 	orgIssuers.Add(owner, presentOrgIssuerEntry(allow))
 
-	s := &sts{appCount: 1}
+	s := &sts{router: routerFor(nil, 1)}
 	_, err = s.checkOrgTrustedIssuers(t.Context(), owner, "https://evil.example.com")
 	st, _ := status.FromError(err)
 	if st.Message() != msgIssuerNotPermitted {
@@ -1405,7 +1413,7 @@ func TestExchangeEnforcesOrgAllowlist(t *testing.T) {
 
 			atr := newAppsTransport(t, newFakeGitHub())
 			ctx := newExchangeContext(t)
-			s := &sts{rrm: &fakeInstallMgr{atr: atr}, appCount: 1}
+			s := &sts{router: routerFor(&fakeInstallMgr{atr: atr}, 1)}
 
 			_, err := s.Exchange(ctx, &v1.ExchangeRequest{
 				Identity: "foo",
@@ -1456,7 +1464,7 @@ func TestExchangeAllowlistIsCached(t *testing.T) {
 	counter := &allowlistCounter{Handler: newFakeGitHub()}
 	atr := newAppsTransport(t, counter)
 	ctx := newExchangeContext(t)
-	s := &sts{rrm: &fakeInstallMgr{atr: atr}, appCount: 1}
+	s := &sts{router: routerFor(&fakeInstallMgr{atr: atr}, 1)}
 
 	for i := range 2 {
 		if _, err := s.Exchange(ctx, &v1.ExchangeRequest{Identity: "foo", Scope: "org/repo"}); err != nil {
@@ -1515,7 +1523,7 @@ func TestExchangeRecordsAuditDecisionOnEvent(t *testing.T) {
 	ce := &captureCEClient{}
 	atr := newAppsTransport(t, newFakeGitHub())
 	ctx := newExchangeContext(t)
-	s := &sts{rrm: &fakeInstallMgr{atr: atr}, appCount: 1, ceclient: ce, metrics: true}
+	s := &sts{router: routerFor(&fakeInstallMgr{atr: atr}, 1), ceclient: ce, metrics: true}
 
 	if _, err := s.Exchange(ctx, &v1.ExchangeRequest{Identity: "foo", Scope: "orgaudit/repo"}); err != nil {
 		t.Fatalf("Exchange() = %v, want success (audit mode never denies)", err)
@@ -1570,7 +1578,7 @@ var _ ghinstall.Manager = (*notInstalledMgr)(nil)
 // than a cost one.
 //
 // scope is caller-supplied and arbitrary. The check therefore runs AFTER
-// s.rrm.Get, whose negative install cache rejects an owner the App is not
+// the pool's Get, whose negative install cache rejects an owner the App is not
 // installed on. Hoisting the check above it would let any holder of one valid
 // token drive an installation enumeration, a token mint and a contents read
 // against ANY organization on GitHub, once per request — unauthenticated
@@ -1586,7 +1594,7 @@ func TestExchangeUninstalledOwnerReadsNoAllowlist(t *testing.T) {
 	counter := &allowlistCounter{Handler: newFakeGitHub()}
 	atr := newAppsTransport(t, counter)
 	ctx := newExchangeContext(t)
-	s := &sts{rrm: &notInstalledMgr{atr: atr}, appCount: 1}
+	s := &sts{router: routerFor(&notInstalledMgr{atr: atr}, 1)}
 
 	if _, err := s.Exchange(ctx, &v1.ExchangeRequest{
 		Identity: "foo",
@@ -1596,7 +1604,7 @@ func TestExchangeUninstalledOwnerReadsNoAllowlist(t *testing.T) {
 	}
 
 	if got := counter.n.Load(); got != 0 {
-		t.Errorf("allowlist was read %d times for an owner with no installation, want 0 — the check must not run before s.rrm.Get", got)
+		t.Errorf("allowlist was read %d times for an owner with no installation, want 0 — the check must not run before the pool's Get", got)
 	}
 	if _, ok := orgIssuers.Get("orgallow"); ok {
 		t.Error("nothing may be cached for an owner the App is not installed on")
@@ -1625,7 +1633,7 @@ func TestLookupConfirmsBeforeGrantingAllowAll(t *testing.T) {
 			{Transport: hidden, ID: 2, AppID: 20},
 		},
 	}
-	s := &sts{rrm: mgr, appCount: 2}
+	s := &sts{router: routerFor(mgr, 2)}
 
 	entry, err := s.orgIssuerLookup(t.Context(), "orgallow")
 	if err != nil {
@@ -1649,10 +1657,10 @@ func TestLookupFailedConfirmNeverCachesAbsent(t *testing.T) {
 
 	blind := newAppsTransport(t, newOrgFakeGitHub(withNoGitHubRepoAccess()))
 
-	s := &sts{rrm: &enumMgr{
+	s := &sts{router: routerFor(&enumMgr{
 		installs: []ghinstall.Installation{{Transport: blind, ID: 1, AppID: 10}},
 		freshErr: errors.New("could not list installations for app 20"),
-	}, appCount: 2}
+	}, 2)}
 
 	_, err := s.orgIssuerLookup(t.Context(), "orgallow")
 	st, ok := status.FromError(err)
@@ -1673,13 +1681,13 @@ func TestLookupNewlyFoundInstallationBlindIsAbsent(t *testing.T) {
 	a := newAppsTransport(t, newOrgFakeGitHub(withNoGitHubRepoAccess()))
 	b := newAppsTransport(t, newOrgFakeGitHub(withNoGitHubRepoAccess()))
 
-	s := &sts{rrm: &enumMgr{
+	s := &sts{router: routerFor(&enumMgr{
 		installs: []ghinstall.Installation{{Transport: a, ID: 1, AppID: 10}},
 		freshInstalls: []ghinstall.Installation{
 			{Transport: a, ID: 1, AppID: 10},
 			{Transport: b, ID: 2, AppID: 20},
 		},
-	}, appCount: 2}
+	}, 2)}
 
 	entry, err := s.orgIssuerLookup(t.Context(), "orgallow")
 	if err != nil {
@@ -1702,13 +1710,13 @@ func TestLookupNewlyFoundInstallationRateLimitedFailsClosed(t *testing.T) {
 	blind := newAppsTransport(t, newOrgFakeGitHub(withNoGitHubRepoAccess()))
 	limited := newAppsTransport(t, newOrgFakeGitHub(withMintRateLimited()))
 
-	s := &sts{rrm: &enumMgr{
+	s := &sts{router: routerFor(&enumMgr{
 		installs: []ghinstall.Installation{{Transport: blind, ID: 1, AppID: 10}},
 		freshInstalls: []ghinstall.Installation{
 			{Transport: blind, ID: 1, AppID: 10},
 			{Transport: limited, ID: 2, AppID: 20},
 		},
-	}, appCount: 2}
+	}, 2)}
 
 	_, err := s.orgIssuerLookup(t.Context(), "orgallow")
 	st, ok := status.FromError(err)
@@ -1730,13 +1738,13 @@ func TestLookupConfirmSubsetIsAbsent(t *testing.T) {
 	a := newAppsTransport(t, newOrgFakeGitHub(withNoGitHubRepoAccess()))
 	b := newAppsTransport(t, newOrgFakeGitHub(withNoGitHubRepoAccess()))
 
-	s := &sts{rrm: &enumMgr{
+	s := &sts{router: routerFor(&enumMgr{
 		installs: []ghinstall.Installation{
 			{Transport: a, ID: 1, AppID: 10},
 			{Transport: b, ID: 2, AppID: 20},
 		},
 		freshInstalls: []ghinstall.Installation{{Transport: a, ID: 1, AppID: 10}},
-	}, appCount: 2}
+	}, 2)}
 
 	entry, err := s.orgIssuerLookup(t.Context(), "orgallow")
 	if err != nil {
@@ -1756,7 +1764,7 @@ func TestTallyAccumulatesAcrossPasses(t *testing.T) {
 	blindB := newAppsTransport(t, newOrgFakeGitHub(withNoGitHubRepoAccess()))
 	broken := newAppsTransport(t, newOrgFakeGitHub(withContentsServerError()))
 
-	s := &sts{appCount: 2}
+	s := &sts{router: routerFor(nil, 2)}
 	first := []ghinstall.Installation{{Transport: blindA, ID: 1, AppID: 10}}
 
 	t.Run("a failure in the second pass destroys exhaustiveness", func(t *testing.T) {
@@ -1916,7 +1924,7 @@ func TestStaleEntryIsNotReseededIntoPrimary(t *testing.T) {
 		t.Fatal("stale entry missing; this test needs one to serve")
 	}
 
-	s := &sts{rrm: &enumMgr{err: errors.New("enumeration failed")}, appCount: 1}
+	s := &sts{router: routerFor(&enumMgr{err: errors.New("enumeration failed")}, 1)}
 	entry, err := s.orgIssuerLookup(t.Context(), "orgallow")
 	if err != nil {
 		t.Fatalf("orgIssuerLookup() = %v, want the stale entry served", err)
@@ -1971,7 +1979,7 @@ func TestOrgIssuerLookupSingleFlightsColdBurst(t *testing.T) {
 	}}
 	release := make(chan struct{})
 	mgr := &countingMgr{enumMgr: base, block: release}
-	s := &sts{rrm: mgr, appCount: 2}
+	s := &sts{router: routerFor(mgr, 2)}
 
 	const n = 50
 	var wg sync.WaitGroup
@@ -2021,7 +2029,7 @@ func TestOrgIssuerLookupWaiterHonorsOwnContext(t *testing.T) {
 	release := make(chan struct{})
 	entered := make(chan struct{})
 	mgr := &countingMgr{enumMgr: base, block: release, entered: entered}
-	s := &sts{rrm: mgr, appCount: 1}
+	s := &sts{router: routerFor(mgr, 1)}
 
 	// Leader: starts the flight on a background context and blocks inside GetAll.
 	leaderDone := make(chan struct{})


### PR DESCRIPTION
Multi-Org GitHub App Routing

Problem

octo-sts supports multiple GitHub Apps, but only as a flat pool for rate-limit scaling — all apps serve all orgs indiscriminately. There's no way to:

- Assign dedicated apps to specific GitHub organizations
- Use different credential types per app (e.g., KMS for org-A, injected PEM for org-B)
- Get a clear error when a request arrives for an org with no configured apps

The env-var config (GITHUB_APP_IDS, KMS_KEYS) is structurally limited to a single credential type across all apps.

Solution

Introduce a YAML config file (pointed to by APP_CONFIG_FILE) that maps orgs to their dedicated app pools, each with per-app credential configuration:

```
orgs:
  - name: org-a
    apps:
      - app_id: 111
        kms_key: projects/.../cryptoKeyVersions/1
  - name: org-b
    apps:
      - app_id: 222
        private_key: "${INJECTED_PEM}"  # env var expanded at load time
```

Let me know what you guys think!