### PR TITLE
Add a quota warmup

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -94,6 +94,7 @@ func main() {
 	if len(managers) == 0 {
 		log.Panic("no apps with valid KMS keys configured")
 	}
+
 	var rrm ghinstall.Manager
 	var sticky stickystore.Store
 	if len(managers) == 1 {
@@ -112,9 +113,6 @@ func main() {
 
 	d := duplex.New(
 		baseCfg.Port,
-		// grpc.StatsHandler(otelgrpc.NewServerHandler()),
-		// grpc.ChainStreamInterceptor(grpc_prometheus.StreamServerInterceptor),
-		// grpc.ChainUnaryInterceptor(grpc_prometheus.UnaryServerInterceptor, interceptors.ServerErrorInterceptor),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
 

--- a/pkg/ghinstall/ghinstall.go
+++ b/pkg/ghinstall/ghinstall.go
@@ -201,8 +201,9 @@ func (rr *roundRobin) GetByInstallation(ctx context.Context, owner string, insta
 
 // pickByQuota selects an installed manager using three-tier capacity-aware
 // fairshare. Returns ok=false when quota selection cannot proceed (no config,
-// or no candidate has known quota data) — callers fall back to the atomic
-// counter.
+// or any candidate lacks quota data) — callers fall back to the atomic
+// counter. This ensures the counter distributes evenly on cold start until
+// every installation has been seen at least once via the transport tap.
 //
 //	comfortable = installs with remaining >= SoftFloor
 //	tight       = installs with HardFloor <= remaining < SoftFloor
@@ -210,10 +211,6 @@ func (rr *roundRobin) GetByInstallation(ctx context.Context, owner string, insta
 //
 // The first non-empty pool wins; within a pool the install with the most
 // absolute remaining headroom is selected.
-//
-// A candidate without quota data is included as if it had remaining =
-// SoftFloor + 1 so that newly-seen installs are explored. Until at least
-// one candidate has known data, ok=false to keep cold-start deterministic.
 func pickByQuota(ctx context.Context, managers []Manager, owner, scope, identity string, q *QuotaConfig) (*ghinstallation.AppsTransport, int64, bool) {
 	if q == nil || q.Store == nil {
 		return nil, 0, false
@@ -229,25 +226,19 @@ func pickByQuota(ctx context.Context, managers []Manager, owner, scope, identity
 	}
 
 	var candidates []cand
-	anyKnown := false
 	for _, m := range managers {
 		atr, id, err := m.Get(ctx, owner, scope, identity)
 		if err != nil {
 			continue
 		}
 		rem, _, ok := q.Store.Get(id)
-		if ok {
-			anyKnown = true
-		} else {
-			// Treat unknowns as "just above the soft floor" — they're
-			// candidates worth exploring, but known-comfortable installs
-			// (which have remaining >> SoftFloor early in the hour) win.
-			rem = q.SoftFloor + 1
+		if !ok {
+			return nil, 0, false
 		}
 		candidates = append(candidates, cand{atr, id, rem})
 	}
 
-	if !anyKnown || len(candidates) == 0 {
+	if len(candidates) == 0 {
 		return nil, 0, false
 	}
 

--- a/pkg/ghinstall/picker_test.go
+++ b/pkg/ghinstall/picker_test.go
@@ -76,21 +76,17 @@ func TestPickByQuotaColdStartFallsThrough(t *testing.T) {
 	}
 }
 
-func TestPickByQuotaSomeKnownPicksKnownComfortable(t *testing.T) {
-	// One install has known headroom comfortably above the soft floor; the
-	// other two are unknown (treated as soft+1). The known install must win
-	// because its remaining is greater.
+func TestPickByQuotaPartialDataFallsThrough(t *testing.T) {
+	// Only one of three installs has known data. The picker must return
+	// ok=false so the atomic counter distributes evenly until all installs
+	// have been discovered.
 	managers := newFakePickerManagers(1, 2, 3)
 	store := NewQuotaStore(time.Minute)
-	store.Update(2, 49000, 50000) // install 2 known, well above SoftFloor
+	store.Update(2, 49000, 50000)
 
 	cfg := &QuotaConfig{Store: store, SoftFloor: 15000, HardFloor: 1500}
-	_, id, ok := pickByQuota(context.Background(), managers, "owner", "owner/repo", "id", cfg)
-	if !ok {
-		t.Fatalf("ok = false, want true (one install has data)")
-	}
-	if id != 2 {
-		t.Errorf("picked install %d, want 2 (49000 > soft+1 = 15001)", id)
+	if _, _, ok := pickByQuota(context.Background(), managers, "owner", "owner/repo", "id", cfg); ok {
+		t.Errorf("partial data: ok = true, want false (not all installs have data)")
 	}
 }
 


### PR DESCRIPTION
Seeing a bug, with the fair share picker, where the first install to get picked will populate its quota but this will then bias that install as looking healthiest.

We should ignore fair share until all installs have been picked, naturally, by round robin and then let it kick in.