### PR TITLE
Also use subject for request hashing for better distribution

### DIFF
--- a/hack/smoketest/testdata/octo-sts-staging.yaml
+++ b/hack/smoketest/testdata/octo-sts-staging.yaml
@@ -29,7 +29,7 @@ tests:
   - name: "checks:write sticky routing"
     scope: octo-sts/prober
     identity: smoke-test-checks
-    sticky_repeat: 3
+    sticky_repeat: 6
 
   - name: "missing STS policy"
     scope: octo-sts/prober

--- a/hack/smoketest/testdata/octo-sts.yaml
+++ b/hack/smoketest/testdata/octo-sts.yaml
@@ -29,7 +29,7 @@ tests:
   - name: "checks:write sticky routing"
     scope: octo-sts/prober
     identity: smoke-test-checks
-    sticky_repeat: 3
+    sticky_repeat: 30
 
   - name: "missing STS policy"
     scope: octo-sts/prober

--- a/pkg/octosts/octosts.go
+++ b/pkg/octosts/octosts.go
@@ -177,7 +177,7 @@ func (s *sts) Exchange(ctx context.Context, request *pboidc.ExchangeRequest) (_ 
 	}
 
 	var base *ghinstallation.AppsTransport
-	base, e.InstallationID, e.TrustPolicy, err = s.lookupInstallAndTrustPolicy(ctx, requestScope, request.GetIdentity())
+	base, e.InstallationID, e.TrustPolicy, err = s.lookupInstallAndTrustPolicy(ctx, requestScope, request.GetIdentity(), tok.Subject)
 	if err != nil {
 		return nil, err
 	}
@@ -254,12 +254,12 @@ func hasChecksWrite(perms github.InstallationPermissions) bool {
 // permissions are unknown, so this falls through to plain round-robin.
 // The caller (lookupInstallAndTrustPolicy) retroactively persists the
 // assignment once the policy is fetched and found to have checks:write.
-func (s *sts) getExchangeInstall(ctx context.Context, owner, scope, identity string, tpKey cacheTrustPolicyKey) (*ghinstallation.AppsTransport, int64, error) {
+func (s *sts) getExchangeInstall(ctx context.Context, owner, scope, identity, subject string, tpKey cacheTrustPolicyKey) (*ghinstallation.AppsTransport, int64, error) {
 	if s.sticky != nil {
 		if raw, ok := trustPolicies.Get(tpKey); ok && raw != negativeCacheConst {
 			var cached OrgTrustPolicy
 			if err := yaml.UnmarshalStrict([]byte(raw), &cached); err == nil && hasChecksWrite(cached.Permissions) {
-				return s.stickyExchange(ctx, owner, scope, identity)
+				return s.stickyExchange(ctx, owner, scope, identity, subject)
 			}
 		}
 	}
@@ -271,8 +271,8 @@ func (s *sts) getExchangeInstall(ctx context.Context, owner, scope, identity str
 // preserving check-run ownership. On a miss (or if the cached installation
 // is no longer installed for this owner) it falls through to round-robin
 // for a capacity-aware assignment and persists the result.
-func (s *sts) stickyExchange(ctx context.Context, owner, scope, identity string) (*ghinstallation.AppsTransport, int64, error) {
-	key := routekey.Key(scope, identity)
+func (s *sts) stickyExchange(ctx context.Context, owner, scope, identity, subject string) (*ghinstallation.AppsTransport, int64, error) {
+	key := routekey.Key(scope, identity, subject)
 	if cachedID, ok, err := s.sticky.Get(ctx, key); err == nil && ok {
 		atr, id, err := s.rrm.GetByInstallation(ctx, owner, cachedID)
 		if err == nil {
@@ -286,13 +286,13 @@ func (s *sts) stickyExchange(ctx context.Context, owner, scope, identity string)
 		return nil, 0, err
 	}
 
-	if putErr := s.sticky.Put(ctx, key, id, scope, identity); putErr != nil {
+	if putErr := s.sticky.Put(ctx, key, id, scope, identity, subject); putErr != nil {
 		clog.FromContext(ctx).Warnf("stickystore: Put failed for key %s: %v", key, putErr)
 	}
 	return atr, id, nil
 }
 
-func (s *sts) lookupInstallAndTrustPolicy(ctx context.Context, scope, identity string) (*ghinstallation.AppsTransport, int64, *OrgTrustPolicy, error) {
+func (s *sts) lookupInstallAndTrustPolicy(ctx context.Context, scope, identity, subject string) (*ghinstallation.AppsTransport, int64, *OrgTrustPolicy, error) {
 	otp := &OrgTrustPolicy{}
 	var tp trustPolicy = &otp.TrustPolicy
 
@@ -314,7 +314,7 @@ func (s *sts) lookupInstallAndTrustPolicy(ctx context.Context, scope, identity s
 		return nil, 0, nil, status.Errorf(codes.NotFound, "unable to find trust policy for %q", tpKey.identity)
 	}
 
-	atr, id, err := s.getExchangeInstall(ctx, owner, scope, identity, tpKey)
+	atr, id, err := s.getExchangeInstall(ctx, owner, scope, identity, subject, tpKey)
 	if err != nil {
 		return nil, 0, nil, err
 	}
@@ -324,7 +324,7 @@ func (s *sts) lookupInstallAndTrustPolicy(ctx context.Context, scope, identity s
 		return nil, 0, nil, err
 	}
 
-	s.ensureSticky(ctx, scope, identity, id, otp.Permissions)
+	s.ensureSticky(ctx, scope, identity, subject, id, otp.Permissions)
 
 	return atr, id, otp, nil
 }
@@ -355,13 +355,13 @@ func (s *sts) lookupTrustPolicyWithRetry(ctx context.Context, atr *ghinstallatio
 // ensureSticky persists the installation assignment for checks:write
 // policies when the sticky store was not consulted during routing (e.g.
 // first request when the trust policy cache is cold).
-func (s *sts) ensureSticky(ctx context.Context, scope, identity string, id int64, perms github.InstallationPermissions) {
+func (s *sts) ensureSticky(ctx context.Context, scope, identity, subject string, id int64, perms github.InstallationPermissions) {
 	if s.sticky == nil || !hasChecksWrite(perms) {
 		return
 	}
-	key := routekey.Key(scope, identity)
+	key := routekey.Key(scope, identity, subject)
 	if _, ok, err := s.sticky.Get(ctx, key); err != nil || !ok {
-		if putErr := s.sticky.Put(ctx, key, id, scope, identity); putErr != nil {
+		if putErr := s.sticky.Put(ctx, key, id, scope, identity, subject); putErr != nil {
 			clog.FromContext(ctx).Warnf("stickystore: retroactive Put failed for key %s: %v", key, putErr)
 		}
 	}

--- a/pkg/octosts/octosts_test.go
+++ b/pkg/octosts/octosts_test.go
@@ -675,7 +675,7 @@ func TestNegativeCacheSkipsInstallationTokenCreation(t *testing.T) {
 		appCount: 1,
 	}
 
-	_, _, _, err := s.lookupInstallAndTrustPolicy(context.Background(), "org/repo", "cached-missing")
+	_, _, _, err := s.lookupInstallAndTrustPolicy(context.Background(), "org/repo", "cached-missing", "some-subject")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}

--- a/pkg/routekey/routekey.go
+++ b/pkg/routekey/routekey.go
@@ -8,10 +8,12 @@ import (
 	"hash/fnv"
 )
 
-// Key returns a stable FNV-32a string key for a (scope, identity) pair.
-// Used by the sticky store to consistently identify a routing target.
-func Key(scope, identity string) string {
+// Key returns a stable FNV-32a string key for a (scope, identity, subject)
+// tuple. Using subject gives each distinct caller its own sticky mapping,
+// improving distribution across installations while preserving check-run
+// ownership.
+func Key(scope, identity, subject string) string {
 	h := fnv.New32a()
-	_, _ = h.Write([]byte(scope + ":" + identity))
+	_, _ = h.Write([]byte(scope + ":" + identity + ":" + subject))
 	return fmt.Sprintf("%d", h.Sum32())
 }

--- a/pkg/routekey/routekey_test.go
+++ b/pkg/routekey/routekey_test.go
@@ -6,31 +6,39 @@ package routekey
 import "testing"
 
 func TestKeyDeterministic(t *testing.T) {
-	a := Key("org/repo", "bot")
-	b := Key("org/repo", "bot")
+	a := Key("org/repo", "bot", "sub:1")
+	b := Key("org/repo", "bot", "sub:1")
 	if a != b {
 		t.Errorf("same inputs produced different keys: %s vs %s", a, b)
 	}
 }
 
 func TestKeyDiffersByScope(t *testing.T) {
-	a := Key("org/repo-a", "bot")
-	b := Key("org/repo-b", "bot")
+	a := Key("org/repo-a", "bot", "sub:1")
+	b := Key("org/repo-b", "bot", "sub:1")
 	if a == b {
 		t.Errorf("different scopes produced same key: %s", a)
 	}
 }
 
 func TestKeyDiffersByIdentity(t *testing.T) {
-	a := Key("org/repo", "alice")
-	b := Key("org/repo", "bob")
+	a := Key("org/repo", "alice", "sub:1")
+	b := Key("org/repo", "bob", "sub:1")
 	if a == b {
 		t.Errorf("different identities produced same key: %s", a)
 	}
 }
 
+func TestKeyDiffersBySubject(t *testing.T) {
+	a := Key("org/repo", "bot", "repo:org/mono:ref:refs/heads/main")
+	b := Key("org/repo", "bot", "repo:org/mono:ref:refs/heads/feature")
+	if a == b {
+		t.Errorf("different subjects produced same key: %s", a)
+	}
+}
+
 func TestKeyIsNonEmpty(t *testing.T) {
-	if k := Key("org/repo", "bot"); k == "" {
+	if k := Key("org/repo", "bot", "sub:1"); k == "" {
 		t.Error("Key returned empty string")
 	}
 }

--- a/pkg/stickystore/firestore/firestore.go
+++ b/pkg/stickystore/firestore/firestore.go
@@ -23,6 +23,7 @@ type doc struct {
 	InstallationID int64     `firestore:"installation_id"`
 	Scope          string    `firestore:"scope"`
 	Identity       string    `firestore:"identity"`
+	Subject        string    `firestore:"subject"`
 	CreatedAt      time.Time `firestore:"created_at"`
 	ExpireAt       time.Time `firestore:"expire_at"`
 }
@@ -66,13 +67,14 @@ func (s *Store) Get(ctx context.Context, key string) (int64, bool, error) {
 }
 
 // Put persists a sticky mapping. Overwrites any existing document for the
-// key. scope and identity are stored for operator debuggability.
-func (s *Store) Put(ctx context.Context, key string, installationID int64, scope, identity string) error {
+// key. scope, identity, and subject are stored for operator debuggability.
+func (s *Store) Put(ctx context.Context, key string, installationID int64, scope, identity, subject string) error {
 	now := time.Now()
 	_, err := s.client.Collection(s.collection).Doc(key).Set(ctx, doc{
 		InstallationID: installationID,
 		Scope:          scope,
 		Identity:       identity,
+		Subject:        subject,
 		CreatedAt:      now,
 		ExpireAt:       now.Add(s.ttl),
 	})

--- a/pkg/stickystore/firestore/firestore_test.go
+++ b/pkg/stickystore/firestore/firestore_test.go
@@ -13,6 +13,7 @@ func TestDocFields(t *testing.T) {
 		InstallationID: 12345,
 		Scope:          "org/repo",
 		Identity:       "bot",
+		Subject:        "repo:org/mono:ref:refs/heads/main",
 		CreatedAt:      time.Now(),
 		ExpireAt:       time.Now().Add(720 * time.Hour),
 	}
@@ -21,6 +22,9 @@ func TestDocFields(t *testing.T) {
 	}
 	if d.Scope != "org/repo" {
 		t.Errorf("Scope = %q, want org/repo", d.Scope)
+	}
+	if d.Subject != "repo:org/mono:ref:refs/heads/main" {
+		t.Errorf("Subject = %q, want repo:org/mono:ref:refs/heads/main", d.Subject)
 	}
 }
 

--- a/pkg/stickystore/memory/memory.go
+++ b/pkg/stickystore/memory/memory.go
@@ -27,8 +27,8 @@ func (s *Store) Get(_ context.Context, key string) (int64, bool, error) {
 	return id, ok, nil
 }
 
-// Put stores a mapping. scope and identity are ignored by this implementation.
-func (s *Store) Put(_ context.Context, key string, installationID int64, _, _ string) error {
+// Put stores a mapping. scope, identity, and subject are ignored by this implementation.
+func (s *Store) Put(_ context.Context, key string, installationID int64, _, _, _ string) error {
 	s.mu.Lock()
 	s.m[key] = installationID
 	s.mu.Unlock()

--- a/pkg/stickystore/memory/memory_test.go
+++ b/pkg/stickystore/memory/memory_test.go
@@ -23,7 +23,7 @@ func TestPutThenGet(t *testing.T) {
 	s := New()
 	ctx := context.Background()
 
-	if err := s.Put(ctx, "k1", 42, "scope", "id"); err != nil {
+	if err := s.Put(ctx, "k1", 42, "scope", "id", "sub"); err != nil {
 		t.Fatalf("Put: %v", err)
 	}
 
@@ -43,8 +43,8 @@ func TestPutOverwrites(t *testing.T) {
 	s := New()
 	ctx := context.Background()
 
-	_ = s.Put(ctx, "k1", 42, "s", "i")
-	_ = s.Put(ctx, "k1", 99, "s", "i")
+	_ = s.Put(ctx, "k1", 42, "s", "i", "sub")
+	_ = s.Put(ctx, "k1", 99, "s", "i", "sub")
 
 	id, ok, err := s.Get(ctx, "k1")
 	if err != nil {
@@ -59,8 +59,8 @@ func TestIndependentKeys(t *testing.T) {
 	s := New()
 	ctx := context.Background()
 
-	_ = s.Put(ctx, "a", 1, "s", "i")
-	_ = s.Put(ctx, "b", 2, "s", "i")
+	_ = s.Put(ctx, "a", 1, "s", "i", "sub")
+	_ = s.Put(ctx, "b", 2, "s", "i", "sub")
 
 	id1, _, _ := s.Get(ctx, "a")
 	id2, _, _ := s.Get(ctx, "b")

--- a/pkg/stickystore/stickystore.go
+++ b/pkg/stickystore/stickystore.go
@@ -15,8 +15,8 @@ type Store interface {
 	// round-robin).
 	Get(ctx context.Context, key string) (installationID int64, ok bool, err error)
 
-	// Put persists a mapping. scope and identity are stored by backends
-	// that support operator debuggability (e.g. Firestore); backends that
-	// do not need them may ignore them.
-	Put(ctx context.Context, key string, installationID int64, scope, identity string) error
+	// Put persists a mapping. scope, identity, and subject are stored by
+	// backends that support operator debuggability (e.g. Firestore);
+	// backends that do not need them may ignore them.
+	Put(ctx context.Context, key string, installationID int64, scope, identity, subject string) error
 }


### PR DESCRIPTION
To further tighten the uniqueness of the hash, I've added `subject` into the inputs.  This will still mean that a started check will get the same installation.  However, it means the same check on different PRs will get different installations. 