### PR TITLE
Add smoke tests to test sticky routing

### DIFF
--- a/hack/smoketest/README.md
+++ b/hack/smoketest/README.md
@@ -116,6 +116,7 @@ The config file is YAML with two top-level fields:
 | `expect_failure` | bool   | no       | `false` | If `true`, expect the exchange to fail                |
 | `expected_error` | string | no       |         | Substring to match in the error message               |
 | `verify`         | object | no       |         | Optional verification block (see below)               |
+| `sticky_repeat`  | int    | no       | `0`     | Exchange N times and verify all use the same app      |
 
 ### Verify Block
 
@@ -177,6 +178,23 @@ verify:
   pull_requests_read:
     org: octo-sts
     repo: prober
+```
+
+### Sticky Routing Verification
+
+The `sticky_repeat` field tests that multi-app sticky routing is working for
+`checks: write` policies. When set, the tool exchanges N times with the same
+(scope, identity) and calls `GET /app` with each token to discover which GitHub
+App issued it. All N app IDs must match — if any differ, the test fails.
+
+This requires a trust policy with `checks: write` permissions and a deployment
+with multiple GitHub Apps and a sticky store configured.
+
+```yaml
+- name: "checks:write sticky routing"
+  scope: octo-sts/prober
+  identity: smoke-test-checks
+  sticky_repeat: 3
 ```
 
 ## Switching Between Staging and Prod

--- a/hack/smoketest/config.go
+++ b/hack/smoketest/config.go
@@ -22,6 +22,7 @@ type TestCase struct {
 	ExpectFailure bool    `json:"expect_failure"`
 	ExpectedError string  `json:"expected_error"`
 	Verify        *Verify `json:"verify,omitempty"`
+	StickyRepeat  int     `json:"sticky_repeat,omitempty"`
 }
 
 type Verify struct {

--- a/hack/smoketest/runner.go
+++ b/hack/smoketest/runner.go
@@ -41,6 +41,10 @@ func RunTests(ctx context.Context, cfg *Config) []TestResult {
 func runSingleTest(ctx context.Context, domain string, tc TestCase) TestResult {
 	result := TestResult{Name: tc.Name}
 
+	if tc.StickyRepeat > 0 {
+		return runStickyTest(ctx, domain, tc)
+	}
+
 	token, err := MintGitHubActionsToken(domain)
 	if err != nil {
 		result.Error = fmt.Sprintf("minting OIDC token: %v", err)
@@ -83,6 +87,62 @@ func runSingleTest(ctx context.Context, domain string, tc TestCase) TestResult {
 	if tc.Verify != nil {
 		if err := runVerifications(ctx, res.AccessToken, tc.Verify); err != nil {
 			result.Error = fmt.Sprintf("verification failed: %v", err)
+			return result
+		}
+	}
+
+	result.Passed = true
+	return result
+}
+
+// runStickyTest exchanges N times with the same identity and verifies all
+// tokens come from the same GitHub App, proving sticky routing is working.
+func runStickyTest(ctx context.Context, domain string, tc TestCase) TestResult {
+	result := TestResult{Name: tc.Name}
+
+	var appIDs []int64
+	for i := range tc.StickyRepeat {
+		token, err := MintGitHubActionsToken(domain)
+		if err != nil {
+			result.Error = fmt.Sprintf("exchange %d: minting OIDC token: %v", i+1, err)
+			return result
+		}
+
+		xchg := sts.New(
+			fmt.Sprintf("https://%s", domain),
+			"does-not-matter",
+			sts.WithScope(tc.Scope),
+			sts.WithIdentity(tc.Identity),
+		)
+
+		res, err := xchg.Exchange(ctx, token)
+		if err != nil {
+			result.Error = fmt.Sprintf("exchange %d: %v", i+1, err)
+			return result
+		}
+
+		ghc := github.NewClient(
+			oauth2.NewClient(ctx,
+				oauth2.StaticTokenSource(&oauth2.Token{
+					AccessToken: res.AccessToken,
+				}),
+			),
+		)
+		app, _, err := ghc.Apps.Get(ctx, "")
+		if err != nil {
+			result.Error = fmt.Sprintf("exchange %d: GET /app failed: %v", i+1, err)
+			return result
+		}
+		appIDs = append(appIDs, app.GetID())
+
+		if err := octosts.Revoke(ctx, res.AccessToken); err != nil {
+			clog.FromContext(ctx).Warnf("failed to revoke token for %q exchange %d: %v", tc.Name, i+1, err)
+		}
+	}
+
+	for i, id := range appIDs {
+		if id != appIDs[0] {
+			result.Error = fmt.Sprintf("sticky routing broken: exchange 1 used app %d, exchange %d used app %d", appIDs[0], i+1, id)
 			return result
 		}
 	}

--- a/hack/smoketest/testdata/octo-sts-staging.yaml
+++ b/hack/smoketest/testdata/octo-sts-staging.yaml
@@ -26,6 +26,11 @@ tests:
     identity: smoke-test
     expect_failure: false
 
+  - name: "checks:write sticky routing"
+    scope: octo-sts/prober
+    identity: smoke-test-checks
+    sticky_repeat: 3
+
   - name: "missing STS policy"
     scope: octo-sts/prober
     identity: does-not-exist

--- a/hack/smoketest/testdata/octo-sts.yaml
+++ b/hack/smoketest/testdata/octo-sts.yaml
@@ -26,6 +26,11 @@ tests:
     identity: smoke-test
     expect_failure: false
 
+  - name: "checks:write sticky routing"
+    scope: octo-sts/prober
+    identity: smoke-test-checks
+    sticky_repeat: 3
+
   - name: "missing STS policy"
     scope: octo-sts/prober
     identity: does-not-exist


### PR DESCRIPTION
Will exercise the new policy (https://github.com/octo-sts/prober/pull/4) to ensure that, when a policy has `checks: true`, we always return the same installation ID.