### PR TITLE
Run check lifecycle on smoketest

### DIFF
--- a/hack/smoketest/README.md
+++ b/hack/smoketest/README.md
@@ -116,7 +116,7 @@ The config file is YAML with two top-level fields:
 | `expect_failure` | bool   | no       | `false` | If `true`, expect the exchange to fail                |
 | `expected_error` | string | no       |         | Substring to match in the error message               |
 | `verify`         | object | no       |         | Optional verification block (see below)               |
-| `sticky_repeat`  | int    | no       | `0`     | Exchange N times and verify all use the same app      |
+| `sticky_repeat`  | int    | no       | `0`     | Create a check run, then exchange N-1 more times and update it to verify same app |
 
 ### Verify Block
 
@@ -183,12 +183,15 @@ verify:
 ### Sticky Routing Verification
 
 The `sticky_repeat` field tests that multi-app sticky routing is working for
-`checks: write` policies. When set, the tool exchanges N times with the same
-(scope, identity) and calls `GET /app` with each token to discover which GitHub
-App issued it. All N app IDs must match — if any differ, the test fails.
+`checks: write` policies. It exploits the GitHub check-run ownership constraint:
+only the app that created a check run can update it. The test exchanges a token,
+creates a check run on the target repo, then exchanges N-1 more times and
+updates the same check run with each token. If any update fails with 403, a
+different app was used — proving sticky routing is broken.
 
-This requires a trust policy with `checks: write` permissions and a deployment
-with multiple GitHub Apps and a sticky store configured.
+This requires a trust policy with `checks: write` and `contents: read`
+permissions, and a deployment with multiple GitHub Apps and a sticky store
+configured.
 
 ```yaml
 - name: "checks:write sticky routing"

--- a/hack/smoketest/runner.go
+++ b/hack/smoketest/runner.go
@@ -26,7 +26,7 @@ func RunTests(ctx context.Context, cfg *Config) []TestResult {
 	results := make([]TestResult, 0, len(cfg.Tests))
 
 	for _, tc := range cfg.Tests {
-		result := runSingleTest(ctx, cfg.Domain, tc)
+		result := runSingleTest(ctx, cfg, tc)
 		if result.Passed {
 			clog.FromContext(ctx).Infof("PASS: %s", result.Name)
 		} else {
@@ -38,11 +38,12 @@ func RunTests(ctx context.Context, cfg *Config) []TestResult {
 	return results
 }
 
-func runSingleTest(ctx context.Context, domain string, tc TestCase) TestResult {
+func runSingleTest(ctx context.Context, cfg *Config, tc TestCase) TestResult {
 	result := TestResult{Name: tc.Name}
+	domain := cfg.Domain
 
 	if tc.StickyRepeat > 0 {
-		return runStickyTest(ctx, domain, tc)
+		return runStickyTest(ctx, cfg.Domain, tc)
 	}
 
 	token, err := MintGitHubActionsToken(domain)
@@ -95,60 +96,134 @@ func runSingleTest(ctx context.Context, domain string, tc TestCase) TestResult {
 	return result
 }
 
-// runStickyTest exchanges N times with the same identity and verifies all
-// tokens come from the same GitHub App, proving sticky routing is working.
+// runStickyTest proves that sticky routing works end-to-end by exploiting
+// the GitHub check-run ownership constraint: only the app that created a
+// check run can update it. The test exchanges a token, creates a check run,
+// then exchanges again and updates the same check run. If the second token
+// came from a different app, the update fails with 403.
 func runStickyTest(ctx context.Context, domain string, tc TestCase) TestResult {
 	result := TestResult{Name: tc.Name}
 
-	var appIDs []int64
-	for i := range tc.StickyRepeat {
-		token, err := MintGitHubActionsToken(domain)
-		if err != nil {
-			result.Error = fmt.Sprintf("exchange %d: minting OIDC token: %v", i+1, err)
-			return result
+	owner, repo := parseScope(tc.Scope)
+	if owner == "" || repo == "" {
+		result.Error = fmt.Sprintf("invalid scope %q: expected owner/repo", tc.Scope)
+		return result
+	}
+
+	// First exchange: create a check run.
+	token1, err := exchangeToken(ctx, domain, tc.Scope, tc.Identity)
+	if err != nil {
+		result.Error = fmt.Sprintf("exchange 1: %v", err)
+		return result
+	}
+	defer func() {
+		if err := octosts.Revoke(ctx, token1); err != nil {
+			clog.FromContext(ctx).Warnf("failed to revoke token 1 for %q: %v", tc.Name, err)
 		}
+	}()
 
-		xchg := sts.New(
-			fmt.Sprintf("https://%s", domain),
-			"does-not-matter",
-			sts.WithScope(tc.Scope),
-			sts.WithIdentity(tc.Identity),
-		)
+	ghc1 := newGitHubClient(ctx, token1)
 
-		res, err := xchg.Exchange(ctx, token)
+	// Get the latest commit SHA — CreateCheckRun requires a real SHA.
+	branch, _, err := ghc1.Repositories.GetBranch(ctx, owner, repo, "main", 0)
+	if err != nil {
+		result.Error = fmt.Sprintf("getting HEAD SHA: %v", err)
+		return result
+	}
+	headSHA := branch.GetCommit().GetSHA()
+
+	checkRun, _, err := ghc1.Checks.CreateCheckRun(ctx, owner, repo, github.CreateCheckRunOptions{
+		Name:       "octo-sts-sticky-routing-test",
+		HeadSHA:    headSHA,
+		Status:     github.Ptr("completed"),
+		Conclusion: github.Ptr("success"),
+	})
+	if err != nil {
+		result.Error = fmt.Sprintf("creating check run: %v", err)
+		return result
+	}
+	clog.FromContext(ctx).Infof("created check run %d on %s/%s", checkRun.GetID(), owner, repo)
+
+	// Subsequent exchanges: update the same check run. If the token came
+	// from a different app, this fails with 403 — proving sticky routing
+	// is broken.
+	defer func() {
+		// Clean up: mark the check run as completed so it doesn't linger.
+		// Use token1 which is still valid (deferred revoke runs after this).
+		_, _, _ = ghc1.Checks.UpdateCheckRun(ctx, owner, repo, checkRun.GetID(), github.UpdateCheckRunOptions{
+			Name:       "octo-sts-sticky-routing-test",
+			Status:     github.Ptr("completed"),
+			Conclusion: github.Ptr("neutral"),
+			Output: &github.CheckRunOutput{
+				Title:   github.Ptr("Sticky routing smoke test"),
+				Summary: github.Ptr("This check was created by the OctoSTS smoke test to verify sticky routing. It can be ignored."),
+			},
+		})
+	}()
+
+	for i := 1; i < tc.StickyRepeat; i++ {
+		tokenN, err := exchangeToken(ctx, domain, tc.Scope, tc.Identity)
 		if err != nil {
 			result.Error = fmt.Sprintf("exchange %d: %v", i+1, err)
 			return result
 		}
 
-		ghc := github.NewClient(
-			oauth2.NewClient(ctx,
-				oauth2.StaticTokenSource(&oauth2.Token{
-					AccessToken: res.AccessToken,
-				}),
-			),
-		)
-		app, _, err := ghc.Apps.Get(ctx, "")
+		ghcN := newGitHubClient(ctx, tokenN)
+		_, _, err = ghcN.Checks.UpdateCheckRun(ctx, owner, repo, checkRun.GetID(), github.UpdateCheckRunOptions{
+			Name:       "octo-sts-sticky-routing-test",
+			Status:     github.Ptr("completed"),
+			Conclusion: github.Ptr("success"),
+		})
+
+		if rErr := octosts.Revoke(ctx, tokenN); rErr != nil {
+			clog.FromContext(ctx).Warnf("failed to revoke token %d for %q: %v", i+1, tc.Name, rErr)
+		}
+
 		if err != nil {
-			result.Error = fmt.Sprintf("exchange %d: GET /app failed: %v", i+1, err)
+			result.Error = fmt.Sprintf("exchange %d: updating check run %d failed (different app?): %v", i+1, checkRun.GetID(), err)
 			return result
 		}
-		appIDs = append(appIDs, app.GetID())
-
-		if err := octosts.Revoke(ctx, res.AccessToken); err != nil {
-			clog.FromContext(ctx).Warnf("failed to revoke token for %q exchange %d: %v", tc.Name, i+1, err)
-		}
-	}
-
-	for i, id := range appIDs {
-		if id != appIDs[0] {
-			result.Error = fmt.Sprintf("sticky routing broken: exchange 1 used app %d, exchange %d used app %d", appIDs[0], i+1, id)
-			return result
-		}
+		clog.FromContext(ctx).Infof("exchange %d: successfully updated check run %d (same app confirmed)", i+1, checkRun.GetID())
 	}
 
 	result.Passed = true
 	return result
+}
+
+func exchangeToken(ctx context.Context, domain, scope, identity string) (string, error) {
+	oidcToken, err := MintGitHubActionsToken(domain)
+	if err != nil {
+		return "", fmt.Errorf("minting OIDC token: %w", err)
+	}
+	xchg := sts.New(
+		fmt.Sprintf("https://%s", domain),
+		"does-not-matter",
+		sts.WithScope(scope),
+		sts.WithIdentity(identity),
+	)
+	res, err := xchg.Exchange(ctx, oidcToken)
+	if err != nil {
+		return "", err
+	}
+	return res.AccessToken, nil
+}
+
+func newGitHubClient(ctx context.Context, accessToken string) *github.Client {
+	return github.NewClient(
+		oauth2.NewClient(ctx,
+			oauth2.StaticTokenSource(&oauth2.Token{
+				AccessToken: accessToken,
+			}),
+		),
+	)
+}
+
+func parseScope(scope string) (owner, repo string) {
+	parts := strings.SplitN(scope, "/", 2)
+	if len(parts) != 2 {
+		return "", ""
+	}
+	return parts[0], parts[1]
 }
 
 func runVerifications(ctx context.Context, accessToken string, v *Verify) error {

--- a/hack/smoketest/runner.go
+++ b/hack/smoketest/runner.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -104,6 +105,11 @@ func runSingleTest(ctx context.Context, cfg *Config, tc TestCase) TestResult {
 func runStickyTest(ctx context.Context, domain string, tc TestCase) TestResult {
 	result := TestResult{Name: tc.Name}
 
+	if tc.StickyRepeat < 2 {
+		result.Error = "sticky_repeat must be >= 2 to verify routing"
+		return result
+	}
+
 	owner, repo := parseScope(tc.Scope)
 	if owner == "" || repo == "" {
 		result.Error = fmt.Sprintf("invalid scope %q: expected owner/repo", tc.Scope)
@@ -116,10 +122,14 @@ func runStickyTest(ctx context.Context, domain string, tc TestCase) TestResult {
 		result.Error = fmt.Sprintf("exchange 1: %v", err)
 		return result
 	}
+	defer func() {
+		if err := octosts.Revoke(ctx, token1); err != nil {
+			clog.FromContext(ctx).Warnf("failed to revoke token 1 for %q: %v", tc.Name, err)
+		}
+	}()
 
 	ghc1 := newGitHubClient(ctx, token1)
 
-	// Get the latest commit SHA — CreateCheckRun requires a real SHA.
 	branch, _, err := ghc1.Repositories.GetBranch(ctx, owner, repo, "main", 0)
 	if err != nil {
 		result.Error = fmt.Sprintf("getting HEAD SHA: %v", err)
@@ -139,15 +149,8 @@ func runStickyTest(ctx context.Context, domain string, tc TestCase) TestResult {
 	}
 	clog.FromContext(ctx).Infof("created check run %d on %s/%s", checkRun.GetID(), owner, repo)
 
-	// Clean up the check run and revoke token1 on exit.
-	// Cleanup runs first (registered second, LIFO), then revoke.
 	defer func() {
-		if err := octosts.Revoke(ctx, token1); err != nil {
-			clog.FromContext(ctx).Warnf("failed to revoke token 1 for %q: %v", tc.Name, err)
-		}
-	}()
-	defer func() {
-		_, _, _ = ghc1.Checks.UpdateCheckRun(ctx, owner, repo, checkRun.GetID(), github.UpdateCheckRunOptions{
+		if _, _, err := ghc1.Checks.UpdateCheckRun(ctx, owner, repo, checkRun.GetID(), github.UpdateCheckRunOptions{
 			Name:       "octo-sts-sticky-routing-test",
 			Status:     github.Ptr("completed"),
 			Conclusion: github.Ptr("neutral"),
@@ -155,9 +158,13 @@ func runStickyTest(ctx context.Context, domain string, tc TestCase) TestResult {
 				Title:   github.Ptr("Sticky routing smoke test"),
 				Summary: github.Ptr("Automated test to verify sticky routing. Can be ignored."),
 			},
-		})
+		}); err != nil {
+			clog.FromContext(ctx).Warnf("failed to clean up check run %d: %v", checkRun.GetID(), err)
+		}
 	}()
 
+	// Subsequent exchanges: update the same check run. Only the app that
+	// created it can update it — a 403 proves sticky routing is broken.
 	for i := 1; i < tc.StickyRepeat; i++ {
 		tokenN, err := exchangeToken(ctx, domain, tc.Scope, tc.Identity)
 		if err != nil {
@@ -166,7 +173,7 @@ func runStickyTest(ctx context.Context, domain string, tc TestCase) TestResult {
 		}
 
 		ghcN := newGitHubClient(ctx, tokenN)
-		_, _, err = ghcN.Checks.UpdateCheckRun(ctx, owner, repo, checkRun.GetID(), github.UpdateCheckRunOptions{
+		_, _, updateErr := ghcN.Checks.UpdateCheckRun(ctx, owner, repo, checkRun.GetID(), github.UpdateCheckRunOptions{
 			Name:       "octo-sts-sticky-routing-test",
 			Status:     github.Ptr("completed"),
 			Conclusion: github.Ptr("success"),
@@ -176,8 +183,13 @@ func runStickyTest(ctx context.Context, domain string, tc TestCase) TestResult {
 			clog.FromContext(ctx).Warnf("failed to revoke token %d for %q: %v", i+1, tc.Name, rErr)
 		}
 
-		if err != nil {
-			result.Error = fmt.Sprintf("exchange %d: updating check run %d failed (different app?): %v", i+1, checkRun.GetID(), err)
+		if updateErr != nil {
+			var ghErr *github.ErrorResponse
+			if errors.As(updateErr, &ghErr) && ghErr.Response.StatusCode == 403 {
+				result.Error = fmt.Sprintf("exchange %d: sticky routing broken — different app cannot update check run %d", i+1, checkRun.GetID())
+			} else {
+				result.Error = fmt.Sprintf("exchange %d: updating check run %d failed: %v", i+1, checkRun.GetID(), updateErr)
+			}
 			return result
 		}
 		clog.FromContext(ctx).Infof("exchange %d: successfully updated check run %d (same app confirmed)", i+1, checkRun.GetID())

--- a/hack/smoketest/runner.go
+++ b/hack/smoketest/runner.go
@@ -116,11 +116,6 @@ func runStickyTest(ctx context.Context, domain string, tc TestCase) TestResult {
 		result.Error = fmt.Sprintf("exchange 1: %v", err)
 		return result
 	}
-	defer func() {
-		if err := octosts.Revoke(ctx, token1); err != nil {
-			clog.FromContext(ctx).Warnf("failed to revoke token 1 for %q: %v", tc.Name, err)
-		}
-	}()
 
 	ghc1 := newGitHubClient(ctx, token1)
 
@@ -144,19 +139,21 @@ func runStickyTest(ctx context.Context, domain string, tc TestCase) TestResult {
 	}
 	clog.FromContext(ctx).Infof("created check run %d on %s/%s", checkRun.GetID(), owner, repo)
 
-	// Subsequent exchanges: update the same check run. If the token came
-	// from a different app, this fails with 403 — proving sticky routing
-	// is broken.
+	// Clean up the check run and revoke token1 on exit.
+	// Cleanup runs first (registered second, LIFO), then revoke.
 	defer func() {
-		// Clean up: mark the check run as completed so it doesn't linger.
-		// Use token1 which is still valid (deferred revoke runs after this).
+		if err := octosts.Revoke(ctx, token1); err != nil {
+			clog.FromContext(ctx).Warnf("failed to revoke token 1 for %q: %v", tc.Name, err)
+		}
+	}()
+	defer func() {
 		_, _, _ = ghc1.Checks.UpdateCheckRun(ctx, owner, repo, checkRun.GetID(), github.UpdateCheckRunOptions{
 			Name:       "octo-sts-sticky-routing-test",
 			Status:     github.Ptr("completed"),
 			Conclusion: github.Ptr("neutral"),
 			Output: &github.CheckRunOutput{
 				Title:   github.Ptr("Sticky routing smoke test"),
-				Summary: github.Ptr("This check was created by the OctoSTS smoke test to verify sticky routing. It can be ignored."),
+				Summary: github.Ptr("Automated test to verify sticky routing. Can be ignored."),
 			},
 		})
 	}()


### PR DESCRIPTION
Because there's no way, without pinning these tests to GCP, we'll need to run a real check lifecycle.  These are done on the scope of the test, in our case the prober repo.