### PR TITLE
fix: retry transient GitHub API errors in trust policy lookup

### DIFF
--- a/pkg/octosts/octosts.go
+++ b/pkg/octosts/octosts.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
+	"github.com/cenkalti/backoff/v5"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/google/go-github/v84/github"
@@ -393,29 +394,40 @@ func (s *sts) lookupTrustPolicy(ctx context.Context, base *ghinstallation.AppsTr
 			Transport: atr,
 		})
 
-		file, _, _, err := client.Repositories.GetContents(ctx,
-			trustPolicyKey.owner, trustPolicyKey.repo,
-			fmt.Sprintf(".github/chainguard/%s.sts.yaml", trustPolicyKey.identity),
-			&github.RepositoryContentGetOptions{ /* defaults to the default branch */ },
-		)
-		if err != nil {
-			clog.InfoContextf(ctx, "failed to find trust policy: %v", err)
-			// Don't leak the error to the client.
-			var ghErr *github.ErrorResponse
-			if errors.As(err, &ghErr) && ghErr.Response != nil {
-				switch ghErr.Response.StatusCode {
-				case http.StatusForbidden:
-					return status.Errorf(codes.ResourceExhausted, "GitHub API rate limit exceeded (403) for %q", trustPolicyKey.identity)
-				case http.StatusTooManyRequests:
-					return status.Errorf(codes.ResourceExhausted, "GitHub API rate limit exceeded (429) for %q", trustPolicyKey.identity)
+		file, fetchErr := backoff.Retry(ctx, func() (*github.RepositoryContent, error) {
+			f, _, _, err := client.Repositories.GetContents(ctx,
+				trustPolicyKey.owner, trustPolicyKey.repo,
+				fmt.Sprintf(".github/chainguard/%s.sts.yaml", trustPolicyKey.identity),
+				&github.RepositoryContentGetOptions{ /* defaults to the default branch */ },
+			)
+			if err != nil {
+				clog.InfoContextf(ctx, "failed to find trust policy (will retry if transient): %v", err)
+				// Permanent errors: don't retry.
+				var ghErr *github.ErrorResponse
+				if errors.As(err, &ghErr) && ghErr.Response != nil {
+					switch ghErr.Response.StatusCode {
+					case http.StatusNotFound:
+						return nil, backoff.Permanent(status.Errorf(codes.NotFound, "unable to find trust policy for %q", trustPolicyKey.identity))
+					case http.StatusForbidden:
+						return nil, backoff.Permanent(status.Errorf(codes.ResourceExhausted, "GitHub API rate limit exceeded (403) for %q", trustPolicyKey.identity))
+					case http.StatusTooManyRequests:
+						return nil, backoff.Permanent(status.Errorf(codes.ResourceExhausted, "GitHub API rate limit exceeded (429) for %q", trustPolicyKey.identity))
+					}
 				}
+				// Transient error (network blip, 5xx, token creation failure, etc.) — return
+				// a retriable sentinel. The original error is logged above; don't leak details.
+				return nil, status.Errorf(codes.Unavailable, "transient error fetching trust policy for %q", trustPolicyKey.identity)
 			}
-			return status.Errorf(codes.NotFound, "unable to find trust policy for %q", trustPolicyKey.identity)
+			return f, nil
+		}, backoff.WithBackOff(backoff.NewExponentialBackOff()))
+		if fetchErr != nil {
+			return fetchErr
 		}
 
-		raw, err = file.GetContent()
-		if err != nil {
-			clog.ErrorContextf(ctx, "failed to read trust policy: %v", err)
+		var getContentErr error
+		raw, getContentErr = file.GetContent()
+		if getContentErr != nil {
+			clog.ErrorContextf(ctx, "failed to read trust policy: %v", getContentErr)
 			// Don't leak the error to the client.
 			return status.Errorf(codes.NotFound, "unable to read trust policy found for %q", trustPolicyKey.identity)
 		}


### PR DESCRIPTION
## Problem

Intermittent `unable to find trust policy for "<identity>"` errors occur even when the policy file exists in the target repository.

`lookupTrustPolicy` fetches `.github/chainguard/<identity>.sts.yaml` from the GitHub API on every cache miss (the per-pod LRU expires after 5 minutes). The previous error handling had two gaps:

**1. Transport-level errors were not distinguished from file-not-found.**

When `atr.Token(ctx)` fails inside the HTTP transport — e.g. due to a transient 5xx or rate limiting during installation token creation — the error surfaces as an opaque transport error, not a `*github.ErrorResponse`. So `errors.As` never matched and all such errors fell through to the generic `codes.NotFound` / "unable to find trust policy" response, masking the real cause.

**2. No retry for transient errors.**

A single network blip or momentary GitHub API unavailability failed the request immediately with no recovery path.

## Fix

Wrap the `GetContents` call in `backoff.Retry` with exponential backoff (the same `cenkalti/backoff/v5` library already used in `provider.go`). Error classification:

- **404** → permanent, return `codes.NotFound` immediately (policy genuinely missing)
- **403 / 429** → permanent, return `codes.ResourceExhausted` immediately (rate limited)
- **Everything else** → transient, retry with exponential backoff

## Testing

- Existing `pkg/octosts` unit tests pass unchanged.