### PR TITLE
webhook: don't panic when no KMS key is configured

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -61,11 +61,14 @@ func main() {
 	} else {
 		log.Panic("at least one GitHub App ID must be provided")
 	}
+	// kmsKey is only required when neither APP_SECRET_CERTIFICATE_ENV_VAR
+	// nor APP_SECRET_CERTIFICATE_FILE is set; ghtransport.New picks the
+	// right source and returns an error when none is configured. Do not
+	// panic here — self-hosted deployments using cert-file/env-var paths
+	// must not be forced to configure a KMS key.
 	var kmsKey string
 	if len(baseCfg.KMSKeys) > 0 {
 		kmsKey = baseCfg.KMSKeys[0]
-	} else {
-		log.Panic("at least one KMS key must be provided")
 	}
 	atr, err := ghtransport.New(ctx, appID, kmsKey, baseCfg, client)
 	if err != nil {


### PR DESCRIPTION
Fixes octo-sts/app#1329.

## Problem

Since v0.6.0 the webhook binary panics on startup with

```
at least one KMS key must be provided
```

even when the deployment correctly configures `APP_SECRET_CERTIFICATE_FILE` or `APP_SECRET_CERTIFICATE_ENV_VAR`. That broke self-hosted, non-GCP deployments that had been using the cert-file path since it was added.

The regression landed in `cmd/webhook/main.go` where a new pre-check panics before `ghtransport.New` gets a chance to decide which secret source to use. `ghtransport.New` already covers all three paths via its switch statement and returns a proper error when none is configured, so the extra pre-check is redundant for the GCP case and wrong for the non-GCP case.

## Fix

Remove the `log.Panic("at least one KMS key must be provided")` and let `ghtransport.New` own the decision. The main app binary already uses this same pattern and works correctly with all three secret sources; the webhook now matches.

## Test

`go test ./...` passes locally:
```
ok  	github.com/octo-sts/app/pkg/envconfig	0.960s
ok  	github.com/octo-sts/app/pkg/gcpkms	3.241s
ok  	github.com/octo-sts/app/pkg/ghinstall	15.943s
ok  	github.com/octo-sts/app/pkg/ghtransport	4.313s
ok  	github.com/octo-sts/app/pkg/webhook	4.167s
```