### PR TITLE
feat(ghinstall): capacity-aware fairshare routing across installations

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -57,6 +57,18 @@ func main() {
 		}
 	}
 
+	// Capacity-aware routing: a shared QuotaStore is populated by the
+	// transport tap (X-RateLimit-Remaining headers on every GitHub response)
+	// and read by the manager selection logic. Cold start (no quota data
+	// yet) safely falls back to the existing FNV-hash / atomic-counter
+	// strategies.
+	quotaStore := ghinstall.NewQuotaStore(baseCfg.QuotaStaleAfter)
+	quotaCfg := &ghinstall.QuotaConfig{
+		Store:     quotaStore,
+		SoftFloor: baseCfg.QuotaFloorSoft,
+		HardFloor: baseCfg.QuotaFloorHard,
+	}
+
 	managers := make([]ghinstall.Manager, 0, len(baseCfg.AppIDs))
 	for i, appID := range baseCfg.AppIDs {
 		var kmsKey string
@@ -67,7 +79,7 @@ func main() {
 				continue
 			}
 		}
-		atr, err := ghtransport.New(ctx, appID, kmsKey, baseCfg, client)
+		atr, err := ghtransport.New(ctx, appID, kmsKey, baseCfg, client, quotaStore)
 		if err != nil {
 			log.Panicf("error creating GitHub App transport for app %d: %v", appID, err)
 		}
@@ -80,8 +92,8 @@ func main() {
 	if len(managers) == 0 {
 		log.Panic("no apps with valid KMS keys configured")
 	}
-	im := ghinstall.NewMultiManager(managers)
-	rrm := ghinstall.NewRoundRobin(managers)
+	im := ghinstall.NewMultiManagerWithQuota(managers, quotaCfg)
+	rrm := ghinstall.NewRoundRobinWithQuota(managers, quotaCfg)
 
 	d := duplex.New(
 		baseCfg.Port,

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -57,11 +57,12 @@ func main() {
 		}
 	}
 
-	// Capacity-aware routing: a shared QuotaStore is populated by the
-	// transport tap (X-RateLimit-Remaining headers on every GitHub response)
-	// and read by the manager selection logic. Cold start (no quota data
-	// yet) safely falls back to the existing FNV-hash / atomic-counter
-	// strategies.
+	// Capacity-aware routing for the round-robin path: a shared QuotaStore
+	// is populated by the transport tap (X-RateLimit-Remaining headers on
+	// every GitHub response) and read by NewRoundRobinWithQuota. Cold start
+	// (no quota data yet) safely falls back to the existing atomic-counter
+	// strategy. multiManager keeps strict consistent hashing — necessary
+	// for GitHub check-run ownership preservation across token rotations.
 	quotaStore := ghinstall.NewQuotaStore(baseCfg.QuotaStaleAfter)
 	quotaCfg := &ghinstall.QuotaConfig{
 		Store:     quotaStore,
@@ -92,7 +93,7 @@ func main() {
 	if len(managers) == 0 {
 		log.Panic("no apps with valid KMS keys configured")
 	}
-	im := ghinstall.NewMultiManagerWithQuota(managers, quotaCfg)
+	im := ghinstall.NewMultiManager(managers)
 	rrm := ghinstall.NewRoundRobinWithQuota(managers, quotaCfg)
 
 	d := duplex.New(

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -68,7 +68,7 @@ func main() {
 		kmsKey = baseCfg.KMSKeys[0]
 	}
 
-	atr, err := ghtransport.New(ctx, appID, kmsKey, baseCfg, client)
+	atr, err := ghtransport.New(ctx, appID, kmsKey, baseCfg, client, nil)
 	if err != nil {
 		log.Panicf("error creating GitHub App transport for app %d: %v", appID, err)
 	}

--- a/pkg/envconfig/envconfig.go
+++ b/pkg/envconfig/envconfig.go
@@ -95,6 +95,9 @@ func BaseConfig() (*EnvConfig, error) {
 	if cfg.QuotaFloorSoft < cfg.QuotaFloorHard {
 		return nil, fmt.Errorf("OCTOSTS_QUOTA_FLOOR_SOFT (%d) must be >= OCTOSTS_QUOTA_FLOOR_HARD (%d)", cfg.QuotaFloorSoft, cfg.QuotaFloorHard)
 	}
+	if cfg.QuotaStaleAfter <= 0 {
+		return nil, fmt.Errorf("OCTOSTS_QUOTA_STALE (%s) must be positive", cfg.QuotaStaleAfter)
+	}
 
 	return cfg, err
 }

--- a/pkg/envconfig/envconfig.go
+++ b/pkg/envconfig/envconfig.go
@@ -12,15 +12,22 @@ import (
 )
 
 type EnvConfig struct {
-	Port                       int           `envconfig:"PORT" required:"true"`
-	KMSKeys                    []string      `envconfig:"KMS_KEYS" required:"false"`
-	AppIDs                     []int64       `envconfig:"GITHUB_APP_IDS" required:"true"`
-	AppSecretCertificateFile   string        `envconfig:"APP_SECRET_CERTIFICATE_FILE" required:"false"`
-	AppSecretCertificateEnvVar string        `envconfig:"APP_SECRET_CERTIFICATE_ENV_VAR" required:"false"`
-	Metrics                    bool          `envconfig:"METRICS" required:"false" default:"true"`
-	QuotaFloorHard             int           `envconfig:"OCTOSTS_QUOTA_FLOOR_HARD" required:"false" default:"1500"`
-	QuotaFloorSoft             int           `envconfig:"OCTOSTS_QUOTA_FLOOR_SOFT" required:"false" default:"15000"`
-	QuotaStaleAfter            time.Duration `envconfig:"OCTOSTS_QUOTA_STALE" required:"false" default:"5m"`
+	Port                       int      `envconfig:"PORT" required:"true"`
+	KMSKeys                    []string `envconfig:"KMS_KEYS" required:"false"`
+	AppIDs                     []int64  `envconfig:"GITHUB_APP_IDS" required:"true"`
+	AppSecretCertificateFile   string   `envconfig:"APP_SECRET_CERTIFICATE_FILE" required:"false"`
+	AppSecretCertificateEnvVar string   `envconfig:"APP_SECRET_CERTIFICATE_ENV_VAR" required:"false"`
+	Metrics                    bool     `envconfig:"METRICS" required:"false" default:"true"`
+	// QuotaFloorHard / QuotaFloorSoft tune the three-tier capacity-aware
+	// picker in pkg/ghinstall. Defaults target GitHub's default 15,000/hr
+	// installation rate-limit cap: drop out of the preferred pool below
+	// ~33% remaining (5,000), exclude entirely below ~10% remaining (1,500).
+	// Operators with elevated installation tiers (50,000/hr) should raise
+	// SOFT to roughly the lowest cap in their pool so high-cap installs are
+	// preferred while they have at least one low-cap-worth of headroom.
+	QuotaFloorHard  int           `envconfig:"OCTOSTS_QUOTA_FLOOR_HARD" required:"false" default:"1500"`
+	QuotaFloorSoft  int           `envconfig:"OCTOSTS_QUOTA_FLOOR_SOFT" required:"false" default:"5000"`
+	QuotaStaleAfter time.Duration `envconfig:"OCTOSTS_QUOTA_STALE" required:"false" default:"5m"`
 }
 
 type EnvConfigApp struct {

--- a/pkg/envconfig/envconfig.go
+++ b/pkg/envconfig/envconfig.go
@@ -6,17 +6,21 @@ package envconfig
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/kelseyhightower/envconfig"
 )
 
 type EnvConfig struct {
-	Port                       int      `envconfig:"PORT" required:"true"`
-	KMSKeys                    []string `envconfig:"KMS_KEYS" required:"false"`
-	AppIDs                     []int64  `envconfig:"GITHUB_APP_IDS" required:"true"`
-	AppSecretCertificateFile   string   `envconfig:"APP_SECRET_CERTIFICATE_FILE" required:"false"`
-	AppSecretCertificateEnvVar string   `envconfig:"APP_SECRET_CERTIFICATE_ENV_VAR" required:"false"`
-	Metrics                    bool     `envconfig:"METRICS" required:"false" default:"true"`
+	Port                       int           `envconfig:"PORT" required:"true"`
+	KMSKeys                    []string      `envconfig:"KMS_KEYS" required:"false"`
+	AppIDs                     []int64       `envconfig:"GITHUB_APP_IDS" required:"true"`
+	AppSecretCertificateFile   string        `envconfig:"APP_SECRET_CERTIFICATE_FILE" required:"false"`
+	AppSecretCertificateEnvVar string        `envconfig:"APP_SECRET_CERTIFICATE_ENV_VAR" required:"false"`
+	Metrics                    bool          `envconfig:"METRICS" required:"false" default:"true"`
+	QuotaFloorHard             int           `envconfig:"OCTOSTS_QUOTA_FLOOR_HARD" required:"false" default:"1500"`
+	QuotaFloorSoft             int           `envconfig:"OCTOSTS_QUOTA_FLOOR_SOFT" required:"false" default:"15000"`
+	QuotaStaleAfter            time.Duration `envconfig:"OCTOSTS_QUOTA_STALE" required:"false" default:"5m"`
 }
 
 type EnvConfigApp struct {
@@ -76,6 +80,13 @@ func BaseConfig() (*EnvConfig, error) {
 
 	if len(cfg.KMSKeys) > 0 && len(cfg.KMSKeys) != len(cfg.AppIDs) {
 		return nil, fmt.Errorf("KMS_KEYS length (%d) must match GITHUB_APP_IDS length (%d)", len(cfg.KMSKeys), len(cfg.AppIDs))
+	}
+
+	if cfg.QuotaFloorHard < 0 || cfg.QuotaFloorSoft < 0 {
+		return nil, errors.New("OCTOSTS_QUOTA_FLOOR_HARD and OCTOSTS_QUOTA_FLOOR_SOFT must be non-negative")
+	}
+	if cfg.QuotaFloorSoft < cfg.QuotaFloorHard {
+		return nil, fmt.Errorf("OCTOSTS_QUOTA_FLOOR_SOFT (%d) must be >= OCTOSTS_QUOTA_FLOOR_HARD (%d)", cfg.QuotaFloorSoft, cfg.QuotaFloorHard)
 	}
 
 	return cfg, err

--- a/pkg/envconfig/envconfig_test.go
+++ b/pkg/envconfig/envconfig_test.go
@@ -132,6 +132,24 @@ func TestBaseConfig(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "Zero stale duration rejected",
+			envVars: map[string]string{
+				"PORT":                "8080",
+				"GITHUB_APP_IDS":      "12345678",
+				"OCTOSTS_QUOTA_STALE": "0s",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Negative stale duration rejected",
+			envVars: map[string]string{
+				"PORT":                "8080",
+				"GITHUB_APP_IDS":      "12345678",
+				"OCTOSTS_QUOTA_STALE": "-5m",
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/envconfig/envconfig_test.go
+++ b/pkg/envconfig/envconfig_test.go
@@ -92,6 +92,46 @@ func TestBaseConfig(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "Quota floors valid",
+			envVars: map[string]string{
+				"PORT":                     "8080",
+				"GITHUB_APP_IDS":           "12345678",
+				"OCTOSTS_QUOTA_FLOOR_HARD": "1500",
+				"OCTOSTS_QUOTA_FLOOR_SOFT": "15000",
+				"OCTOSTS_QUOTA_STALE":      "5m",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Quota soft floor must be >= hard floor",
+			envVars: map[string]string{
+				"PORT":                     "8080",
+				"GITHUB_APP_IDS":           "12345678",
+				"OCTOSTS_QUOTA_FLOOR_HARD": "5000",
+				"OCTOSTS_QUOTA_FLOOR_SOFT": "1500",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Quota floors equal is allowed",
+			envVars: map[string]string{
+				"PORT":                     "8080",
+				"GITHUB_APP_IDS":           "12345678",
+				"OCTOSTS_QUOTA_FLOOR_HARD": "1500",
+				"OCTOSTS_QUOTA_FLOOR_SOFT": "1500",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Negative floor rejected",
+			envVars: map[string]string{
+				"PORT":                     "8080",
+				"GITHUB_APP_IDS":           "12345678",
+				"OCTOSTS_QUOTA_FLOOR_HARD": "-1",
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/ghinstall/ghinstall.go
+++ b/pkg/ghinstall/ghinstall.go
@@ -79,10 +79,11 @@ func (m *manager) Get(ctx context.Context, owner, _, _ string) (*ghinstallation.
 	return nil, 0, status.Errorf(codes.NotFound, "no installation found for %q", owner)
 }
 
-// QuotaConfig configures three-tier capacity-aware selection. When set on a
-// Manager, the Get path first attempts to pick the install with the most
-// absolute remaining quota among those above the soft floor, falling back
-// through tighter pools before reaching the cold-start strategy.
+// QuotaConfig configures three-tier capacity-aware selection for the
+// roundRobin manager. multiManager intentionally opts out: its consistent
+// (scope, identity) hash exists to preserve GitHub check-run ownership
+// across token rotations, and that determinism is incompatible with
+// capacity-aware re-routing.
 type QuotaConfig struct {
 	// Store is the source of per-installation remaining-quota snapshots,
 	// populated by the ghtransport response tap. May be nil to disable
@@ -159,7 +160,6 @@ func (rr *roundRobin) Get(ctx context.Context, owner, scope, identity string) (*
 
 type multiManager struct {
 	managers []Manager
-	quota    *QuotaConfig
 }
 
 // NewMultiManager creates a Manager that distributes requests across the given
@@ -169,6 +169,8 @@ type multiManager struct {
 // GitHub App. This is required because GitHub check runs can only be updated
 // by the app that created them — non-deterministic app selection causes 403
 // errors when a token refresh or process restart lands on a different app.
+// Capacity-aware fairshare (QuotaConfig) intentionally does not apply here:
+// the determinism is the contract.
 //
 // Load is distributed across apps by owner: different owners hash to different
 // apps. If the selected app is not installed for an owner, the remaining apps
@@ -180,32 +182,7 @@ func NewMultiManager(managers []Manager) Manager {
 	return &multiManager{managers: managers}
 }
 
-// NewMultiManagerWithQuota is NewMultiManager with capacity-aware selection
-// layered on top. When quota data is available, requests are routed via
-// argmax(remaining) within the highest non-empty tier (comfortable, tight,
-// or last-resort). When no candidate has quota data, consistent hashing is
-// used.
-//
-// Note that this trades the strict (scope, identity) determinism of
-// consistent hashing for capacity-aware distribution. Callers that hold a
-// minted token across many GitHub calls (e.g. via oauth2.ReuseTokenSource)
-// retain stickiness within the lifetime of a single token, but successive
-// Exchange calls for the same (scope, identity) may route to different
-// Apps and cannot update GitHub check runs created by a previous App.
-// Operators who require strict check-run ownership preservation should
-// continue to use NewMultiManager.
-func NewMultiManagerWithQuota(managers []Manager, q *QuotaConfig) Manager {
-	if len(managers) == 0 {
-		panic("ghinstall: NewMultiManagerWithQuota requires at least one manager")
-	}
-	return &multiManager{managers: managers, quota: q}
-}
-
 func (rr *multiManager) Get(ctx context.Context, owner, scope, identity string) (*ghinstallation.AppsTransport, int64, error) {
-	if atr, id, ok := pickByQuota(ctx, rr.managers, owner, scope, identity, rr.quota); ok {
-		return atr, id, nil
-	}
-
 	// Consistent hashing on (scope, identity): the same requester acting on
 	// the same repo always maps to the same GitHub App. This is required
 	// because GitHub check runs can only be updated by the app that created

--- a/pkg/ghinstall/ghinstall.go
+++ b/pkg/ghinstall/ghinstall.go
@@ -99,8 +99,12 @@ type QuotaConfig struct {
 }
 
 // roundRobin distributes requests across managers using an atomic counter as
-// the cold-start strategy. When a non-nil QuotaConfig is provided, requests
-// first try capacity-aware selection.
+// the cold-start strategy, optionally with capacity-aware selection layered
+// on top via QuotaConfig. It does not use scope or identity for routing, so
+// different callers with the same (scope, identity) may land on different
+// apps. Use this only when the caller's trust policy does not require
+// checks:write — i.e., when there is no GitHub check-run ownership
+// constraint.
 type roundRobin struct {
 	managers []Manager
 	counter  atomic.Uint64
@@ -108,7 +112,12 @@ type roundRobin struct {
 }
 
 // NewRoundRobin creates a Manager that distributes requests across the given
-// managers using an atomic round-robin counter on cold start.
+// managers using an atomic round-robin counter.
+//
+// Use this when the trust policy does NOT require checks:write. For policies
+// that do require checks:write, use NewMultiManager (consistent hashing) so
+// that the same GitHub App always handles a given (scope, identity) and can
+// therefore update check runs it previously created.
 func NewRoundRobin(managers []Manager) Manager {
 	if len(managers) == 0 {
 		panic("ghinstall: NewRoundRobin requires at least one manager")
@@ -121,6 +130,10 @@ func NewRoundRobin(managers []Manager) Manager {
 // argmax(remaining) within the highest non-empty tier (comfortable, tight,
 // or last-resort). When no candidate has quota data, the atomic counter is
 // used.
+//
+// Same checks:write caveat as NewRoundRobin: capacity-aware re-routing is
+// non-deterministic across (scope, identity) and will break check-run
+// ownership. Use NewMultiManager for trust policies that grant checks:write.
 func NewRoundRobinWithQuota(managers []Manager, q *QuotaConfig) Manager {
 	if len(managers) == 0 {
 		panic("ghinstall: NewRoundRobinWithQuota requires at least one manager")
@@ -239,6 +252,9 @@ func pickByQuota(ctx context.Context, managers []Manager, owner, scope, identity
 	if q == nil || q.Store == nil {
 		return nil, 0, false
 	}
+	if ctx.Err() != nil {
+		return nil, 0, false
+	}
 
 	type cand struct {
 		atr       *ghinstallation.AppsTransport
@@ -270,13 +286,27 @@ func pickByQuota(ctx context.Context, managers []Manager, owner, scope, identity
 	}
 
 	pickFromPool := func(pool []cand) cand {
+		// Find the max remaining, then break ties with a stable hash of
+		// (scope, identity) so equal-quota installs share load deterministically
+		// per request rather than always sending bursts to pool[0].
 		best := pool[0]
 		for _, c := range pool[1:] {
 			if c.remaining > best.remaining {
 				best = c
 			}
 		}
-		return best
+		var tied []cand
+		for _, c := range pool {
+			if c.remaining == best.remaining {
+				tied = append(tied, c)
+			}
+		}
+		if len(tied) == 1 {
+			return tied[0]
+		}
+		h := fnv.New32a()
+		_, _ = h.Write([]byte(scope + ":" + identity))
+		return tied[int(h.Sum32())%len(tied)]
 	}
 
 	var comfortable, tight, lastResort []cand

--- a/pkg/ghinstall/ghinstall.go
+++ b/pkg/ghinstall/ghinstall.go
@@ -79,23 +79,35 @@ func (m *manager) Get(ctx context.Context, owner, _, _ string) (*ghinstallation.
 	return nil, 0, status.Errorf(codes.NotFound, "no installation found for %q", owner)
 }
 
-// roundRobin distributes requests across managers using an atomic counter.
-// It does not use scope or identity for routing, so different callers with
-// the same (scope, identity) may land on different apps. Use this only when
-// the caller's trust policy does not require checks:write — i.e., when there
-// is no GitHub check-run ownership constraint.
+// QuotaConfig configures three-tier capacity-aware selection. When set on a
+// Manager, the Get path first attempts to pick the install with the most
+// absolute remaining quota among those above the soft floor, falling back
+// through tighter pools before reaching the cold-start strategy.
+type QuotaConfig struct {
+	// Store is the source of per-installation remaining-quota snapshots,
+	// populated by the ghtransport response tap. May be nil to disable
+	// quota-aware selection.
+	Store *QuotaStore
+	// SoftFloor: remaining < SoftFloor demotes an install out of the
+	// preferred pool. Heavy/sticky callers landing on the preferred pool
+	// always have at least SoftFloor headroom.
+	SoftFloor int
+	// HardFloor: remaining < HardFloor excludes an install entirely except
+	// when every install is below it ("last resort").
+	HardFloor int
+}
+
+// roundRobin distributes requests across managers using an atomic counter as
+// the cold-start strategy. When a non-nil QuotaConfig is provided, requests
+// first try capacity-aware selection.
 type roundRobin struct {
 	managers []Manager
 	counter  atomic.Uint64
+	quota    *QuotaConfig
 }
 
 // NewRoundRobin creates a Manager that distributes requests across the given
-// managers using an atomic round-robin counter.
-//
-// Use this when the trust policy does NOT require checks:write. For policies
-// that do require checks:write, use NewMultiManager (consistent hashing) so
-// that the same GitHub App always handles a given (scope, identity) and can
-// therefore update check runs it previously created.
+// managers using an atomic round-robin counter on cold start.
 func NewRoundRobin(managers []Manager) Manager {
 	if len(managers) == 0 {
 		panic("ghinstall: NewRoundRobin requires at least one manager")
@@ -103,7 +115,23 @@ func NewRoundRobin(managers []Manager) Manager {
 	return &roundRobin{managers: managers}
 }
 
+// NewRoundRobinWithQuota is NewRoundRobin with capacity-aware selection
+// layered on top. When quota data is available, requests are routed via
+// argmax(remaining) within the highest non-empty tier (comfortable, tight,
+// or last-resort). When no candidate has quota data, the atomic counter is
+// used.
+func NewRoundRobinWithQuota(managers []Manager, q *QuotaConfig) Manager {
+	if len(managers) == 0 {
+		panic("ghinstall: NewRoundRobinWithQuota requires at least one manager")
+	}
+	return &roundRobin{managers: managers, quota: q}
+}
+
 func (rr *roundRobin) Get(ctx context.Context, owner, scope, identity string) (*ghinstallation.AppsTransport, int64, error) {
+	if atr, id, ok := pickByQuota(ctx, rr.managers, owner, scope, identity, rr.quota); ok {
+		return atr, id, nil
+	}
+
 	idx := rr.counter.Add(1) % uint64(len(rr.managers))
 
 	atr, id, err := rr.managers[idx].Get(ctx, owner, scope, identity)
@@ -131,6 +159,7 @@ func (rr *roundRobin) Get(ctx context.Context, owner, scope, identity string) (*
 
 type multiManager struct {
 	managers []Manager
+	quota    *QuotaConfig
 }
 
 // NewMultiManager creates a Manager that distributes requests across the given
@@ -151,7 +180,25 @@ func NewMultiManager(managers []Manager) Manager {
 	return &multiManager{managers: managers}
 }
 
+// NewMultiManagerWithQuota is NewMultiManager with capacity-aware selection
+// layered on top. When quota data is available, requests are routed via
+// argmax(remaining) within the highest non-empty tier (comfortable, tight,
+// or last-resort). When no candidate has quota data, consistent hashing is
+// used. Within a single oauth2.ReuseTokenSource window (~55 min) callers
+// reuse a minted token, which provides natural per-window stickiness; quota
+// drift between windows is acceptable.
+func NewMultiManagerWithQuota(managers []Manager, q *QuotaConfig) Manager {
+	if len(managers) == 0 {
+		panic("ghinstall: NewMultiManagerWithQuota requires at least one manager")
+	}
+	return &multiManager{managers: managers, quota: q}
+}
+
 func (rr *multiManager) Get(ctx context.Context, owner, scope, identity string) (*ghinstallation.AppsTransport, int64, error) {
+	if atr, id, ok := pickByQuota(ctx, rr.managers, owner, scope, identity, rr.quota); ok {
+		return atr, id, nil
+	}
+
 	// Consistent hashing on (scope, identity): the same requester acting on
 	// the same repo always maps to the same GitHub App. This is required
 	// because GitHub check runs can only be updated by the app that created
@@ -185,4 +232,96 @@ func (rr *multiManager) Get(ctx context.Context, owner, scope, identity string) 
 	}
 
 	return nil, 0, err
+}
+
+// pickByQuota selects an installed manager using three-tier capacity-aware
+// fairshare. Returns ok=false when quota selection cannot proceed (no config,
+// or no candidate has known quota data) — callers fall back to their cold-
+// start strategy.
+//
+//	comfortable = installs with remaining >= SoftFloor
+//	tight       = installs with HardFloor <= remaining < SoftFloor
+//	last_resort = installs with remaining < HardFloor
+//
+// The first non-empty pool wins; within a pool, argmax(remaining) — the
+// install with the most absolute headroom — is selected. Heavy callers thus
+// land on the install best able to absorb them.
+//
+// A candidate without quota data is included as if it had remaining = limit
+// = SoftFloor + 1 so that newly-seen installs are explored. Until at least
+// one candidate has known data, ok=false to keep cold-start deterministic
+// (FNV hash for multiManager, atomic counter for roundRobin).
+func pickByQuota(ctx context.Context, managers []Manager, owner, scope, identity string, q *QuotaConfig) (*ghinstallation.AppsTransport, int64, bool) {
+	if q == nil || q.Store == nil {
+		return nil, 0, false
+	}
+
+	type cand struct {
+		atr       *ghinstallation.AppsTransport
+		installID int64
+		remaining int
+	}
+
+	var candidates []cand
+	anyKnown := false
+	for _, m := range managers {
+		atr, id, err := m.Get(ctx, owner, scope, identity)
+		if err != nil {
+			continue
+		}
+		rem, _, ok := q.Store.Get(id)
+		if ok {
+			anyKnown = true
+		} else {
+			// Treat unknowns as "just above the soft floor" — they're
+			// candidates worth exploring, but known-comfortable installs
+			// (which have remaining >> SoftFloor early in the hour) win.
+			rem = q.SoftFloor + 1
+		}
+		candidates = append(candidates, cand{atr, id, rem})
+	}
+
+	if !anyKnown || len(candidates) == 0 {
+		return nil, 0, false
+	}
+
+	pickFromPool := func(pool []cand) cand {
+		best := pool[0]
+		for _, c := range pool[1:] {
+			if c.remaining > best.remaining {
+				best = c
+			}
+		}
+		return best
+	}
+
+	var comfortable, tight, lastResort []cand
+	for _, c := range candidates {
+		switch {
+		case c.remaining >= q.SoftFloor:
+			comfortable = append(comfortable, c)
+		case c.remaining >= q.HardFloor:
+			tight = append(tight, c)
+		default:
+			lastResort = append(lastResort, c)
+		}
+	}
+
+	pool := comfortable
+	tier := "comfortable"
+	if len(pool) == 0 {
+		pool = tight
+		tier = "tight"
+	}
+	if len(pool) == 0 {
+		pool = lastResort
+		tier = "last_resort"
+	}
+	if len(pool) == 0 {
+		return nil, 0, false
+	}
+
+	chosen := pickFromPool(pool)
+	clog.DebugContextf(ctx, "ghinstall: quota-aware pick install=%d tier=%s remaining=%d", chosen.installID, tier, chosen.remaining)
+	return chosen.atr, chosen.installID, true
 }

--- a/pkg/ghinstall/ghinstall.go
+++ b/pkg/ghinstall/ghinstall.go
@@ -184,9 +184,16 @@ func NewMultiManager(managers []Manager) Manager {
 // layered on top. When quota data is available, requests are routed via
 // argmax(remaining) within the highest non-empty tier (comfortable, tight,
 // or last-resort). When no candidate has quota data, consistent hashing is
-// used. Within a single oauth2.ReuseTokenSource window (~55 min) callers
-// reuse a minted token, which provides natural per-window stickiness; quota
-// drift between windows is acceptable.
+// used.
+//
+// Note that this trades the strict (scope, identity) determinism of
+// consistent hashing for capacity-aware distribution. Callers that hold a
+// minted token across many GitHub calls (e.g. via oauth2.ReuseTokenSource)
+// retain stickiness within the lifetime of a single token, but successive
+// Exchange calls for the same (scope, identity) may route to different
+// Apps and cannot update GitHub check runs created by a previous App.
+// Operators who require strict check-run ownership preservation should
+// continue to use NewMultiManager.
 func NewMultiManagerWithQuota(managers []Manager, q *QuotaConfig) Manager {
 	if len(managers) == 0 {
 		panic("ghinstall: NewMultiManagerWithQuota requires at least one manager")

--- a/pkg/ghinstall/ghinstall_test.go
+++ b/pkg/ghinstall/ghinstall_test.go
@@ -635,54 +635,6 @@ func TestRoundRobinWithQuotaColdStartFallsBack(t *testing.T) {
 	}
 }
 
-func TestMultiManagerWithQuotaPicksMaxRemaining(t *testing.T) {
-	ctx := context.Background()
-	managers, installIDs := makeManagersWithDistinctInstalls(t, []int64{111, 222, 333})
-
-	store := NewQuotaStore(time.Minute)
-	store.Update(installIDs[0], 8000, 15000)
-	store.Update(installIDs[1], 1200, 15000) // last_resort
-	store.Update(installIDs[2], 30000, 50000)
-
-	mm := NewMultiManagerWithQuota(managers, &QuotaConfig{Store: store, SoftFloor: 15000, HardFloor: 1500})
-
-	// Even though FNV would deterministically pick one slot, capacity-aware
-	// selection must override and pick installIDs[2] (only comfortable one).
-	for i := range 5 {
-		_, id, err := mm.Get(ctx, testOwner, testOwner+"/repo", "ident")
-		if err != nil {
-			t.Fatalf("Get: %v", err)
-		}
-		if id != installIDs[2] {
-			t.Errorf("call %d: picked install %d, want %d (only one in comfortable tier)", i, id, installIDs[2])
-		}
-	}
-}
-
-func TestMultiManagerWithQuotaColdStartUsesFNV(t *testing.T) {
-	ctx := context.Background()
-	managers, _ := makeManagersWithDistinctInstalls(t, []int64{111, 222, 333})
-
-	store := NewQuotaStore(time.Minute)
-	mm := NewMultiManagerWithQuota(managers, &QuotaConfig{Store: store, SoftFloor: 15000, HardFloor: 1500})
-
-	// No quota data yet — must fall back to FNV consistent hashing, which
-	// is deterministic for the same (scope, identity).
-	_, firstID, err := mm.Get(ctx, testOwner, testOwner+"/repo", "ident")
-	if err != nil {
-		t.Fatalf("Get: %v", err)
-	}
-	for i := range 4 {
-		_, id, err := mm.Get(ctx, testOwner, testOwner+"/repo", "ident")
-		if err != nil {
-			t.Fatalf("Get: %v", err)
-		}
-		if id != firstID {
-			t.Errorf("call %d: FNV cold-start fallback should be deterministic, got %d, first was %d", i, id, firstID)
-		}
-	}
-}
-
 func newTestClient(t *testing.T, h http.Handler, appIDs ...int64) *ghinstallation.AppsTransport {
 	t.Helper()
 

--- a/pkg/ghinstall/ghinstall_test.go
+++ b/pkg/ghinstall/ghinstall_test.go
@@ -554,6 +554,135 @@ func TestRoundRobinFallbackNotInstalled(t *testing.T) {
 	}
 }
 
+// testOwner is the GitHub org login used by makeManagersWithDistinctInstalls.
+const testOwner = "my-org"
+
+// makeManagersWithDistinctInstalls builds one Manager per appID, each backed
+// by a test server that reports a unique installation ID for testOwner.
+// Installation IDs are 1000, 1001, ..., 1000+n-1 (parallel to manager index).
+func makeManagersWithDistinctInstalls(t *testing.T, appIDs []int64) ([]Manager, []int64) {
+	t.Helper()
+	managers := make([]Manager, 0, len(appIDs))
+	installIDs := make([]int64, 0, len(appIDs))
+	for i, appID := range appIDs {
+		installID := int64(1000 + i)
+		atr := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/app/installations" {
+				_ = json.NewEncoder(w).Encode([]github.Installation{{
+					ID:      github.Ptr(installID),
+					Account: &github.User{Login: github.Ptr(testOwner)},
+				}})
+				return
+			}
+			w.WriteHeader(http.StatusNotImplemented)
+		}), appID)
+		m, err := New(atr)
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		managers = append(managers, m)
+		installIDs = append(installIDs, installID)
+	}
+	return managers, installIDs
+}
+
+func TestRoundRobinWithQuotaPicksMaxRemaining(t *testing.T) {
+	ctx := context.Background()
+	managers, installIDs := makeManagersWithDistinctInstalls(t, []int64{111, 222, 333})
+
+	store := NewQuotaStore(time.Minute)
+	// Make installIDs[1] the "best" by absolute remaining.
+	store.Update(installIDs[0], 5000, 15000)
+	store.Update(installIDs[1], 49000, 50000)
+	store.Update(installIDs[2], 14000, 50000)
+
+	rrm := NewRoundRobinWithQuota(managers, &QuotaConfig{Store: store, SoftFloor: 15000, HardFloor: 1500})
+
+	// Run multiple times — capacity-aware path must always pick installIDs[1]
+	// while the data is fresh, regardless of the atomic counter.
+	for i := range 5 {
+		_, id, err := rrm.Get(ctx, testOwner, testOwner+"/repo", "ident")
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if id != installIDs[1] {
+			t.Errorf("call %d: picked install %d, want %d (max remaining)", i, id, installIDs[1])
+		}
+	}
+}
+
+func TestRoundRobinWithQuotaColdStartFallsBack(t *testing.T) {
+	ctx := context.Background()
+	managers, installIDs := makeManagersWithDistinctInstalls(t, []int64{111, 222, 333})
+
+	store := NewQuotaStore(time.Minute)
+	rrm := NewRoundRobinWithQuota(managers, &QuotaConfig{Store: store, SoftFloor: 15000, HardFloor: 1500})
+
+	// No quota data yet — must fall back to atomic round-robin and visit
+	// every install across enough calls.
+	seen := make(map[int64]bool)
+	for range 12 {
+		_, id, err := rrm.Get(ctx, testOwner, testOwner+"/repo", "ident")
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		seen[id] = true
+	}
+	for _, want := range installIDs {
+		if !seen[want] {
+			t.Errorf("install %d never picked: cold-start fallback must spread across all installs (seen=%v)", want, seen)
+		}
+	}
+}
+
+func TestMultiManagerWithQuotaPicksMaxRemaining(t *testing.T) {
+	ctx := context.Background()
+	managers, installIDs := makeManagersWithDistinctInstalls(t, []int64{111, 222, 333})
+
+	store := NewQuotaStore(time.Minute)
+	store.Update(installIDs[0], 8000, 15000)
+	store.Update(installIDs[1], 1200, 15000) // last_resort
+	store.Update(installIDs[2], 30000, 50000)
+
+	mm := NewMultiManagerWithQuota(managers, &QuotaConfig{Store: store, SoftFloor: 15000, HardFloor: 1500})
+
+	// Even though FNV would deterministically pick one slot, capacity-aware
+	// selection must override and pick installIDs[2] (only comfortable one).
+	for i := range 5 {
+		_, id, err := mm.Get(ctx, testOwner, testOwner+"/repo", "ident")
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if id != installIDs[2] {
+			t.Errorf("call %d: picked install %d, want %d (only one in comfortable tier)", i, id, installIDs[2])
+		}
+	}
+}
+
+func TestMultiManagerWithQuotaColdStartUsesFNV(t *testing.T) {
+	ctx := context.Background()
+	managers, _ := makeManagersWithDistinctInstalls(t, []int64{111, 222, 333})
+
+	store := NewQuotaStore(time.Minute)
+	mm := NewMultiManagerWithQuota(managers, &QuotaConfig{Store: store, SoftFloor: 15000, HardFloor: 1500})
+
+	// No quota data yet — must fall back to FNV consistent hashing, which
+	// is deterministic for the same (scope, identity).
+	_, firstID, err := mm.Get(ctx, testOwner, testOwner+"/repo", "ident")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	for i := range 4 {
+		_, id, err := mm.Get(ctx, testOwner, testOwner+"/repo", "ident")
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if id != firstID {
+			t.Errorf("call %d: FNV cold-start fallback should be deterministic, got %d, first was %d", i, id, firstID)
+		}
+	}
+}
+
 func newTestClient(t *testing.T, h http.Handler, appIDs ...int64) *ghinstallation.AppsTransport {
 	t.Helper()
 

--- a/pkg/ghinstall/picker_test.go
+++ b/pkg/ghinstall/picker_test.go
@@ -15,13 +15,19 @@ import (
 
 // fakePickerManager implements Manager for picker tests. It returns the
 // configured installID without going through GitHub's installations API,
-// which lets the picker tests focus on tier selection logic only.
+// which lets the picker tests focus on tier selection logic only. When
+// getErr is set, Get returns that error instead of the default NotFound or
+// success path — used to model a misconfigured / failing manager.
 type fakePickerManager struct {
 	installID int64
 	installed bool
+	getErr    error
 }
 
 func (f *fakePickerManager) Get(_ context.Context, _, _, _ string) (*ghinstallation.AppsTransport, int64, error) {
+	if f.getErr != nil {
+		return nil, 0, f.getErr
+	}
 	if !f.installed {
 		return nil, 0, status.Error(codes.NotFound, "not installed")
 	}
@@ -225,5 +231,83 @@ func TestPickByQuota50kBelowSoftFloorTakesBackseat(t *testing.T) {
 	}
 	if id != 2 {
 		t.Errorf("picked install %d, want 2 (comfortable beats tight even when tight has more cap)", id)
+	}
+}
+
+func TestPickByQuotaCanceledContext(t *testing.T) {
+	// A canceled context must short-circuit the picker before it touches
+	// any manager — the caller's atomic-counter fallback will then surface
+	// context.Canceled naturally on the single fallback Get call.
+	managers := newFakePickerManagers(1, 2, 3)
+	store := NewQuotaStore(time.Minute)
+	store.Update(1, 5000, 15000)
+	store.Update(2, 12000, 15000)
+	store.Update(3, 30000, 50000)
+
+	cfg := &QuotaConfig{Store: store, SoftFloor: 15000, HardFloor: 1500}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, _, ok := pickByQuota(ctx, managers, "owner", "owner/repo", "id", cfg); ok {
+		t.Errorf("canceled context: ok = true, want false (must short-circuit)")
+	}
+}
+
+func TestPickByQuotaTieBreakHashesByIdentity(t *testing.T) {
+	// All four installs tied at exactly cap. Tie-break must be:
+	//   - stable per (scope, identity): repeated calls with the same identity
+	//     return the same install
+	//   - distributed across the tied pool over a spread of identities: not
+	//     every identity collapses to pool[0]
+	managers := newFakePickerManagers(1, 2, 3, 4)
+	store := NewQuotaStore(time.Minute)
+	for _, id := range []int64{1, 2, 3, 4} {
+		store.Update(id, 50000, 50000)
+	}
+	cfg := &QuotaConfig{Store: store, SoftFloor: 15000, HardFloor: 1500}
+
+	_, idA, _ := pickByQuota(context.Background(), managers, "owner", "owner/repo", "alice", cfg)
+	for range 5 {
+		_, id, _ := pickByQuota(context.Background(), managers, "owner", "owner/repo", "alice", cfg)
+		if id != idA {
+			t.Errorf("same identity, different pick: %d vs %d", id, idA)
+		}
+	}
+
+	picks := make(map[int64]bool)
+	for _, ident := range []string{"alice", "bob", "carol", "dave", "eve", "frank", "grace", "heidi"} {
+		_, id, _ := pickByQuota(context.Background(), managers, "owner", "owner/repo", ident, cfg)
+		picks[id] = true
+	}
+	if len(picks) < 2 {
+		t.Errorf("tied pool of 4 produced only %d distinct picks across 8 identities: %v", len(picks), picks)
+	}
+}
+
+func TestPickByQuotaSkipsNonNotFoundErrors(t *testing.T) {
+	// Manager 1 is broken (Internal error). Managers 2 and 3 are healthy.
+	// The picker must skip 1 and route to the best of 2 and 3 by remaining.
+	// This locks in the resilience behavior — a misconfigured app must not
+	// poison every Nth request.
+	managers := []Manager{
+		&fakePickerManager{installID: 1, getErr: status.Error(codes.Internal, "kms borked")},
+		&fakePickerManager{installID: 2, installed: true},
+		&fakePickerManager{installID: 3, installed: true},
+	}
+	store := NewQuotaStore(time.Minute)
+	store.Update(2, 20000, 50000)
+	store.Update(3, 30000, 50000)
+	// install 1 has quota data too, but the manager errors out — picker
+	// must never reach the Store.Get for it.
+	store.Update(1, 99000, 50000)
+
+	cfg := &QuotaConfig{Store: store, SoftFloor: 15000, HardFloor: 1500}
+	_, id, ok := pickByQuota(context.Background(), managers, "owner", "owner/repo", "id", cfg)
+	if !ok {
+		t.Fatalf("ok = false; expected picker to route around the broken manager")
+	}
+	if id != 3 {
+		t.Errorf("picked install %d, want 3 (max remaining among healthy managers)", id)
 	}
 }

--- a/pkg/ghinstall/picker_test.go
+++ b/pkg/ghinstall/picker_test.go
@@ -1,0 +1,229 @@
+// Copyright 2026 Chainguard, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package ghinstall
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bradleyfalzon/ghinstallation/v2"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// fakePickerManager implements Manager for picker tests. It returns the
+// configured installID without going through GitHub's installations API,
+// which lets the picker tests focus on tier selection logic only.
+type fakePickerManager struct {
+	installID int64
+	installed bool
+}
+
+func (f *fakePickerManager) Get(_ context.Context, _, _, _ string) (*ghinstallation.AppsTransport, int64, error) {
+	if !f.installed {
+		return nil, 0, status.Error(codes.NotFound, "not installed")
+	}
+	return nil, f.installID, nil
+}
+
+func newFakePickerManagers(installIDs ...int64) []Manager {
+	out := make([]Manager, len(installIDs))
+	for i, id := range installIDs {
+		out[i] = &fakePickerManager{installID: id, installed: true}
+	}
+	return out
+}
+
+func TestPickByQuotaNilConfig(t *testing.T) {
+	managers := newFakePickerManagers(1, 2, 3)
+	if _, _, ok := pickByQuota(context.Background(), managers, "owner", "owner/repo", "id", nil); ok {
+		t.Errorf("nil config: ok = true, want false")
+	}
+}
+
+func TestPickByQuotaNilStore(t *testing.T) {
+	managers := newFakePickerManagers(1, 2, 3)
+	cfg := &QuotaConfig{Store: nil, SoftFloor: 15000, HardFloor: 1500}
+	if _, _, ok := pickByQuota(context.Background(), managers, "owner", "owner/repo", "id", cfg); ok {
+		t.Errorf("nil store: ok = true, want false")
+	}
+}
+
+func TestPickByQuotaColdStartFallsThrough(t *testing.T) {
+	// All installs unknown → must report ok=false so the caller falls back
+	// to its cold-start strategy (FNV / atomic counter).
+	managers := newFakePickerManagers(1, 2, 3)
+	store := NewQuotaStore(time.Minute)
+	cfg := &QuotaConfig{Store: store, SoftFloor: 15000, HardFloor: 1500}
+
+	if _, _, ok := pickByQuota(context.Background(), managers, "owner", "owner/repo", "id", cfg); ok {
+		t.Errorf("cold start: ok = true, want false (no install has data)")
+	}
+}
+
+func TestPickByQuotaSomeKnownPicksKnownComfortable(t *testing.T) {
+	// One install has known headroom comfortably above the soft floor; the
+	// other two are unknown (treated as soft+1). The known install must win
+	// because its remaining is greater.
+	managers := newFakePickerManagers(1, 2, 3)
+	store := NewQuotaStore(time.Minute)
+	store.Update(2, 49000, 50000) // install 2 known, well above SoftFloor
+
+	cfg := &QuotaConfig{Store: store, SoftFloor: 15000, HardFloor: 1500}
+	_, id, ok := pickByQuota(context.Background(), managers, "owner", "owner/repo", "id", cfg)
+	if !ok {
+		t.Fatalf("ok = false, want true (one install has data)")
+	}
+	if id != 2 {
+		t.Errorf("picked install %d, want 2 (49000 > soft+1 = 15001)", id)
+	}
+}
+
+func TestPickByQuotaArgmaxRemainingPrefers50k(t *testing.T) {
+	// 50k install at full vs 15k install at full — argmax(remaining) picks
+	// the 50k. This is the core "heavy caller lands on the install with
+	// most absolute room" property.
+	managers := newFakePickerManagers(1, 2)
+	store := NewQuotaStore(time.Minute)
+	store.Update(1, 15000, 15000) // 15k tier full
+	store.Update(2, 50000, 50000) // 50k tier full
+
+	cfg := &QuotaConfig{Store: store, SoftFloor: 15000, HardFloor: 1500}
+	_, id, ok := pickByQuota(context.Background(), managers, "owner", "owner/repo", "id", cfg)
+	if !ok {
+		t.Fatalf("ok = false")
+	}
+	if id != 2 {
+		t.Errorf("picked install %d, want 2 (50k beats 15k by absolute remaining)", id)
+	}
+}
+
+func TestPickByQuotaPrefersComfortableOverTight(t *testing.T) {
+	// install 1: tight (3000 remaining)
+	// install 2: comfortable (16000 remaining)
+	// Picker must choose 2 even though 1 also has data.
+	managers := newFakePickerManagers(1, 2)
+	store := NewQuotaStore(time.Minute)
+	store.Update(1, 3000, 15000)
+	store.Update(2, 16000, 50000)
+
+	cfg := &QuotaConfig{Store: store, SoftFloor: 15000, HardFloor: 1500}
+	_, id, ok := pickByQuota(context.Background(), managers, "owner", "owner/repo", "id", cfg)
+	if !ok {
+		t.Fatalf("ok = false")
+	}
+	if id != 2 {
+		t.Errorf("picked install %d, want 2 (comfortable tier wins over tight)", id)
+	}
+}
+
+func TestPickByQuotaAllTightPicksMaxRemaining(t *testing.T) {
+	// All installs in tight tier — argmax(remaining) picks the highest.
+	managers := newFakePickerManagers(1, 2, 3)
+	store := NewQuotaStore(time.Minute)
+	store.Update(1, 3000, 15000)
+	store.Update(2, 8000, 50000) // tight (below soft floor of 15k) but most slack
+	store.Update(3, 5000, 15000)
+
+	cfg := &QuotaConfig{Store: store, SoftFloor: 15000, HardFloor: 1500}
+	_, id, ok := pickByQuota(context.Background(), managers, "owner", "owner/repo", "id", cfg)
+	if !ok {
+		t.Fatalf("ok = false")
+	}
+	if id != 2 {
+		t.Errorf("picked install %d, want 2 (max remaining 8000 in tight tier)", id)
+	}
+}
+
+func TestPickByQuotaAllLastResortStillReturns(t *testing.T) {
+	// All installs below hard floor — must still pick the best one rather
+	// than refusing service.
+	managers := newFakePickerManagers(1, 2, 3)
+	store := NewQuotaStore(time.Minute)
+	store.Update(1, 100, 15000)
+	store.Update(2, 800, 15000) // most remaining (still <hardFloor)
+	store.Update(3, 50, 50000)
+
+	cfg := &QuotaConfig{Store: store, SoftFloor: 15000, HardFloor: 1500}
+	_, id, ok := pickByQuota(context.Background(), managers, "owner", "owner/repo", "id", cfg)
+	if !ok {
+		t.Fatalf("ok = false")
+	}
+	if id != 2 {
+		t.Errorf("picked install %d, want 2 (max remaining among last-resort)", id)
+	}
+}
+
+func TestPickByQuotaSkipsNotInstalled(t *testing.T) {
+	// Two installed managers and one not-installed (returns NotFound).
+	managers := []Manager{
+		&fakePickerManager{installID: 1, installed: true},
+		&fakePickerManager{installID: 2, installed: false},
+		&fakePickerManager{installID: 3, installed: true},
+	}
+	store := NewQuotaStore(time.Minute)
+	store.Update(1, 20000, 50000)
+	store.Update(3, 30000, 50000)
+	// install 2 has data too, but the manager returns NotFound for the owner
+	store.Update(2, 99000, 50000)
+
+	cfg := &QuotaConfig{Store: store, SoftFloor: 15000, HardFloor: 1500}
+	_, id, ok := pickByQuota(context.Background(), managers, "owner", "owner/repo", "id", cfg)
+	if !ok {
+		t.Fatalf("ok = false")
+	}
+	if id != 3 {
+		t.Errorf("picked install %d, want 3 (max remaining among installed)", id)
+	}
+}
+
+func TestPickByQuotaTieBreakingDeterministic(t *testing.T) {
+	// Two 50k installs both fresh at 50000 remaining (hour reset). The
+	// picker must return a deterministic answer, and over many calls (with
+	// the chosen install's remaining decremented), traffic must alternate
+	// between them — neither install should be starved.
+	managers := newFakePickerManagers(1, 2)
+	store := NewQuotaStore(time.Minute)
+
+	cfg := &QuotaConfig{Store: store, SoftFloor: 15000, HardFloor: 1500}
+
+	chosen := map[int64]int{}
+	rem := map[int64]int{1: 50000, 2: 50000}
+	for range 100 {
+		store.Update(1, rem[1], 50000)
+		store.Update(2, rem[2], 50000)
+		_, id, ok := pickByQuota(context.Background(), managers, "owner", "owner/repo", "id", cfg)
+		if !ok {
+			t.Fatalf("ok = false")
+		}
+		chosen[id]++
+		rem[id] -= 30
+	}
+
+	// Both installs should have been picked roughly equally.
+	if chosen[1] < 40 || chosen[2] < 40 {
+		t.Errorf("alternation broken: install 1 picked %d times, install 2 picked %d times (want ~50 each)", chosen[1], chosen[2])
+	}
+}
+
+func TestPickByQuota50kBelowSoftFloorTakesBackseat(t *testing.T) {
+	// 50k install drained to 14000 (below the 15k soft floor) → tight tier.
+	// 15k install fresh at 15000 (== soft floor) → comfortable tier.
+	// Picker prefers the comfortable 15k over the tight 50k, demonstrating
+	// the "stop preferring 50k when it drops below 15k remaining" rule.
+	managers := newFakePickerManagers(1, 2)
+	store := NewQuotaStore(time.Minute)
+	store.Update(1, 14000, 50000) // tight: was preferred, now dipped below soft
+	store.Update(2, 15000, 15000) // comfortable: at boundary
+
+	cfg := &QuotaConfig{Store: store, SoftFloor: 15000, HardFloor: 1500}
+	_, id, ok := pickByQuota(context.Background(), managers, "owner", "owner/repo", "id", cfg)
+	if !ok {
+		t.Fatalf("ok = false")
+	}
+	if id != 2 {
+		t.Errorf("picked install %d, want 2 (comfortable beats tight even when tight has more cap)", id)
+	}
+}

--- a/pkg/ghinstall/quota.go
+++ b/pkg/ghinstall/quota.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Chainguard, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package ghinstall
+
+import (
+	"sync"
+	"time"
+)
+
+// QuotaStore tracks per-installation rate-limit state, populated by a
+// transport-layer tap on GitHub responses (see pkg/ghtransport).
+//
+// The store is a hint, not a source of truth: callers must tolerate missing
+// or stale entries by falling back to capacity-blind selection. Entries older
+// than the configured TTL are reported as missing.
+type QuotaStore struct {
+	mu    sync.RWMutex
+	state map[int64]quotaSnapshot
+	ttl   time.Duration
+}
+
+type quotaSnapshot struct {
+	remaining int
+	limit     int
+	updatedAt time.Time
+}
+
+// NewQuotaStore creates a quota store. Snapshots older than ttl are treated
+// as missing.
+func NewQuotaStore(ttl time.Duration) *QuotaStore {
+	return &QuotaStore{
+		state: make(map[int64]quotaSnapshot),
+		ttl:   ttl,
+	}
+}
+
+// Update records a fresh quota snapshot for installID.
+func (q *QuotaStore) Update(installID int64, remaining, limit int) {
+	if installID == 0 || limit <= 0 {
+		return
+	}
+	q.mu.Lock()
+	q.state[installID] = quotaSnapshot{remaining, limit, time.Now()}
+	q.mu.Unlock()
+}
+
+// Get returns the most recent snapshot for installID. ok is false if no
+// snapshot exists or if the snapshot is older than the configured TTL.
+func (q *QuotaStore) Get(installID int64) (remaining, limit int, ok bool) {
+	q.mu.RLock()
+	s, exists := q.state[installID]
+	q.mu.RUnlock()
+	if !exists {
+		return 0, 0, false
+	}
+	if time.Since(s.updatedAt) > q.ttl {
+		return 0, 0, false
+	}
+	return s.remaining, s.limit, true
+}

--- a/pkg/ghinstall/quota_test.go
+++ b/pkg/ghinstall/quota_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Chainguard, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package ghinstall
+
+import (
+	"testing"
+	"time"
+)
+
+func TestQuotaStoreGetMissing(t *testing.T) {
+	q := NewQuotaStore(time.Minute)
+	if _, _, ok := q.Get(123); ok {
+		t.Errorf("Get on empty store: ok = true, want false")
+	}
+}
+
+func TestQuotaStoreUpdateGet(t *testing.T) {
+	q := NewQuotaStore(time.Minute)
+	q.Update(123, 4500, 15000)
+
+	rem, lim, ok := q.Get(123)
+	if !ok {
+		t.Fatalf("Get after Update: ok = false, want true")
+	}
+	if rem != 4500 || lim != 15000 {
+		t.Errorf("Get returned (%d, %d), want (4500, 15000)", rem, lim)
+	}
+}
+
+func TestQuotaStoreOverwrite(t *testing.T) {
+	q := NewQuotaStore(time.Minute)
+	q.Update(123, 1000, 15000)
+	q.Update(123, 9999, 15000)
+
+	rem, _, ok := q.Get(123)
+	if !ok {
+		t.Fatalf("Get: ok = false")
+	}
+	if rem != 9999 {
+		t.Errorf("Get remaining = %d, want 9999 (latest)", rem)
+	}
+}
+
+func TestQuotaStoreStale(t *testing.T) {
+	q := NewQuotaStore(50 * time.Millisecond)
+	q.Update(123, 4500, 15000)
+
+	// Fresh — should be visible.
+	if _, _, ok := q.Get(123); !ok {
+		t.Fatalf("immediate Get: ok = false, want true")
+	}
+
+	// Wait past TTL.
+	time.Sleep(80 * time.Millisecond)
+	if _, _, ok := q.Get(123); ok {
+		t.Errorf("Get past TTL: ok = true, want false")
+	}
+}
+
+func TestQuotaStoreIgnoreInvalid(t *testing.T) {
+	q := NewQuotaStore(time.Minute)
+	// installID 0 is invalid (uninitialized) — must be a no-op.
+	q.Update(0, 5000, 15000)
+	if _, _, ok := q.Get(0); ok {
+		t.Errorf("Get(0) after Update(0, ...): ok = true, want false (must ignore)")
+	}
+
+	// limit <= 0 is invalid — must be a no-op.
+	q.Update(123, 5000, 0)
+	if _, _, ok := q.Get(123); ok {
+		t.Errorf("Get(123) after Update with limit=0: ok = true, want false (must ignore)")
+	}
+}

--- a/pkg/ghtransport/ghtransport.go
+++ b/pkg/ghtransport/ghtransport.go
@@ -7,28 +7,70 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	kms "cloud.google.com/go/kms/apiv1"
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	metrics "github.com/chainguard-dev/terraform-infra-common/pkg/httpmetrics"
 	envConfig "github.com/octo-sts/app/pkg/envconfig"
 	"github.com/octo-sts/app/pkg/gcpkms"
+	"github.com/octo-sts/app/pkg/ghinstall"
 )
+
+type ctxKey int
+
+const installIDCtxKey ctxKey = 0
 
 // EnrichContext adds GitHub App and installation ID values to the context so
 // that the httpmetrics transport can label rate-limit metrics with the specific
-// installation consuming quota.
+// installation consuming quota, and so that the quota tap (if configured) can
+// attribute X-RateLimit-Remaining headers to the right installation.
 func EnrichContext(ctx context.Context, appID, installationID int64) context.Context {
 	ctx = metrics.WithGitHubAppID(ctx, appID)
 	ctx = metrics.WithGitHubInstallationID(ctx, installationID)
+	ctx = context.WithValue(ctx, installIDCtxKey, installationID)
 	return ctx
 }
 
-func New(ctx context.Context, appID int64, kmsKey string, env *envConfig.EnvConfig, kmsClient *kms.KeyManagementClient) (*ghinstallation.AppsTransport, error) {
+func installationIDFromContext(ctx context.Context) int64 {
+	v, _ := ctx.Value(installIDCtxKey).(int64)
+	return v
+}
+
+// quotaTap is a RoundTripper that updates a QuotaStore from each response's
+// X-RateLimit-Remaining / X-RateLimit-Limit headers. The (app_id,
+// installation_id) labels populated by EnrichContext are used to attribute
+// the snapshot to the correct installation.
+type quotaTap struct {
+	inner http.RoundTripper
+	store *ghinstall.QuotaStore
+}
+
+func (q *quotaTap) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := q.inner.RoundTrip(req)
+	if err != nil || resp == nil {
+		return resp, err
+	}
+	if installID := installationIDFromContext(req.Context()); installID != 0 {
+		remaining, rerr := strconv.Atoi(resp.Header.Get("X-RateLimit-Remaining"))
+		limit, lerr := strconv.Atoi(resp.Header.Get("X-RateLimit-Limit"))
+		if rerr == nil && lerr == nil && limit > 0 {
+			q.store.Update(installID, remaining, limit)
+		}
+	}
+	return resp, err
+}
+
+// New creates a GitHub AppsTransport. If quota is non-nil, response headers
+// are also tapped into the QuotaStore for capacity-aware routing decisions.
+func New(ctx context.Context, appID int64, kmsKey string, env *envConfig.EnvConfig, kmsClient *kms.KeyManagementClient, quota *ghinstall.QuotaStore) (*ghinstallation.AppsTransport, error) {
 	// Wrap the base HTTP transport so every GitHub response's X-RateLimit-*
 	// headers populate the github_rate_limit_* metrics with the app_id and
 	// installation_id labels set on the request context by EnrichContext.
 	base := metrics.WrapTransport(http.DefaultTransport)
+	if quota != nil {
+		base = &quotaTap{inner: base, store: quota}
+	}
 
 	switch {
 	case env.AppSecretCertificateEnvVar != "":

--- a/pkg/ghtransport/ghtransport_test.go
+++ b/pkg/ghtransport/ghtransport_test.go
@@ -13,16 +13,69 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	kms "cloud.google.com/go/kms/apiv1"
 	"github.com/octo-sts/app/pkg/envconfig"
+	"github.com/octo-sts/app/pkg/ghinstall"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
+
+func TestQuotaTapPopulatesStore(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-RateLimit-Remaining", "8421")
+		w.Header().Set("X-RateLimit-Limit", "15000")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	store := ghinstall.NewQuotaStore(time.Minute)
+	tap := &quotaTap{inner: http.DefaultTransport, store: store}
+	client := &http.Client{Transport: tap}
+
+	const installID = int64(987654)
+	req, err := http.NewRequestWithContext(EnrichContext(context.Background(), 12345, installID), http.MethodGet, srv.URL, nil)
+	assert.NoError(t, err)
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+	resp.Body.Close()
+
+	rem, lim, ok := store.Get(installID)
+	assert.True(t, ok, "quota store should be populated after a tapped response")
+	assert.Equal(t, 8421, rem)
+	assert.Equal(t, 15000, lim)
+}
+
+func TestQuotaTapIgnoresMissingContext(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-RateLimit-Remaining", "1234")
+		w.Header().Set("X-RateLimit-Limit", "15000")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	store := ghinstall.NewQuotaStore(time.Minute)
+	tap := &quotaTap{inner: http.DefaultTransport, store: store}
+	client := &http.Client{Transport: tap}
+
+	// Plain context with no EnrichContext → no installID → no store update.
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	assert.NoError(t, err)
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+	resp.Body.Close()
+
+	if _, _, ok := store.Get(0); ok {
+		t.Errorf("store unexpectedly populated for installID=0")
+	}
+}
 
 func TestGCPKMS(t *testing.T) {
 	ctx := context.Background()
@@ -42,7 +95,7 @@ func TestGCPKMS(t *testing.T) {
 
 	kmsClient := generateKMSClient(ctx, t)
 	for i, appID := range testConfig.AppIDs {
-		transport, err := New(ctx, appID, testConfig.KMSKeys[i], testConfig, kmsClient)
+		transport, err := New(ctx, appID, testConfig.KMSKeys[i], testConfig, kmsClient, nil)
 		assert.NoError(t, err)
 		assert.NotNil(t, transport)
 	}
@@ -60,7 +113,7 @@ func TestCertEnvVar(t *testing.T) {
 
 	kmsClient := generateKMSClient(ctx, t)
 	for _, appID := range testConfig.AppIDs {
-		transport, err := New(ctx, appID, "", testConfig, kmsClient)
+		transport, err := New(ctx, appID, "", testConfig, kmsClient, nil)
 		assert.NoError(t, err)
 		assert.NotNil(t, transport)
 	}
@@ -78,7 +131,7 @@ func TestCertFile(t *testing.T) {
 
 	kmsClient := generateKMSClient(ctx, t)
 	for _, appID := range testConfig.AppIDs {
-		transport, err := New(ctx, appID, "", testConfig, kmsClient)
+		transport, err := New(ctx, appID, "", testConfig, kmsClient, nil)
 		assert.NoError(t, err)
 		assert.NotNil(t, transport)
 	}


### PR DESCRIPTION
## Summary

Adds capacity-aware fairshare selection to the `roundRobin` manager. When quota data is available, requests route via three-tier waterfall — `comfortable` (`remaining ≥ SoftFloor`) → `tight` (`HardFloor ≤ remaining < SoftFloor`) → `last_resort` (`remaining < HardFloor`) — picking by `argmax(remaining)` within the highest non-empty pool.

`multiManager` is intentionally **not** changed: its consistent (scope, identity) hashing is the contract that preserves GitHub check-run ownership across token rotations, and any non-deterministic re-routing would cause 403s on check-run updates after a token refresh lands on a different App.

Quota state is sourced from `X-RateLimit-Remaining` / `X-RateLimit-Limit` headers via a transport-layer tap. Cold start (no quota data) falls back to the existing atomic-counter behavior.

## Why

When configured Apps have different installation rate-limit caps, the round-robin path treats them as equal slots — so high-cap installations can sit nearly idle while low-cap installations exhaust. `argmax(remaining)` (absolute, not ratio) routes heavy callers to the installation with the most absolute headroom, naturally absorbing more traffic on high-cap installations until they near parity with the rest.

## Tests

- Quota store: fresh / stale / overwrite / invalid input.
- Picker: nil-config / nil-store / cold-start / mixed-known / argmax / tier waterfall / not-installed skip / soft-floor demotion / tie-break alternation.
- `roundRobin`: integration with quota config, cold-start fallback (atomic counter spreads).
- Transport tap: header parsing, missing-context safety.
- Env config: floor validation.