### PR TITLE
Register host buckets for httpmetrics transport

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -46,6 +46,18 @@ func main() {
 	}
 
 	if baseCfg.Metrics {
+		// Label outbound HTTP traffic by host so dashboards can distinguish
+		// GitHub API calls from background Google API traffic instead of
+		// collapsing everything into "other".
+		metrics.SetBuckets(map[string]string{
+			"api.github.com":                      "GH API",
+			"token.actions.githubusercontent.com": "GitHub Actions Token",
+			"github.com":                          "GitHub",
+		})
+		metrics.SetBucketSuffixes(map[string]string{
+			"googleapis.com": "Google API",
+		})
+
 		go metrics.ServeMetrics()
 
 		// Setup tracing.

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -49,7 +49,7 @@ func main() {
 		// Label outbound HTTP traffic by host so dashboards can distinguish
 		// GitHub API calls from background Google API traffic instead of
 		// collapsing everything into "other".
-		metrics.SetBuckets(map[string]string{
+		metrics.SetBuckets(map[string]string{ //nolint:gosec // G101: hostname -> metric bucket map, not credentials
 			"api.github.com":                      "GH API",
 			"token.actions.githubusercontent.com": "GitHub Actions Token",
 			"github.com":                          "GitHub",

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -42,7 +42,7 @@ func main() {
 		// Label outbound HTTP traffic by host so dashboards can distinguish
 		// GitHub API calls from background Google API traffic instead of
 		// collapsing everything into "other".
-		metrics.SetBuckets(map[string]string{
+		metrics.SetBuckets(map[string]string{ //nolint:gosec // G101: hostname -> metric bucket map, not credentials
 			"api.github.com":                      "GH API",
 			"token.actions.githubusercontent.com": "GitHub Actions Token",
 			"github.com":                          "GitHub",

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -39,6 +39,18 @@ func main() {
 	}
 
 	if baseCfg.Metrics {
+		// Label outbound HTTP traffic by host so dashboards can distinguish
+		// GitHub API calls from background Google API traffic instead of
+		// collapsing everything into "other".
+		metrics.SetBuckets(map[string]string{
+			"api.github.com":                      "GH API",
+			"token.actions.githubusercontent.com": "GitHub Actions Token",
+			"github.com":                          "GitHub",
+		})
+		metrics.SetBucketSuffixes(map[string]string{
+			"googleapis.com": "Google API",
+		})
+
 		go metrics.ServeMetrics()
 
 		// Setup tracing.


### PR DESCRIPTION
## What

Register a host → label map for the `httpmetrics` transport at startup in both `cmd/app` and `cmd/webhook` so outbound calls show up under meaningful host labels instead of `"other"`.

## Why

`httpmetrics.Transport` derives the `host` metric label from a package-level bucket map populated via `SetBuckets`/`SetBucketSuffixes`. When the maps are empty, `bucketize()` falls through to `"other"` for every request and the package logs `"no buckets configured, use httpmetrics.SetBuckets or SetBucketSuffixes"` every tenth call.

octo-sts never calls these setters, so every outbound HTTP call — token mints, installation lookups, OIDC validation, KMS/Secret Manager/Firestore — gets the same `host="other"` label. That makes per-destination dashboards and rate-limit views useless and means standard fleet dashboards that filter on `host=~"GH API|github|GitHub"` miss octo-sts's GitHub traffic entirely.

The fix is the smallest possible: register a map for the hostnames octo-sts actually contacts.

## Notes

- The bucket *values* (e.g. `"GH API"`, `"GitHub Actions Token"`) match labels in use by other consumers of `terraform-infra-common/pkg/httpmetrics`, so existing dashboards keyed on them just start working for octo-sts.
- No behavior change beyond the metric label; transport, retries, and rate limit accounting are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)