### PR TITLE
Add logging API to egress

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -63,6 +63,7 @@ jobs:
             go.dev:443
             iam.googleapis.com:443
             iamcredentials.googleapis.com:443
+            logging.googleapis.com:443
             monitoring.googleapis.com:443
             objects.githubusercontent.com:443
             openidconnect.googleapis.com:443


### PR DESCRIPTION
Stage deploy failed because of missing logging GCP API in the egress list.

https://github.com/octo-sts/app/actions/runs/25019849675/job/73277311809
