### PR TITLE
Make sure we only read quota from installations

### DIFF
--- a/pkg/ghtransport/ghtransport.go
+++ b/pkg/ghtransport/ghtransport.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	kms "cloud.google.com/go/kms/apiv1"
 	"github.com/bradleyfalzon/ghinstallation/v2"
@@ -38,9 +39,12 @@ func installationIDFromContext(ctx context.Context) int64 {
 }
 
 // quotaTap is a RoundTripper that updates a QuotaStore from each response's
-// X-RateLimit-Remaining / X-RateLimit-Limit headers. The (app_id,
-// installation_id) labels populated by EnrichContext are used to attribute
-// the snapshot to the correct installation.
+// X-RateLimit-Remaining / X-RateLimit-Limit headers. Only installation-token
+// requests are recorded — app-level JWT requests return the shared app rate
+// limit (~5 000/hr) which would contaminate the per-installation store.
+//
+// ghinstallation uses "token <tok>" for installation tokens and "Bearer <jwt>"
+// for app JWTs, so we gate on the "token " prefix.
 type quotaTap struct {
 	inner http.RoundTripper
 	store *ghinstall.QuotaStore
@@ -51,7 +55,8 @@ func (q *quotaTap) RoundTrip(req *http.Request) (*http.Response, error) {
 	if err != nil || resp == nil {
 		return resp, err
 	}
-	if installID := installationIDFromContext(req.Context()); installID != 0 {
+	if installID := installationIDFromContext(req.Context()); installID != 0 &&
+		strings.HasPrefix(req.Header.Get("Authorization"), "token ") {
 		remaining, rerr := strconv.Atoi(resp.Header.Get("X-RateLimit-Remaining"))
 		limit, lerr := strconv.Atoi(resp.Header.Get("X-RateLimit-Limit"))
 		if rerr == nil && lerr == nil && limit > 0 {

--- a/pkg/ghtransport/ghtransport_test.go
+++ b/pkg/ghtransport/ghtransport_test.go
@@ -43,6 +43,8 @@ func TestQuotaTapPopulatesStore(t *testing.T) {
 	const installID = int64(987654)
 	req, err := http.NewRequestWithContext(EnrichContext(context.Background(), 12345, installID), http.MethodGet, srv.URL, nil)
 	assert.NoError(t, err)
+	// Simulate an installation-token request (ghinstallation uses "token " prefix).
+	req.Header.Set("Authorization", "token ghs_fake_installation_token")
 	resp, err := client.Do(req)
 	assert.NoError(t, err)
 	resp.Body.Close()
@@ -51,6 +53,33 @@ func TestQuotaTapPopulatesStore(t *testing.T) {
 	assert.True(t, ok, "quota store should be populated after a tapped response")
 	assert.Equal(t, 8421, rem)
 	assert.Equal(t, 15000, lim)
+}
+
+func TestQuotaTapIgnoresJWTAuth(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-RateLimit-Remaining", "4900")
+		w.Header().Set("X-RateLimit-Limit", "5000")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	store := ghinstall.NewQuotaStore(time.Minute)
+	tap := &quotaTap{inner: http.DefaultTransport, store: store}
+	client := &http.Client{Transport: tap}
+
+	const installID = int64(987654)
+	req, err := http.NewRequestWithContext(EnrichContext(context.Background(), 12345, installID), http.MethodGet, srv.URL, nil)
+	assert.NoError(t, err)
+	// Simulate an app-JWT request (ghinstallation uses "Bearer " prefix).
+	// The 5000 limit is the app-level rate limit, not per-installation.
+	req.Header.Set("Authorization", "Bearer eyJhbGciOiJSUzI1NiJ9.fake.jwt")
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+	resp.Body.Close()
+
+	if _, _, ok := store.Get(installID); ok {
+		t.Errorf("store populated for JWT request — app-level rate limits must not be recorded")
+	}
 }
 
 func TestQuotaTapIgnoresMissingContext(t *testing.T) {


### PR DESCRIPTION
We're currently capturing both installations and applications, giving us bad numbers.  This filters everything except installations.