### PR TITLE
Reduce TTL to 1 hour

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ back to round-robin (non-sticky) routing which may break check-run updates.
 | `OCTOSTS_STICKY_STORE` | (empty) | Set to `firestore` to enable |
 | `OCTOSTS_STICKY_STORE_FIRESTORE_PROJECT` | running GCP project | Firestore GCP project |
 | `OCTOSTS_STICKY_STORE_FIRESTORE_COLLECTION` | `sticky-routes` | Firestore collection name |
-| `OCTOSTS_STICKY_STORE_FIRESTORE_TTL` | `720h` (30 days) | TTL for inactive mappings |
+| `OCTOSTS_STICKY_STORE_FIRESTORE_TTL` | `1h` | TTL for inactive mappings |
 
 Active mappings have their TTL refreshed on every use, so they never expire.
 Only mappings unused for the TTL duration are automatically cleaned up.

--- a/env/octo-sts-staging/main.tf
+++ b/env/octo-sts-staging/main.tf
@@ -76,7 +76,8 @@ module "app" {
     webhook = cosign_sign.webhook.signed_ref
   }
 
-  github_apps           = var.github_apps
-  notification_channels = local.notification_channels
-  sticky_store          = "firestore"
+  github_apps                = var.github_apps
+  notification_channels      = local.notification_channels
+  sticky_store               = "firestore"
+  sticky_store_firestore_ttl = "1h"
 }

--- a/env/octo-sts/main.tf
+++ b/env/octo-sts/main.tf
@@ -72,7 +72,8 @@ module "app" {
     webhook = cosign_sign.webhook.signed_ref
   }
 
-  github_apps           = var.github_apps
-  notification_channels = local.notification_channels
-  sticky_store          = "firestore"
+  github_apps                = var.github_apps
+  notification_channels      = local.notification_channels
+  sticky_store               = "firestore"
+  sticky_store_firestore_ttl = "1h"
 }

--- a/modules/app/variables.tf
+++ b/modules/app/variables.tf
@@ -79,7 +79,7 @@ variable "sticky_store_firestore_collection" {
 }
 
 variable "sticky_store_firestore_ttl" {
-  description = "TTL for sticky route documents (e.g. 720h)."
+  description = "TTL for sticky route documents (e.g. 1h)."
   type        = string
-  default     = "720h"
+  default     = "1h"
 }

--- a/pkg/envconfig/envconfig.go
+++ b/pkg/envconfig/envconfig.go
@@ -32,7 +32,7 @@ type EnvConfig struct {
 	StickyStore                    string        `envconfig:"OCTOSTS_STICKY_STORE" required:"false"`
 	StickyStoreFirestoreProject    string        `envconfig:"OCTOSTS_STICKY_STORE_FIRESTORE_PROJECT" required:"false"`
 	StickyStoreFirestoreCollection string        `envconfig:"OCTOSTS_STICKY_STORE_FIRESTORE_COLLECTION" required:"false" default:"sticky-routes"`
-	StickyStoreFirestoreTTL        time.Duration `envconfig:"OCTOSTS_STICKY_STORE_FIRESTORE_TTL" required:"false" default:"720h"`
+	StickyStoreFirestoreTTL        time.Duration `envconfig:"OCTOSTS_STICKY_STORE_FIRESTORE_TTL" required:"false" default:"1h"`
 }
 
 type EnvConfigApp struct {

--- a/pkg/envconfig/envconfig_test.go
+++ b/pkg/envconfig/envconfig_test.go
@@ -156,7 +156,7 @@ func TestBaseConfig(t *testing.T) {
 				"PORT":                               "8080",
 				"GITHUB_APP_IDS":                     "12345678",
 				"OCTOSTS_STICKY_STORE":               "firestore",
-				"OCTOSTS_STICKY_STORE_FIRESTORE_TTL": "720h",
+				"OCTOSTS_STICKY_STORE_FIRESTORE_TTL": "1h",
 			},
 			wantErr: false,
 		},

--- a/pkg/stickystore/factory.go
+++ b/pkg/stickystore/factory.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"time"
 
 	gofirestore "cloud.google.com/go/firestore"
 
@@ -42,15 +41,5 @@ func newFirestore(ctx context.Context, cfg *envconfig.EnvConfig) (Store, io.Clos
 		return nil, nil, fmt.Errorf("stickystore: creating Firestore client: %w", err)
 	}
 
-	collection := cfg.StickyStoreFirestoreCollection
-	if collection == "" {
-		collection = "sticky-routes"
-	}
-
-	ttl := cfg.StickyStoreFirestoreTTL
-	if ttl == 0 {
-		ttl = 720 * time.Hour
-	}
-
-	return firestore.New(client, collection, ttl), client, nil
+	return firestore.New(client, cfg.StickyStoreFirestoreCollection, cfg.StickyStoreFirestoreTTL), client, nil
 }

--- a/pkg/stickystore/firestore/firestore_test.go
+++ b/pkg/stickystore/firestore/firestore_test.go
@@ -29,11 +29,11 @@ func TestDocFields(t *testing.T) {
 }
 
 func TestNewStoreFields(t *testing.T) {
-	s := New(nil, "my-collection", 30*24*time.Hour)
+	s := New(nil, "my-collection", time.Hour)
 	if s.collection != "my-collection" {
 		t.Errorf("collection = %q, want my-collection", s.collection)
 	}
-	if s.ttl != 30*24*time.Hour {
-		t.Errorf("ttl = %v, want 720h", s.ttl)
+	if s.ttl != time.Hour {
+		t.Errorf("ttl = %v, want 1h", s.ttl)
 	}
 }


### PR DESCRIPTION
When setting this up, I made the TTL for sticky routes 30 days.  That was *super* conservative.  Looking over our CI, there are no checks that even exceed 30m, so 1 hour should be more than enough.  This keep cache cleaner and allow for automatic rebalancing.