### PR TITLE
Cache not installed in org

### DIFF
--- a/pkg/ghinstall/ghinstall.go
+++ b/pkg/ghinstall/ghinstall.go
@@ -8,11 +8,13 @@ import (
 	"fmt"
 	"net/http"
 	"sync/atomic"
+	"time"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/chainguard-dev/clog"
 	"github.com/google/go-github/v84/github"
 	lru "github.com/hashicorp/golang-lru/v2"
+	expirablelru "github.com/hashicorp/golang-lru/v2/expirable"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -33,38 +35,43 @@ type Manager interface {
 	GetByInstallation(ctx context.Context, owner string, installationID int64) (*ghinstallation.AppsTransport, int64, error)
 }
 
+const defaultNegativeTTL = 5 * time.Minute
+
 type manager struct {
-	atr   *ghinstallation.AppsTransport
-	cache *lru.TwoQueueCache[string, int64]
+	atr           *ghinstallation.AppsTransport
+	cache         *lru.TwoQueueCache[string, int64]
+	negativeCache *expirablelru.LRU[string, bool]
 }
 
 // New creates a Manager backed by the given AppsTransport.
 func New(atr *ghinstallation.AppsTransport) (Manager, error) {
+	return NewWithNegativeTTL(atr, defaultNegativeTTL)
+}
+
+// NewWithNegativeTTL creates a Manager with a configurable TTL for
+// negative (not-installed) cache entries.
+func NewWithNegativeTTL(atr *ghinstallation.AppsTransport, negativeTTL time.Duration) (Manager, error) {
 	cache, err := lru.New2Q[string, int64](200)
 	if err != nil {
 		return nil, err
 	}
 	return &manager{
-		atr:   atr,
-		cache: cache,
+		atr:           atr,
+		cache:         cache,
+		negativeCache: expirablelru.NewLRU[string, bool](200, nil, negativeTTL),
 	}, nil
 }
-
-// negativeCacheConst is the sentinel value stored in the installation
-// LRU cache when a GitHub App is not installed for an owner. Valid
-// installation IDs are always positive, so 0 is unambiguous.
-const negativeCacheConst int64 = 0
 
 // Get returns the AppsTransport and installation ID for the given owner.
 // scope and identity are unused by the single-app manager; routing across
 // apps is handled by the roundRobin manager.
 func (m *manager) Get(ctx context.Context, owner, _, _ string) (*ghinstallation.AppsTransport, int64, error) {
 	cacheKey := fmt.Sprintf("%d/%s", m.atr.AppID(), owner)
+	if _, ok := m.negativeCache.Get(cacheKey); ok {
+		clog.InfoContextf(ctx, "negative install cache hit for %s", cacheKey)
+		return nil, 0, status.Errorf(codes.NotFound, "no installation found for %q", owner)
+	}
 	if v, ok := m.cache.Get(cacheKey); ok {
-		if v == negativeCacheConst {
-			clog.InfoContextf(ctx, "negative install cache hit for %s", cacheKey)
-			return nil, 0, status.Errorf(codes.NotFound, "no installation found for %q", owner)
-		}
 		clog.InfoContextf(ctx, "found installation in cache for %s", cacheKey)
 		return m.atr, v, nil
 	}
@@ -93,7 +100,7 @@ func (m *manager) Get(ctx context.Context, owner, _, _ string) (*ghinstallation.
 		}
 		page = resp.NextPage
 	}
-	m.cache.Add(cacheKey, negativeCacheConst)
+	m.negativeCache.Add(cacheKey, true)
 	return nil, 0, status.Errorf(codes.NotFound, "no installation found for %q", owner)
 }
 

--- a/pkg/ghinstall/ghinstall.go
+++ b/pkg/ghinstall/ghinstall.go
@@ -50,12 +50,21 @@ func New(atr *ghinstallation.AppsTransport) (Manager, error) {
 	}, nil
 }
 
+// negativeCacheConst is the sentinel value stored in the installation
+// LRU cache when a GitHub App is not installed for an owner. Valid
+// installation IDs are always positive, so 0 is unambiguous.
+const negativeCacheConst int64 = 0
+
 // Get returns the AppsTransport and installation ID for the given owner.
 // scope and identity are unused by the single-app manager; routing across
 // apps is handled by the roundRobin manager.
 func (m *manager) Get(ctx context.Context, owner, _, _ string) (*ghinstallation.AppsTransport, int64, error) {
 	cacheKey := fmt.Sprintf("%d/%s", m.atr.AppID(), owner)
 	if v, ok := m.cache.Get(cacheKey); ok {
+		if v == negativeCacheConst {
+			clog.InfoContextf(ctx, "negative install cache hit for %s", cacheKey)
+			return nil, 0, status.Errorf(codes.NotFound, "no installation found for %q", owner)
+		}
 		clog.InfoContextf(ctx, "found installation in cache for %s", cacheKey)
 		return m.atr, v, nil
 	}
@@ -84,6 +93,7 @@ func (m *manager) Get(ctx context.Context, owner, _, _ string) (*ghinstallation.
 		}
 		page = resp.NextPage
 	}
+	m.cache.Add(cacheKey, negativeCacheConst)
 	return nil, 0, status.Errorf(codes.NotFound, "no installation found for %q", owner)
 }
 

--- a/pkg/ghinstall/ghinstall_test.go
+++ b/pkg/ghinstall/ghinstall_test.go
@@ -375,6 +375,108 @@ func TestRoundRobinWithQuotaColdStartFallsBack(t *testing.T) {
 	}
 }
 
+func TestGetNotFoundCached(t *testing.T) {
+	ctx := context.Background()
+	calls := 0
+
+	atr := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/app/installations":
+			calls++
+			json.NewEncoder(w).Encode([]github.Installation{{
+				ID: github.Ptr(int64(1)),
+				Account: &github.User{
+					Login: github.Ptr("other-org"),
+				},
+			}})
+		default:
+			w.WriteHeader(http.StatusNotImplemented)
+		}
+	}))
+
+	mgr, err := New(atr)
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	// First call: should hit GitHub API and get NotFound.
+	_, _, err = mgr.Get(ctx, "missing-org", "missing-org/repo", "my-identity")
+	if err == nil {
+		t.Fatal("expected error on first call, got nil")
+	}
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.NotFound {
+		t.Fatalf("expected gRPC NotFound, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("API calls after first Get: got = %d, wanted = 1", calls)
+	}
+
+	// Second call: should be served from negative cache, no API call.
+	_, _, err = mgr.Get(ctx, "missing-org", "missing-org/repo", "my-identity")
+	if err == nil {
+		t.Fatal("expected error on second call, got nil")
+	}
+	st, ok = status.FromError(err)
+	if !ok || st.Code() != codes.NotFound {
+		t.Fatalf("expected gRPC NotFound, got %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("API calls after second Get: got = %d, wanted = 1 (negative cache should prevent API call)", calls)
+	}
+}
+
+func TestRoundRobinNotFoundCached(t *testing.T) {
+	ctx := context.Background()
+	appIDs := []int64{12345678, 87654321}
+	callsByApp := map[int64]int{}
+
+	managers := make([]Manager, 0, len(appIDs))
+	for _, appID := range appIDs {
+		calls := &callsByApp
+		id := appID
+		atr := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/app/installations":
+				(*calls)[id]++
+				json.NewEncoder(w).Encode([]github.Installation{})
+			default:
+				w.WriteHeader(http.StatusNotImplemented)
+			}
+		}), appID)
+		m, err := New(atr)
+		if err != nil {
+			t.Fatalf("New() = %v", err)
+		}
+		managers = append(managers, m)
+	}
+
+	rr := NewRoundRobin(managers)
+
+	// First call: both apps should be checked (primary miss + fallback).
+	_, _, err := rr.Get(ctx, "missing-org", "missing-org/repo", "my-identity")
+	if err == nil {
+		t.Fatal("expected error on first call, got nil")
+	}
+	firstTotal := 0
+	for _, c := range callsByApp {
+		firstTotal += c
+	}
+
+	// Second call: negative cache should prevent any new API calls.
+	_, _, err = rr.Get(ctx, "missing-org", "missing-org/repo", "my-identity")
+	if err == nil {
+		t.Fatal("expected error on second call, got nil")
+	}
+	secondTotal := 0
+	for _, c := range callsByApp {
+		secondTotal += c
+	}
+	if secondTotal != firstTotal {
+		t.Errorf("API calls increased from %d to %d on second round-robin Get (negative cache should prevent new calls)", firstTotal, secondTotal)
+	}
+}
+
 func newTestClient(t *testing.T, h http.Handler, appIDs ...int64) *ghinstallation.AppsTransport {
 	t.Helper()
 

--- a/pkg/ghinstall/ghinstall_test.go
+++ b/pkg/ghinstall/ghinstall_test.go
@@ -426,6 +426,55 @@ func TestGetNotFoundCached(t *testing.T) {
 	}
 }
 
+func TestGetNotFoundCacheExpires(t *testing.T) {
+	ctx := context.Background()
+	calls := 0
+
+	atr := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/app/installations":
+			calls++
+			json.NewEncoder(w).Encode([]github.Installation{{
+				ID: github.Ptr(int64(1)),
+				Account: &github.User{
+					Login: github.Ptr("other-org"),
+				},
+			}})
+		default:
+			w.WriteHeader(http.StatusNotImplemented)
+		}
+	}))
+
+	mgr, err := NewWithNegativeTTL(atr, 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("NewWithNegativeTTL() = %v", err)
+	}
+
+	// First call: populates negative cache.
+	_, _, err = mgr.Get(ctx, "missing-org", "missing-org/repo", "my-identity")
+	if err == nil {
+		t.Fatal("expected error on first call, got nil")
+	}
+	if calls != 1 {
+		t.Fatalf("API calls after first Get: got = %d, wanted = 1", calls)
+	}
+
+	// Second call: served from negative cache.
+	_, _, _ = mgr.Get(ctx, "missing-org", "missing-org/repo", "my-identity")
+	if calls != 1 {
+		t.Fatalf("API calls after second Get: got = %d, wanted = 1", calls)
+	}
+
+	// Wait for TTL to expire.
+	time.Sleep(100 * time.Millisecond)
+
+	// Third call: negative cache expired, should hit API again.
+	_, _, _ = mgr.Get(ctx, "missing-org", "missing-org/repo", "my-identity")
+	if calls != 2 {
+		t.Errorf("API calls after TTL expiry: got = %d, wanted = 2", calls)
+	}
+}
+
 func TestRoundRobinNotFoundCached(t *testing.T) {
 	ctx := context.Background()
 	appIDs := []int64{12345678, 87654321}


### PR DESCRIPTION
Similar to https://github.com/octo-sts/app/pull/1334

We've seen a spike where many requests where made to an org without Octo-STS installed.  We should cache these misses to avoid quota exhausting churn.