### PR TITLE
Add smoke tests for Octo STS

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -55,6 +55,8 @@ jobs:
             compute.googleapis.com:443
             dl.google.com:443
             dns.googleapis.com:443
+            octo-staging.dev:443
+            octo-sts.dev:443
             fulcio.sigstore.dev:443
             gcr.io:443
             github.com:443
@@ -138,6 +140,11 @@ jobs:
           terraform plan
 
           terraform apply -auto-approve
+
+      - name: Run smoke tests
+        if: steps.terraform-init.outcome == 'success'
+        run: |
+          go run ./hack/smoketest/ -config hack/smoketest/testdata/${{ steps.auth-config.outputs.environment }}.yaml
 
       - uses: step-security/action-slack-notify@e04c77a65bae8b6c0373478a1cb8fd7e012637e6 # v2.3.5
         if: ${{ failure() }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -143,8 +143,10 @@ jobs:
 
       - name: Run smoke tests
         if: steps.terraform-init.outcome == 'success'
+        env:
+          SMOKETEST_ENV: ${{ steps.auth-config.outputs.environment }}
         run: |
-          go run ./hack/smoketest/ -config hack/smoketest/testdata/${{ steps.auth-config.outputs.environment }}.yaml
+          go run ./hack/smoketest/ -config "hack/smoketest/testdata/${SMOKETEST_ENV}.yaml"
 
       - uses: step-security/action-slack-notify@e04c77a65bae8b6c0373478a1cb8fd7e012637e6 # v2.3.5
         if: ${{ failure() }}

--- a/hack/smoketest/README.md
+++ b/hack/smoketest/README.md
@@ -1,0 +1,262 @@
+# Octo STS Smoke Tests
+
+A standalone Go tool that runs smoke tests against a live Octo STS deployment. It
+validates both successful token exchanges and known-bad scenarios such as missing
+trust policies or mismatched OIDC tokens.
+
+## Requirements
+
+**This tool must be run from a GitHub Actions workflow.** It uses GitHub Actions
+OIDC tokens for authentication, which are only available inside Actions runners
+with the `id-token: write` permission. It will not work locally or in other CI
+environments.
+
+The workflow must include:
+
+```yaml
+permissions:
+  id-token: write
+```
+
+## Quick Start
+
+### 1. Build the tool
+
+```bash
+go build -o smoketest ./hack/smoketest/
+```
+
+### 2. Create a config file
+
+Create a YAML file describing your test cases (see [Configuration Reference](#configuration-reference)
+below or the example at `hack/smoketest/testdata/example.yaml`):
+
+```yaml
+domain: octo-sts.dev
+
+tests:
+  - name: "valid exchange"
+    scope: octo-sts/prober
+    identity: smoke-test
+
+  - name: "missing policy"
+    scope: octo-sts/prober
+    identity: does-not-exist
+    expect_failure: true
+    expected_error: "exchange failed"
+```
+
+### 3. Run from a GitHub Actions workflow
+
+```yaml
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: .go-version
+      - run: go build -o smoketest ./hack/smoketest/
+      - run: ./smoketest -config hack/smoketest/testdata/example.yaml
+```
+
+## How It Works
+
+For each test case, the tool:
+
+1. **Mints a GitHub Actions OIDC token** with the `audience` set to the
+   configured `domain`. This uses the `ACTIONS_ID_TOKEN_REQUEST_URL` and
+   `ACTIONS_ID_TOKEN_REQUEST_TOKEN` environment variables that GitHub Actions
+   provides to workflows with `id-token: write`.
+
+2. **Exchanges the OIDC token** with the Octo STS endpoint at
+   `https://{domain}` using the `chainguard.dev/sdk/sts` client. The exchange
+   targets the configured `scope` (repository) and `identity` (trust policy
+   name).
+
+3. **Checks the result** against expectations:
+   - If `expect_failure: true`, the tool asserts that the exchange returned an
+     error. If `expected_error` is set, it checks that the error message contains
+     that substring.
+   - If `expect_failure: false` (the default), the tool asserts that the exchange
+     succeeded and a token was returned.
+
+4. **Runs optional verifications** if a `verify` block is present. This uses the
+   returned GitHub token to make real API calls, confirming the token actually has
+   the expected permissions.
+
+5. **Revokes the token** after use. Every successfully exchanged token is revoked
+   via `DELETE https://api.github.com/installation/token` to clean up rather than
+   letting it expire.
+
+Each test runs independently. A failure in one test does not skip subsequent
+tests. The tool exits 0 if all tests pass, 1 if any fail.
+
+## Configuration Reference
+
+The config file is YAML with two top-level fields:
+
+### Top-Level Fields
+
+| Field    | Type   | Required | Description                                        |
+|----------|--------|----------|----------------------------------------------------|
+| `domain` | string | yes      | Octo STS deployment domain (e.g. `octo-sts.dev`)  |
+| `tests`  | list   | yes      | List of test cases to run                          |
+
+### Test Case Fields
+
+| Field            | Type   | Required | Default | Description                                           |
+|------------------|--------|----------|---------|-------------------------------------------------------|
+| `name`           | string | yes      |         | Human-readable name for the test (used in log output) |
+| `scope`          | string | yes      |         | Target repository scope (e.g. `octo-sts/prober`)     |
+| `identity`       | string | yes      |         | Trust policy identity name                            |
+| `expect_failure` | bool   | no       | `false` | If `true`, expect the exchange to fail                |
+| `expected_error` | string | no       |         | Substring to match in the error message               |
+| `verify`         | object | no       |         | Optional verification block (see below)               |
+
+### Verify Block
+
+The `verify` block is optional and only meaningful for tests where
+`expect_failure` is `false`. It describes GitHub API calls to make with the
+returned token to confirm it has the expected permissions.
+
+All sub-fields are optional. Include only the verifications relevant to the trust
+policy being tested.
+
+#### `contents_read`
+
+Reads a file from a repository. Confirms the token has `contents: read`.
+
+| Field  | Type   | Required | Description                             |
+|--------|--------|----------|-----------------------------------------|
+| `org`  | string | yes      | Repository owner                        |
+| `repo` | string | yes      | Repository name                         |
+| `path` | string | yes      | File path to read (e.g. `README.md`)    |
+
+Example:
+```yaml
+verify:
+  contents_read:
+    org: octo-sts
+    repo: prober
+    path: .github/chainguard/smoke-test.sts.yaml
+```
+
+#### `issues_read`
+
+Lists issues on a repository. Confirms the token has `issues: read`.
+
+| Field  | Type   | Required | Description      |
+|--------|--------|----------|------------------|
+| `org`  | string | yes      | Repository owner |
+| `repo` | string | yes      | Repository name  |
+
+Example:
+```yaml
+verify:
+  issues_read:
+    org: octo-sts
+    repo: prober
+```
+
+#### `pull_requests_read`
+
+Lists pull requests on a repository. Confirms the token has `pull_requests: read`.
+
+| Field  | Type   | Required | Description      |
+|--------|--------|----------|------------------|
+| `org`  | string | yes      | Repository owner |
+| `repo` | string | yes      | Repository name  |
+
+Example:
+```yaml
+verify:
+  pull_requests_read:
+    org: octo-sts
+    repo: prober
+```
+
+## Switching Between Staging and Prod
+
+Change the `domain` field to target different deployments. You can maintain
+separate config files per environment:
+
+```
+hack/smoketest/testdata/staging.yaml   # domain: staging.octo-sts.dev
+hack/smoketest/testdata/prod.yaml      # domain: octo-sts.dev
+```
+
+Or parameterize it in your workflow using `sed`, `envsubst`, or similar.
+
+## Prerequisites
+
+For tests to work, the following must already be in place:
+
+1. **Trust policies must exist.** Each test case references a trust policy by
+   `identity` name. The corresponding `.github/chainguard/{identity}.sts.yaml`
+   file must exist in the target repository's default branch.
+
+2. **The Octo STS GitHub App must be installed.** The App must be installed on
+   the organization/repository referenced by `scope`, with access to the
+   relevant repositories.
+
+3. **Trust policies must match the GitHub Actions OIDC token.** For positive
+   test cases (where the exchange should succeed), the trust policy's issuer,
+   subject, and any claim patterns must match the OIDC token produced by the
+   GitHub Actions workflow running the smoke tests.
+
+## Negative Test Scenarios
+
+The tool supports several categories of negative tests:
+
+### Missing STS Policy
+
+Tests that a non-existent identity is correctly rejected:
+
+```yaml
+- name: "missing STS policy"
+  scope: octo-sts/prober
+  identity: does-not-exist
+  expect_failure: true
+  expected_error: "exchange failed"
+```
+
+### App Not Installed
+
+Tests that a scope where the app is not installed is rejected:
+
+```yaml
+- name: "app not installed"
+  scope: some-org/no-app-here
+  identity: anything
+  expect_failure: true
+  expected_error: "exchange failed"
+```
+
+### Bad OIDC Match
+
+Tests that a trust policy which doesn't match the calling workflow's OIDC token
+is rejected. Create a trust policy with a subject or issuer that won't match
+the Actions token:
+
+```yaml
+- name: "OIDC subject mismatch"
+  scope: octo-sts/prober
+  identity: wrong-subject-policy
+  expect_failure: true
+  expected_error: "exchange failed"
+```
+
+Where `wrong-subject-policy.sts.yaml` contains a subject that doesn't match the
+calling workflow (e.g. `subject: repo:some-other-org/some-other-repo:ref:refs/heads/main`).
+
+## Adding New Verification Types
+
+To add a new verification type (e.g. `actions_read`):
+
+1. Add a new struct field to `Verify` in `config.go`
+2. Add the corresponding API call in `runVerifications()` in `runner.go`
+3. Document the new field in this README

--- a/hack/smoketest/config.go
+++ b/hack/smoketest/config.go
@@ -1,0 +1,74 @@
+// Copyright 2024 Chainguard, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"sigs.k8s.io/yaml"
+)
+
+type Config struct {
+	Domain string     `json:"domain"`
+	Tests  []TestCase `json:"tests"`
+}
+
+type TestCase struct {
+	Name          string  `json:"name"`
+	Scope         string  `json:"scope"`
+	Identity      string  `json:"identity"`
+	ExpectFailure bool    `json:"expect_failure"`
+	ExpectedError string  `json:"expected_error"`
+	Verify        *Verify `json:"verify,omitempty"`
+}
+
+type Verify struct {
+	ContentsRead     *ContentsReadVerify `json:"contents_read,omitempty"`
+	IssuesRead       *RepoVerify         `json:"issues_read,omitempty"`
+	PullRequestsRead *RepoVerify         `json:"pull_requests_read,omitempty"`
+}
+
+type ContentsReadVerify struct {
+	Org  string `json:"org"`
+	Repo string `json:"repo"`
+	Path string `json:"path"`
+}
+
+type RepoVerify struct {
+	Org  string `json:"org"`
+	Repo string `json:"repo"`
+}
+
+func LoadConfig(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading config file: %w", err)
+	}
+
+	var cfg Config
+	if err := yaml.UnmarshalStrict(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing config file: %w", err)
+	}
+
+	if cfg.Domain == "" {
+		return nil, fmt.Errorf("domain is required")
+	}
+	if len(cfg.Tests) == 0 {
+		return nil, fmt.Errorf("at least one test is required")
+	}
+	for i, tc := range cfg.Tests {
+		if tc.Name == "" {
+			return nil, fmt.Errorf("test[%d]: name is required", i)
+		}
+		if tc.Scope == "" {
+			return nil, fmt.Errorf("test[%d] %q: scope is required", i, tc.Name)
+		}
+		if tc.Identity == "" {
+			return nil, fmt.Errorf("test[%d] %q: identity is required", i, tc.Name)
+		}
+	}
+
+	return &cfg, nil
+}

--- a/hack/smoketest/main.go
+++ b/hack/smoketest/main.go
@@ -1,0 +1,51 @@
+// Copyright 2024 Chainguard, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"log/slog"
+	"os"
+
+	"github.com/chainguard-dev/clog"
+)
+
+func main() {
+	configPath := flag.String("config", "", "path to smoke test YAML config file")
+	flag.Parse()
+
+	if *configPath == "" {
+		fmt.Fprintf(os.Stderr, "Usage: smoketest -config <path>\n")
+		os.Exit(1)
+	}
+
+	ctx := clog.WithLogger(context.Background(), clog.New(slog.Default().Handler()))
+
+	cfg, err := LoadConfig(*configPath)
+	if err != nil {
+		log.Fatalf("loading config: %v", err)
+	}
+
+	clog.FromContext(ctx).Infof("running %d smoke tests against %s", len(cfg.Tests), cfg.Domain)
+
+	results := RunTests(ctx, cfg)
+
+	passed, failed := 0, 0
+	for _, r := range results {
+		if r.Passed {
+			passed++
+		} else {
+			failed++
+		}
+	}
+
+	clog.FromContext(ctx).Infof("results: %d passed, %d failed, %d total", passed, failed, len(results))
+
+	if failed > 0 {
+		os.Exit(1)
+	}
+}

--- a/hack/smoketest/oidc.go
+++ b/hack/smoketest/oidc.go
@@ -1,0 +1,63 @@
+// Copyright 2024 Chainguard, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+)
+
+type oidcTokenResponse struct {
+	Value string `json:"value"`
+}
+
+func MintGitHubActionsToken(audience string) (string, error) {
+	requestURL := os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL")
+	requestToken := os.Getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
+
+	if requestURL == "" || requestToken == "" {
+		return "", fmt.Errorf("ACTIONS_ID_TOKEN_REQUEST_URL and ACTIONS_ID_TOKEN_REQUEST_TOKEN must be set (are you running in GitHub Actions with id-token: write?)")
+	}
+
+	u, err := url.Parse(requestURL)
+	if err != nil {
+		return "", fmt.Errorf("parsing ACTIONS_ID_TOKEN_REQUEST_URL: %w", err)
+	}
+	q := u.Query()
+	q.Set("audience", audience)
+	u.RawQuery = q.Encode()
+
+	// URL is from the trusted ACTIONS_ID_TOKEN_REQUEST_URL env var set by GitHub Actions.
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil) //nolint:gosec // URL from trusted GitHub Actions env var
+	if err != nil {
+		return "", fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+requestToken)
+
+	resp, err := http.DefaultClient.Do(req) //nolint:gosec // URL from trusted GitHub Actions env var
+	if err != nil {
+		return "", fmt.Errorf("requesting OIDC token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("OIDC token request returned %d: %s", resp.StatusCode, body)
+	}
+
+	var tokenResp oidcTokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return "", fmt.Errorf("decoding OIDC token response: %w", err)
+	}
+
+	if tokenResp.Value == "" {
+		return "", fmt.Errorf("OIDC token response had empty value")
+	}
+
+	return tokenResp.Value, nil
+}

--- a/hack/smoketest/runner.go
+++ b/hack/smoketest/runner.go
@@ -1,0 +1,138 @@
+// Copyright 2024 Chainguard, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"chainguard.dev/sdk/sts"
+	"github.com/chainguard-dev/clog"
+	"github.com/google/go-github/v84/github"
+	"golang.org/x/oauth2"
+
+	"github.com/octo-sts/app/pkg/octosts"
+)
+
+type TestResult struct {
+	Name   string
+	Passed bool
+	Error  string
+}
+
+func RunTests(ctx context.Context, cfg *Config) []TestResult {
+	results := make([]TestResult, 0, len(cfg.Tests))
+
+	for _, tc := range cfg.Tests {
+		result := runSingleTest(ctx, cfg.Domain, tc)
+		if result.Passed {
+			clog.FromContext(ctx).Infof("PASS: %s", result.Name)
+		} else {
+			clog.FromContext(ctx).Errorf("FAIL: %s: %s", result.Name, result.Error)
+		}
+		results = append(results, result)
+	}
+
+	return results
+}
+
+func runSingleTest(ctx context.Context, domain string, tc TestCase) TestResult {
+	result := TestResult{Name: tc.Name}
+
+	token, err := MintGitHubActionsToken(domain)
+	if err != nil {
+		result.Error = fmt.Sprintf("minting OIDC token: %v", err)
+		return result
+	}
+
+	xchg := sts.New(
+		fmt.Sprintf("https://%s", domain),
+		"does-not-matter",
+		sts.WithScope(tc.Scope),
+		sts.WithIdentity(tc.Identity),
+	)
+
+	res, err := xchg.Exchange(ctx, token)
+
+	if tc.ExpectFailure {
+		if err == nil {
+			result.Error = "expected exchange to fail, but it succeeded"
+			return result
+		}
+		if tc.ExpectedError != "" && !strings.Contains(err.Error(), tc.ExpectedError) {
+			result.Error = fmt.Sprintf("expected error containing %q, got: %v", tc.ExpectedError, err)
+			return result
+		}
+		result.Passed = true
+		return result
+	}
+
+	if err != nil {
+		result.Error = fmt.Sprintf("exchange failed: %v", err)
+		return result
+	}
+
+	defer func() {
+		if err := octosts.Revoke(ctx, res.AccessToken); err != nil {
+			clog.FromContext(ctx).Warnf("failed to revoke token for %q: %v", tc.Name, err)
+		}
+	}()
+
+	if tc.Verify != nil {
+		if err := runVerifications(ctx, res.AccessToken, tc.Verify); err != nil {
+			result.Error = fmt.Sprintf("verification failed: %v", err)
+			return result
+		}
+	}
+
+	result.Passed = true
+	return result
+}
+
+func runVerifications(ctx context.Context, accessToken string, v *Verify) error {
+	ghc := github.NewClient(
+		oauth2.NewClient(ctx,
+			oauth2.StaticTokenSource(&oauth2.Token{
+				AccessToken: accessToken,
+			}),
+		),
+	)
+
+	if v.ContentsRead != nil {
+		cr := v.ContentsRead
+		file, _, _, err := ghc.Repositories.GetContents(ctx,
+			cr.Org, cr.Repo, cr.Path,
+			&github.RepositoryContentGetOptions{},
+		)
+		if err != nil {
+			return fmt.Errorf("contents_read(%s/%s/%s): %w", cr.Org, cr.Repo, cr.Path, err)
+		}
+		if _, err := file.GetContent(); err != nil {
+			return fmt.Errorf("contents_read(%s/%s/%s) reading content: %w", cr.Org, cr.Repo, cr.Path, err)
+		}
+	}
+
+	if v.IssuesRead != nil {
+		ir := v.IssuesRead
+		if _, _, err := ghc.Issues.ListByRepo(ctx,
+			ir.Org, ir.Repo,
+			&github.IssueListByRepoOptions{},
+		); err != nil {
+			return fmt.Errorf("issues_read(%s/%s): %w", ir.Org, ir.Repo, err)
+		}
+	}
+
+	if v.PullRequestsRead != nil {
+		pr := v.PullRequestsRead
+		if _, _, err := ghc.PullRequests.List(ctx,
+			pr.Org, pr.Repo,
+			&github.PullRequestListOptions{},
+		); err != nil {
+			return fmt.Errorf("pull_requests_read(%s/%s): %w", pr.Org, pr.Repo, err)
+		}
+	}
+
+	return nil
+}

--- a/hack/smoketest/testdata/octo-sts-staging.yaml
+++ b/hack/smoketest/testdata/octo-sts-staging.yaml
@@ -1,0 +1,39 @@
+# Smoke tests for the Octo STS staging deployment.
+#
+# Prerequisites:
+#   - The octo-sts GitHub App must be installed on the target org/repos.
+#   - Trust policies referenced by identity must exist in the target repos
+#     and match the GitHub Actions OIDC token from the octo-sts/app deploy workflow.
+
+domain: octo-staging.dev
+
+tests:
+  - name: "valid token exchange with verification"
+    scope: octo-sts/prober
+    identity: smoke-test
+    expect_failure: false
+    verify:
+      contents_read:
+        org: octo-sts
+        repo: prober
+        path: .github/chainguard/smoke-test.sts.yaml
+      issues_read:
+        org: octo-sts
+        repo: prober
+
+  - name: "valid token exchange without verification"
+    scope: octo-sts/prober
+    identity: smoke-test
+    expect_failure: false
+
+  - name: "missing STS policy"
+    scope: octo-sts/prober
+    identity: does-not-exist
+    expect_failure: true
+    expected_error: "exchange failed"
+
+  - name: "app not installed on target"
+    scope: some-org/no-app-here
+    identity: anything
+    expect_failure: true
+    expected_error: "exchange failed"

--- a/hack/smoketest/testdata/octo-sts.yaml
+++ b/hack/smoketest/testdata/octo-sts.yaml
@@ -1,0 +1,39 @@
+# Smoke tests for the Octo STS production deployment.
+#
+# Prerequisites:
+#   - The octo-sts GitHub App must be installed on the target org/repos.
+#   - Trust policies referenced by identity must exist in the target repos
+#     and match the GitHub Actions OIDC token from the octo-sts/app deploy workflow.
+
+domain: octo-sts.dev
+
+tests:
+  - name: "valid token exchange with verification"
+    scope: octo-sts/prober
+    identity: smoke-test
+    expect_failure: false
+    verify:
+      contents_read:
+        org: octo-sts
+        repo: prober
+        path: .github/chainguard/smoke-test.sts.yaml
+      issues_read:
+        org: octo-sts
+        repo: prober
+
+  - name: "valid token exchange without verification"
+    scope: octo-sts/prober
+    identity: smoke-test
+    expect_failure: false
+
+  - name: "missing STS policy"
+    scope: octo-sts/prober
+    identity: does-not-exist
+    expect_failure: true
+    expected_error: "exchange failed"
+
+  - name: "app not installed on target"
+    scope: some-org/no-app-here
+    identity: anything
+    expect_failure: true
+    expected_error: "exchange failed"


### PR DESCRIPTION
Add a smoketest app for STS.  Takes YAML config files to setup what tests to run and is called and run them after deploy.