### PR TITLE
fix(webhook): skip full directory scan for new-branch check_suite events

### DIFF
--- a/pkg/webhook/testdata/api/v3/repos/foo/bar/compare/abcd1234...5678
+++ b/pkg/webhook/testdata/api/v3/repos/foo/bar/compare/abcd1234...5678
@@ -1,0 +1,422 @@
+{
+  "url": "https://api.github.com/repos/chainguard-dev/wlynch-test/compare/main...77d49996a5b88ff14fa57eb9094a0316d23b7537",
+  "html_url": "https://github.com/chainguard-dev/wlynch-test/compare/main...77d49996a5b88ff14fa57eb9094a0316d23b7537",
+  "permalink_url": "https://github.com/chainguard-dev/wlynch-test/compare/chainguard-dev:306e576...chainguard-dev:77d4999",
+  "diff_url": "https://github.com/chainguard-dev/wlynch-test/compare/main...77d49996a5b88ff14fa57eb9094a0316d23b7537.diff",
+  "patch_url": "https://github.com/chainguard-dev/wlynch-test/compare/main...77d49996a5b88ff14fa57eb9094a0316d23b7537.patch",
+  "base_commit": {
+    "sha": "306e576f9026d6afb4baa812df3dd538c35c006d",
+    "node_id": "C_kwDOHUbyj9oAKDMwNmU1NzZmOTAyNmQ2YWZiNGJhYTgxMmRmM2RkNTM4YzM1YzAwNmQ",
+    "commit": {
+      "author": {
+        "name": "Billy Lynch",
+        "email": "1844673+wlynch@users.noreply.github.com",
+        "date": "2024-09-03T18:26:21Z"
+      },
+      "committer": {
+        "name": "GitHub",
+        "email": "noreply@github.com",
+        "date": "2024-09-03T18:26:21Z"
+      },
+      "message": "Create test.sts.yaml\n\nSigned-off-by: Billy Lynch <1844673+wlynch@users.noreply.github.com>",
+      "tree": {
+        "sha": "51c2ca22e725d908da339f40c38a78ab10c69b7e",
+        "url": "https://api.github.com/repos/chainguard-dev/wlynch-test/git/trees/51c2ca22e725d908da339f40c38a78ab10c69b7e"
+      },
+      "url": "https://api.github.com/repos/chainguard-dev/wlynch-test/git/commits/306e576f9026d6afb4baa812df3dd538c35c006d",
+      "comment_count": 0,
+      "verification": {
+        "verified": true,
+        "reason": "valid",
+        "signature": "-----BEGIN PGP SIGNATURE-----\n\nwsFcBAABCAAQBQJm11TNCRC1aQ7uu5UhlAAAvjIQAAYWvoNzlNBOftmCWDdlRD7/\nFpbzoLMAXpuVVh/pPJvfN04ywtmwbDRHDD+Tu7qHHDHe4dyYrqmCT94e5/4kJAtg\ngrhsXhSJQQNOsZTDXV28E7mMKTXUGa1ewB8d6mmhTAWQTuMpCVzWXlUa3qauMP1F\niih49n1YxVLSUFz+U1C/NeacWJC2pGcsLs3lZSmeTQ0kF2i6iFkQyYSVv4uDhUCt\n4iktN3nZY9WhQQ3ucWMQhqk4iNkg9Cusw8pXYMd5V09DQJhNInkjiril55kk8dow\nCfaF5zdPdbWKEPJNvq3Jp7cBuEbGz74TQPkK9OBE4P+GRZu0C0u/fSv63ifXL9W0\nQKh2NXUljmsZ4kmrDla4wWEU4Hdr+r6nmpxRWCUGzOhAgqIQWLE+xW/NF6XodXBK\nfUWh1jfRszbsesC6OdBjsqiqsznCSLhPXZ7XBdJvpf4NzDxBtqn2O0ajfzM8OZRA\n7n+DhC7RiFUKIONapiTFicrz7ZQBRxTJQkcm+ics6hykpvdaN3f6sz2y6apw5OD1\ng55rjcN3lm+36KUI/hE0CGMrYcTAq59KIdYwUE2Sq8NuE2PBv94zOd1Xdud8ryuk\nJVxUG/sOaRP33zYD/VHxR1VN5PDzgSqWqFNPlv8T3cJ0bh/q2WJHoqyMNubZdS/8\nL8t06DSWGSSjZdNuUVdW\n=QFtw\n-----END PGP SIGNATURE-----\n",
+        "payload": "tree 51c2ca22e725d908da339f40c38a78ab10c69b7e\nparent a3d5fd86ce35211a5312a60bc5bdd44ecc426bfa\nauthor Billy Lynch <1844673+wlynch@users.noreply.github.com> 1725387981 -0400\ncommitter GitHub <noreply@github.com> 1725387981 -0400\n\nCreate test.sts.yaml\n\nSigned-off-by: Billy Lynch <1844673+wlynch@users.noreply.github.com>"
+      }
+    },
+    "url": "https://api.github.com/repos/chainguard-dev/wlynch-test/commits/306e576f9026d6afb4baa812df3dd538c35c006d",
+    "html_url": "https://github.com/chainguard-dev/wlynch-test/commit/306e576f9026d6afb4baa812df3dd538c35c006d",
+    "comments_url": "https://api.github.com/repos/chainguard-dev/wlynch-test/commits/306e576f9026d6afb4baa812df3dd538c35c006d/comments",
+    "author": {
+      "login": "wlynch",
+      "id": 1844673,
+      "node_id": "MDQ6VXNlcjE4NDQ2NzM=",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1844673?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/wlynch",
+      "html_url": "https://github.com/wlynch",
+      "followers_url": "https://api.github.com/users/wlynch/followers",
+      "following_url": "https://api.github.com/users/wlynch/following{/other_user}",
+      "gists_url": "https://api.github.com/users/wlynch/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/wlynch/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/wlynch/subscriptions",
+      "organizations_url": "https://api.github.com/users/wlynch/orgs",
+      "repos_url": "https://api.github.com/users/wlynch/repos",
+      "events_url": "https://api.github.com/users/wlynch/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/wlynch/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "web-flow",
+      "id": 19864447,
+      "node_id": "MDQ6VXNlcjE5ODY0NDQ3",
+      "avatar_url": "https://avatars.githubusercontent.com/u/19864447?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/web-flow",
+      "html_url": "https://github.com/web-flow",
+      "followers_url": "https://api.github.com/users/web-flow/followers",
+      "following_url": "https://api.github.com/users/web-flow/following{/other_user}",
+      "gists_url": "https://api.github.com/users/web-flow/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/web-flow/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/web-flow/subscriptions",
+      "organizations_url": "https://api.github.com/users/web-flow/orgs",
+      "repos_url": "https://api.github.com/users/web-flow/repos",
+      "events_url": "https://api.github.com/users/web-flow/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/web-flow/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "a3d5fd86ce35211a5312a60bc5bdd44ecc426bfa",
+        "url": "https://api.github.com/repos/chainguard-dev/wlynch-test/commits/a3d5fd86ce35211a5312a60bc5bdd44ecc426bfa",
+        "html_url": "https://github.com/chainguard-dev/wlynch-test/commit/a3d5fd86ce35211a5312a60bc5bdd44ecc426bfa"
+      }
+    ]
+  },
+  "merge_base_commit": {
+    "sha": "306e576f9026d6afb4baa812df3dd538c35c006d",
+    "node_id": "C_kwDOHUbyj9oAKDMwNmU1NzZmOTAyNmQ2YWZiNGJhYTgxMmRmM2RkNTM4YzM1YzAwNmQ",
+    "commit": {
+      "author": {
+        "name": "Billy Lynch",
+        "email": "1844673+wlynch@users.noreply.github.com",
+        "date": "2024-09-03T18:26:21Z"
+      },
+      "committer": {
+        "name": "GitHub",
+        "email": "noreply@github.com",
+        "date": "2024-09-03T18:26:21Z"
+      },
+      "message": "Create test.sts.yaml\n\nSigned-off-by: Billy Lynch <1844673+wlynch@users.noreply.github.com>",
+      "tree": {
+        "sha": "51c2ca22e725d908da339f40c38a78ab10c69b7e",
+        "url": "https://api.github.com/repos/chainguard-dev/wlynch-test/git/trees/51c2ca22e725d908da339f40c38a78ab10c69b7e"
+      },
+      "url": "https://api.github.com/repos/chainguard-dev/wlynch-test/git/commits/306e576f9026d6afb4baa812df3dd538c35c006d",
+      "comment_count": 0,
+      "verification": {
+        "verified": true,
+        "reason": "valid",
+        "signature": "-----BEGIN PGP SIGNATURE-----\n\nwsFcBAABCAAQBQJm11TNCRC1aQ7uu5UhlAAAvjIQAAYWvoNzlNBOftmCWDdlRD7/\nFpbzoLMAXpuVVh/pPJvfN04ywtmwbDRHDD+Tu7qHHDHe4dyYrqmCT94e5/4kJAtg\ngrhsXhSJQQNOsZTDXV28E7mMKTXUGa1ewB8d6mmhTAWQTuMpCVzWXlUa3qauMP1F\niih49n1YxVLSUFz+U1C/NeacWJC2pGcsLs3lZSmeTQ0kF2i6iFkQyYSVv4uDhUCt\n4iktN3nZY9WhQQ3ucWMQhqk4iNkg9Cusw8pXYMd5V09DQJhNInkjiril55kk8dow\nCfaF5zdPdbWKEPJNvq3Jp7cBuEbGz74TQPkK9OBE4P+GRZu0C0u/fSv63ifXL9W0\nQKh2NXUljmsZ4kmrDla4wWEU4Hdr+r6nmpxRWCUGzOhAgqIQWLE+xW/NF6XodXBK\nfUWh1jfRszbsesC6OdBjsqiqsznCSLhPXZ7XBdJvpf4NzDxBtqn2O0ajfzM8OZRA\n7n+DhC7RiFUKIONapiTFicrz7ZQBRxTJQkcm+ics6hykpvdaN3f6sz2y6apw5OD1\ng55rjcN3lm+36KUI/hE0CGMrYcTAq59KIdYwUE2Sq8NuE2PBv94zOd1Xdud8ryuk\nJVxUG/sOaRP33zYD/VHxR1VN5PDzgSqWqFNPlv8T3cJ0bh/q2WJHoqyMNubZdS/8\nL8t06DSWGSSjZdNuUVdW\n=QFtw\n-----END PGP SIGNATURE-----\n",
+        "payload": "tree 51c2ca22e725d908da339f40c38a78ab10c69b7e\nparent a3d5fd86ce35211a5312a60bc5bdd44ecc426bfa\nauthor Billy Lynch <1844673+wlynch@users.noreply.github.com> 1725387981 -0400\ncommitter GitHub <noreply@github.com> 1725387981 -0400\n\nCreate test.sts.yaml\n\nSigned-off-by: Billy Lynch <1844673+wlynch@users.noreply.github.com>"
+      }
+    },
+    "url": "https://api.github.com/repos/chainguard-dev/wlynch-test/commits/306e576f9026d6afb4baa812df3dd538c35c006d",
+    "html_url": "https://github.com/chainguard-dev/wlynch-test/commit/306e576f9026d6afb4baa812df3dd538c35c006d",
+    "comments_url": "https://api.github.com/repos/chainguard-dev/wlynch-test/commits/306e576f9026d6afb4baa812df3dd538c35c006d/comments",
+    "author": {
+      "login": "wlynch",
+      "id": 1844673,
+      "node_id": "MDQ6VXNlcjE4NDQ2NzM=",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1844673?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/wlynch",
+      "html_url": "https://github.com/wlynch",
+      "followers_url": "https://api.github.com/users/wlynch/followers",
+      "following_url": "https://api.github.com/users/wlynch/following{/other_user}",
+      "gists_url": "https://api.github.com/users/wlynch/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/wlynch/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/wlynch/subscriptions",
+      "organizations_url": "https://api.github.com/users/wlynch/orgs",
+      "repos_url": "https://api.github.com/users/wlynch/repos",
+      "events_url": "https://api.github.com/users/wlynch/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/wlynch/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "web-flow",
+      "id": 19864447,
+      "node_id": "MDQ6VXNlcjE5ODY0NDQ3",
+      "avatar_url": "https://avatars.githubusercontent.com/u/19864447?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/web-flow",
+      "html_url": "https://github.com/web-flow",
+      "followers_url": "https://api.github.com/users/web-flow/followers",
+      "following_url": "https://api.github.com/users/web-flow/following{/other_user}",
+      "gists_url": "https://api.github.com/users/web-flow/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/web-flow/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/web-flow/subscriptions",
+      "organizations_url": "https://api.github.com/users/web-flow/orgs",
+      "repos_url": "https://api.github.com/users/web-flow/repos",
+      "events_url": "https://api.github.com/users/web-flow/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/web-flow/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "a3d5fd86ce35211a5312a60bc5bdd44ecc426bfa",
+        "url": "https://api.github.com/repos/chainguard-dev/wlynch-test/commits/a3d5fd86ce35211a5312a60bc5bdd44ecc426bfa",
+        "html_url": "https://github.com/chainguard-dev/wlynch-test/commit/a3d5fd86ce35211a5312a60bc5bdd44ecc426bfa"
+      }
+    ]
+  },
+  "status": "ahead",
+  "ahead_by": 3,
+  "behind_by": 0,
+  "total_commits": 3,
+  "commits": [
+    {
+      "sha": "ec5f20ca49dddf140fec315b97eb1e00cec2510c",
+      "node_id": "C_kwDOHUbyj9oAKGVjNWYyMGNhNDlkZGRmMTQwZmVjMzE1Yjk3ZWIxZTAwY2VjMjUxMGM",
+      "commit": {
+        "author": {
+          "name": "Billy Lynch",
+          "email": "1844673+wlynch@users.noreply.github.com",
+          "date": "2024-09-03T18:36:30Z"
+        },
+        "committer": {
+          "name": "GitHub",
+          "email": "noreply@github.com",
+          "date": "2024-09-03T18:36:30Z"
+        },
+        "message": "Update test.sts.yaml\n\nSigned-off-by: Billy Lynch <1844673+wlynch@users.noreply.github.com>",
+        "tree": {
+          "sha": "695af171c215d1a82afa7e045d3589ad5fee39a6",
+          "url": "https://api.github.com/repos/chainguard-dev/wlynch-test/git/trees/695af171c215d1a82afa7e045d3589ad5fee39a6"
+        },
+        "url": "https://api.github.com/repos/chainguard-dev/wlynch-test/git/commits/ec5f20ca49dddf140fec315b97eb1e00cec2510c",
+        "comment_count": 0,
+        "verification": {
+          "verified": true,
+          "reason": "valid",
+          "signature": "-----BEGIN PGP SIGNATURE-----\n\nwsFcBAABCAAQBQJm11cuCRC1aQ7uu5UhlAAAEF4QALEIzqZg5sd2aV5ihQiNyph5\npHvm0PDdyMiZUjJt3dC/abIkcWcUFoCVPRvhmIs6/PPAtxOGNhobjzSCb6LTADNM\nXwaTbDFuB8C+p27u1q++gEHxCc476ZZ8MA/YRUndPYznZcUHiRdS3MkW+E5Wuv3a\nLCh8k5/JO/q3n/UtlyPyBa1Ogq/DWIn5wyOEERXfsAmOp7vZOM8E2C4743qrhzbI\nqdgDcGAVP88/ujP49HlQHQnCub3WkY683WOb45LjjvpoZgWkJkf0n+xZ08eCwp38\nwuUm3XHXRNT4IuuPJbc0BKwCvLJTuSIg8w8jdgdu5ix9UcrSOgHK8tNg9bGPd/PF\nz0OoEizaHdIWtBe09ag7WUmVzOLR370sjdADkEoTyUwd/Ad50XO3Vh5EWaEMiSrq\nT04tt5tFbv5rwH5Dl8RaDOag5zmkGFqQD4BhfXykNLW4Vbu3+518cjyEyzj3xpyu\nIL/xpzPPT8DtqoFdMFsgB5JOLkjB3LH43eVWhGcCaaMBdzUs+qoramOL1NSQC442\nRs8MCz0AGWPQQ5Ucc+JsAPwmf8/YuDDSX+gah4CpzPBH0KsEpAOAICmcogXfNG/k\n9DlBTiC1E1NRjtFlASdgt4P5TzQoZoqvmary2sphcoqs6o+sENc/zIrY/4gFj+KG\nM3AAIQrdvzXBP/KgvFVv\n=3hqu\n-----END PGP SIGNATURE-----\n",
+          "payload": "tree 695af171c215d1a82afa7e045d3589ad5fee39a6\nparent 306e576f9026d6afb4baa812df3dd538c35c006d\nauthor Billy Lynch <1844673+wlynch@users.noreply.github.com> 1725388590 -0400\ncommitter GitHub <noreply@github.com> 1725388590 -0400\n\nUpdate test.sts.yaml\n\nSigned-off-by: Billy Lynch <1844673+wlynch@users.noreply.github.com>"
+        }
+      },
+      "url": "https://api.github.com/repos/chainguard-dev/wlynch-test/commits/ec5f20ca49dddf140fec315b97eb1e00cec2510c",
+      "html_url": "https://github.com/chainguard-dev/wlynch-test/commit/ec5f20ca49dddf140fec315b97eb1e00cec2510c",
+      "comments_url": "https://api.github.com/repos/chainguard-dev/wlynch-test/commits/ec5f20ca49dddf140fec315b97eb1e00cec2510c/comments",
+      "author": {
+        "login": "wlynch",
+        "id": 1844673,
+        "node_id": "MDQ6VXNlcjE4NDQ2NzM=",
+        "avatar_url": "https://avatars.githubusercontent.com/u/1844673?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/wlynch",
+        "html_url": "https://github.com/wlynch",
+        "followers_url": "https://api.github.com/users/wlynch/followers",
+        "following_url": "https://api.github.com/users/wlynch/following{/other_user}",
+        "gists_url": "https://api.github.com/users/wlynch/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/wlynch/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/wlynch/subscriptions",
+        "organizations_url": "https://api.github.com/users/wlynch/orgs",
+        "repos_url": "https://api.github.com/users/wlynch/repos",
+        "events_url": "https://api.github.com/users/wlynch/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/wlynch/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "committer": {
+        "login": "web-flow",
+        "id": 19864447,
+        "node_id": "MDQ6VXNlcjE5ODY0NDQ3",
+        "avatar_url": "https://avatars.githubusercontent.com/u/19864447?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/web-flow",
+        "html_url": "https://github.com/web-flow",
+        "followers_url": "https://api.github.com/users/web-flow/followers",
+        "following_url": "https://api.github.com/users/web-flow/following{/other_user}",
+        "gists_url": "https://api.github.com/users/web-flow/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/web-flow/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/web-flow/subscriptions",
+        "organizations_url": "https://api.github.com/users/web-flow/orgs",
+        "repos_url": "https://api.github.com/users/web-flow/repos",
+        "events_url": "https://api.github.com/users/web-flow/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/web-flow/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "parents": [
+        {
+          "sha": "306e576f9026d6afb4baa812df3dd538c35c006d",
+          "url": "https://api.github.com/repos/chainguard-dev/wlynch-test/commits/306e576f9026d6afb4baa812df3dd538c35c006d",
+          "html_url": "https://github.com/chainguard-dev/wlynch-test/commit/306e576f9026d6afb4baa812df3dd538c35c006d"
+        }
+      ]
+    },
+    {
+      "sha": "875521ccd705857d0223213c464cab39d5c5431f",
+      "node_id": "C_kwDOHUbyj9oAKDg3NTUyMWNjZDcwNTg1N2QwMjIzMjEzYzQ2NGNhYjM5ZDVjNTQzMWY",
+      "commit": {
+        "author": {
+          "name": "Billy Lynch",
+          "email": "1844673+wlynch@users.noreply.github.com",
+          "date": "2024-09-03T19:23:21Z"
+        },
+        "committer": {
+          "name": "GitHub",
+          "email": "noreply@github.com",
+          "date": "2024-09-03T19:23:21Z"
+        },
+        "message": "Update test.sts.yaml\n\nSigned-off-by: Billy Lynch <1844673+wlynch@users.noreply.github.com>",
+        "tree": {
+          "sha": "13f2829a9d0a2348abddadcc9460492d03d637a6",
+          "url": "https://api.github.com/repos/chainguard-dev/wlynch-test/git/trees/13f2829a9d0a2348abddadcc9460492d03d637a6"
+        },
+        "url": "https://api.github.com/repos/chainguard-dev/wlynch-test/git/commits/875521ccd705857d0223213c464cab39d5c5431f",
+        "comment_count": 0,
+        "verification": {
+          "verified": true,
+          "reason": "valid",
+          "signature": "-----BEGIN PGP SIGNATURE-----\n\nwsFcBAABCAAQBQJm12IpCRC1aQ7uu5UhlAAALB8QAEDlJ1+3K0QJlpQyQgXA7qlH\netd7xrjOdigvGtq6z6H86eTyMYO7QTApTAAKh6U6H0yLTylQglu2AUaLeE+1Nri+\neOkqkn2bVxqZFzRxdkMFLTEgLbMkQM1LFfKEaB3OVRfFbE9Tsec4rpB9SX/segfv\ns+CVFYz6S+xATwXEf59FZnJ24xHihMGp4eQBighf6H0uReroDgVb4IBnTt8b31iX\nNPDI6ZYilZYVc+BCmMbDHOZvHfoRbassCdYkAzGZVbC2pYZr7elWXJx98XRPiJrB\ncFgmCiUQ0Wv7q2G/0zrADcKe6k72JWPiG5R3JUK0hK5dRmAx+mLvMn0huy3YMTxW\nGA7uPzGFs7J98cjcgRoihW3mqYXt9EfOEjhQpv+3mO38JHsMuxgouf4djE5sF8OL\nlsT4V5UdF6TEX1tQMKuaN4rx4KOa5T0T5CYQ9IjZR7fjRnboG3uUBKRMvvmnIL1z\nbT8c1vsW55C2E8/rDfowlIsfMOmD2Y6/VS9RINpjebSNLRz5M2w4kR8JcF5wP1Wd\nNiuRIDghX7JqCr3EDrNZQl2j6LJskcFJ6NcEVpyAw5Q6yGJIKyApKq2F0S0idTyr\nnqa//MP9yJ+1yFJlFrTRM80jazTd8yQws2WvhS3lE109r6NSMdklWXKFL9SYfOGj\nmqoq2H2ia201ri/DwPjm\n=8xs5\n-----END PGP SIGNATURE-----\n",
+          "payload": "tree 13f2829a9d0a2348abddadcc9460492d03d637a6\nparent ec5f20ca49dddf140fec315b97eb1e00cec2510c\nauthor Billy Lynch <1844673+wlynch@users.noreply.github.com> 1725391401 -0400\ncommitter GitHub <noreply@github.com> 1725391401 -0400\n\nUpdate test.sts.yaml\n\nSigned-off-by: Billy Lynch <1844673+wlynch@users.noreply.github.com>"
+        }
+      },
+      "url": "https://api.github.com/repos/chainguard-dev/wlynch-test/commits/875521ccd705857d0223213c464cab39d5c5431f",
+      "html_url": "https://github.com/chainguard-dev/wlynch-test/commit/875521ccd705857d0223213c464cab39d5c5431f",
+      "comments_url": "https://api.github.com/repos/chainguard-dev/wlynch-test/commits/875521ccd705857d0223213c464cab39d5c5431f/comments",
+      "author": {
+        "login": "wlynch",
+        "id": 1844673,
+        "node_id": "MDQ6VXNlcjE4NDQ2NzM=",
+        "avatar_url": "https://avatars.githubusercontent.com/u/1844673?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/wlynch",
+        "html_url": "https://github.com/wlynch",
+        "followers_url": "https://api.github.com/users/wlynch/followers",
+        "following_url": "https://api.github.com/users/wlynch/following{/other_user}",
+        "gists_url": "https://api.github.com/users/wlynch/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/wlynch/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/wlynch/subscriptions",
+        "organizations_url": "https://api.github.com/users/wlynch/orgs",
+        "repos_url": "https://api.github.com/users/wlynch/repos",
+        "events_url": "https://api.github.com/users/wlynch/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/wlynch/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "committer": {
+        "login": "web-flow",
+        "id": 19864447,
+        "node_id": "MDQ6VXNlcjE5ODY0NDQ3",
+        "avatar_url": "https://avatars.githubusercontent.com/u/19864447?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/web-flow",
+        "html_url": "https://github.com/web-flow",
+        "followers_url": "https://api.github.com/users/web-flow/followers",
+        "following_url": "https://api.github.com/users/web-flow/following{/other_user}",
+        "gists_url": "https://api.github.com/users/web-flow/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/web-flow/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/web-flow/subscriptions",
+        "organizations_url": "https://api.github.com/users/web-flow/orgs",
+        "repos_url": "https://api.github.com/users/web-flow/repos",
+        "events_url": "https://api.github.com/users/web-flow/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/web-flow/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "parents": [
+        {
+          "sha": "ec5f20ca49dddf140fec315b97eb1e00cec2510c",
+          "url": "https://api.github.com/repos/chainguard-dev/wlynch-test/commits/ec5f20ca49dddf140fec315b97eb1e00cec2510c",
+          "html_url": "https://github.com/chainguard-dev/wlynch-test/commit/ec5f20ca49dddf140fec315b97eb1e00cec2510c"
+        }
+      ]
+    },
+    {
+      "sha": "77d49996a5b88ff14fa57eb9094a0316d23b7537",
+      "node_id": "C_kwDOHUbyj9oAKDc3ZDQ5OTk2YTViODhmZjE0ZmE1N2ViOTA5NGEwMzE2ZDIzYjc1Mzc",
+      "commit": {
+        "author": {
+          "name": "Billy Lynch",
+          "email": "1844673+wlynch@users.noreply.github.com",
+          "date": "2024-09-03T21:11:04Z"
+        },
+        "committer": {
+          "name": "GitHub",
+          "email": "noreply@github.com",
+          "date": "2024-09-03T21:11:04Z"
+        },
+        "message": "Update test.sts.yaml\n\nSigned-off-by: Billy Lynch <1844673+wlynch@users.noreply.github.com>",
+        "tree": {
+          "sha": "733d1ebc10535291c48eda45872f65c73b9e019a",
+          "url": "https://api.github.com/repos/chainguard-dev/wlynch-test/git/trees/733d1ebc10535291c48eda45872f65c73b9e019a"
+        },
+        "url": "https://api.github.com/repos/chainguard-dev/wlynch-test/git/commits/77d49996a5b88ff14fa57eb9094a0316d23b7537",
+        "comment_count": 0,
+        "verification": {
+          "verified": true,
+          "reason": "valid",
+          "signature": "-----BEGIN PGP SIGNATURE-----\n\nwsFcBAABCAAQBQJm13tpCRC1aQ7uu5UhlAAAKQYQACiAsy3C36c7kwZA0corgWa4\n+F9EQviJ/ZUunwzWpkE/Yj/n3TinyZbrXRnAah1i1EErhfoJ4G0g+Nir4GcEekOs\nonq+y8Me9ZxSxrefi1aOclqx0BPyYuhplhKt0T3i1jUvvCWWsCVraCy3AF/bUMyv\nv8oDl5k6lmNE+ZMxMSiSpx9un9iscmKy8schSXzLQDvuBodhdlWTfTlOmTBZOMtn\nbekPTV4Y3Wg0YoXeEbnf2s3QGTaXCm7Df593SlmEul/tX7i8BteBx66idFhMZ9Jg\n4QYOownYTIhT1gnoRmkIMiE7Uxc+DG0Wtj0sCKSIR4YLcj33EH57DAaC45LHlZzU\nc3sxQb0dy81DAawdCh6EgioeKFJFJoBc+BKPeGI2qWywRea9rzMiz27Aft691DYi\nQU6DIG8RvUU8lqC38zBry9NvnTeT0IrpxQhZ7GNKIlbWNty0WOz8vudHBBkrwhgR\nMtv7GvE+nducvmRdDPBVxFbWvZEH8ZYlzN7GWdUgiV/SzEJt02kuuOdhKVRgHZ38\n0AUs1A3YnSVhOL/284Ns11uHi/55PMJqywWxjEtrGQbI2F4yrZ1BlI1UoiXEp3yY\nuio4Bli8glvCkkVQ5AF1dgSVNloQh6tMHiz8sLn3/FSJTY9wqHnS0FxBLEMcyLzl\nW1dePrhYnNUz+npJJmW6\n=WWdO\n-----END PGP SIGNATURE-----\n",
+          "payload": "tree 733d1ebc10535291c48eda45872f65c73b9e019a\nparent 875521ccd705857d0223213c464cab39d5c5431f\nauthor Billy Lynch <1844673+wlynch@users.noreply.github.com> 1725397864 -0400\ncommitter GitHub <noreply@github.com> 1725397864 -0400\n\nUpdate test.sts.yaml\n\nSigned-off-by: Billy Lynch <1844673+wlynch@users.noreply.github.com>"
+        }
+      },
+      "url": "https://api.github.com/repos/chainguard-dev/wlynch-test/commits/77d49996a5b88ff14fa57eb9094a0316d23b7537",
+      "html_url": "https://github.com/chainguard-dev/wlynch-test/commit/77d49996a5b88ff14fa57eb9094a0316d23b7537",
+      "comments_url": "https://api.github.com/repos/chainguard-dev/wlynch-test/commits/77d49996a5b88ff14fa57eb9094a0316d23b7537/comments",
+      "author": {
+        "login": "wlynch",
+        "id": 1844673,
+        "node_id": "MDQ6VXNlcjE4NDQ2NzM=",
+        "avatar_url": "https://avatars.githubusercontent.com/u/1844673?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/wlynch",
+        "html_url": "https://github.com/wlynch",
+        "followers_url": "https://api.github.com/users/wlynch/followers",
+        "following_url": "https://api.github.com/users/wlynch/following{/other_user}",
+        "gists_url": "https://api.github.com/users/wlynch/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/wlynch/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/wlynch/subscriptions",
+        "organizations_url": "https://api.github.com/users/wlynch/orgs",
+        "repos_url": "https://api.github.com/users/wlynch/repos",
+        "events_url": "https://api.github.com/users/wlynch/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/wlynch/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "committer": {
+        "login": "web-flow",
+        "id": 19864447,
+        "node_id": "MDQ6VXNlcjE5ODY0NDQ3",
+        "avatar_url": "https://avatars.githubusercontent.com/u/19864447?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/web-flow",
+        "html_url": "https://github.com/web-flow",
+        "followers_url": "https://api.github.com/users/web-flow/followers",
+        "following_url": "https://api.github.com/users/web-flow/following{/other_user}",
+        "gists_url": "https://api.github.com/users/web-flow/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/web-flow/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/web-flow/subscriptions",
+        "organizations_url": "https://api.github.com/users/web-flow/orgs",
+        "repos_url": "https://api.github.com/users/web-flow/repos",
+        "events_url": "https://api.github.com/users/web-flow/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/web-flow/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "parents": [
+        {
+          "sha": "875521ccd705857d0223213c464cab39d5c5431f",
+          "url": "https://api.github.com/repos/chainguard-dev/wlynch-test/commits/875521ccd705857d0223213c464cab39d5c5431f",
+          "html_url": "https://github.com/chainguard-dev/wlynch-test/commit/875521ccd705857d0223213c464cab39d5c5431f"
+        }
+      ]
+    }
+  ],
+  "files": [
+    {
+      "sha": "8a5b8bd985920c84d8fbcf3e04366b679e412b06",
+      "filename": ".github/chainguard/test.sts.yaml",
+      "status": "modified",
+      "additions": 1,
+      "deletions": 0,
+      "changes": 1,
+      "blob_url": "https://github.com/chainguard-dev/wlynch-test/blob/77d49996a5b88ff14fa57eb9094a0316d23b7537/.github%2Fchainguard%2Ftest.sts.yaml",
+      "raw_url": "https://github.com/chainguard-dev/wlynch-test/raw/77d49996a5b88ff14fa57eb9094a0316d23b7537/.github%2Fchainguard%2Ftest.sts.yaml",
+      "contents_url": "https://api.github.com/repos/chainguard-dev/wlynch-test/contents/.github%2Fchainguard%2Ftest.sts.yaml?ref=77d49996a5b88ff14fa57eb9094a0316d23b7537",
+      "patch": "@@ -1,3 +1,4 @@\n+# asdf asdfas\n issuer: https://accounts.google.com\n subject_pattern: '[0-9]+'\n claim_pattern:"
+    }
+  ]
+}

--- a/pkg/webhook/testdata/api/v3/repos/foo/bar/pulls/42/files
+++ b/pkg/webhook/testdata/api/v3/repos/foo/bar/pulls/42/files
@@ -1,0 +1,10 @@
+[
+  {
+    "sha": "abc123",
+    "filename": ".github/chainguard/test.sts.yaml",
+    "status": "added",
+    "additions": 10,
+    "deletions": 0,
+    "changes": 10
+  }
+]

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -362,6 +362,21 @@ func (e *Validator) handleCheckSuite(ctx context.Context, cs checkSuite) (*githu
 
 	var files []string
 	if cs.GetCheckSuite().GetBeforeSHA() == zeroHash {
+		// New non-default branch: skip if there are no associated PRs.
+		// A feature branch points at a commit already present in the
+		// repository and doesn't need a full directory scan. This
+		// avoids reading every policy file (O(N) API calls) on every
+		// new-branch event.
+		//
+		// We still process the default branch (initial commit) and
+		// any branch with associated PRs, since those may introduce
+		// new or modified policy files.
+		defaultBranch := cs.GetRepo().GetDefaultBranch()
+		headBranch := cs.GetCheckSuite().GetHeadBranch()
+		if headBranch != defaultBranch && len(cs.GetCheckSuite().PullRequests) == 0 {
+			log.Infof("skipping new non-default branch with no PRs")
+			return nil, nil
+		}
 		_, dirContents, _, err := client.Repositories.GetContents(ctx, owner, repo, ".github/chainguard", &github.RepositoryContentGetOptions{Ref: sha})
 		if err != nil {
 			return nil, err

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -769,3 +769,431 @@ func TestWebhookPushBoundary19Commits(t *testing.T) {
 		t.Fatal("Compare API was called but should not have been for 19 commits")
 	}
 }
+
+func TestCheckSuiteNewBranchNoPRsSkipped(t *testing.T) {
+	got := []*github.CreateCheckRunOptions{}
+
+	apiCalled := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v3/repos/foo/bar/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		opt := new(github.CreateCheckRunOptions)
+		if err := json.NewDecoder(r.Body).Decode(opt); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		got = append(got, opt)
+	})
+	mux.HandleFunc("/api/v3/repos/foo/bar/contents/", func(w http.ResponseWriter, r *http.Request) {
+		apiCalled = true
+		t.Error("Contents API should not be called for skipped new branch")
+		http.Error(w, "should not be called", http.StatusInternalServerError)
+	})
+	mux.HandleFunc("/api/v3/repos/foo/bar/compare/", func(w http.ResponseWriter, r *http.Request) {
+		apiCalled = true
+		t.Error("Compare API should not be called for skipped new branch")
+		http.Error(w, "should not be called", http.StatusInternalServerError)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		path := filepath.Join("testdata", r.URL.Path)
+		f, err := os.Open(path)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		defer f.Close()
+		io.Copy(w, f)
+	})
+	gh := httptest.NewServer(mux)
+	defer gh.Close()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr := ghinstallation.NewAppsTransportFromPrivateKey(gh.Client().Transport, 1234, key)
+	tr.BaseURL = gh.URL
+
+	secret := []byte("hunter2")
+	v := &Validator{
+		Transport:     tr,
+		WebhookSecret: [][]byte{secret},
+	}
+	srv := httptest.NewServer(v)
+	defer srv.Close()
+
+	body, err := json.Marshal(github.CheckSuiteEvent{
+		Installation: &github.Installation{
+			ID: github.Ptr(int64(1111)),
+		},
+		Repo: &github.Repository{
+			Owner: &github.User{
+				Login: github.Ptr("foo"),
+			},
+			Name:          github.Ptr("bar"),
+			FullName:      github.Ptr("foo/bar"),
+			DefaultBranch: github.Ptr("main"),
+		},
+		Sender: &github.User{Login: github.Ptr("test-user")},
+		Action: github.Ptr("requested"),
+		CheckSuite: &github.CheckSuite{
+			ID:           github.Ptr(int64(1)),
+			HeadSHA:      github.Ptr("deadbeef"),
+			HeadBranch:   github.Ptr("feature-x"),
+			BeforeSHA:    github.Ptr(zeroHash),
+			PullRequests: []*github.PullRequest{},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest(http.MethodPost, srv.URL, bytes.NewBuffer(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Hub-Signature", signature(secret, body))
+	req.Header.Set("X-GitHub-Event", "check_suite")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req.WithContext(slogtest.Context(t)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		out, _ := httputil.DumpResponse(resp, true)
+		t.Fatalf("expected 200, got\n%s", string(out))
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected 0 check runs for skipped new branch, got %d", len(got))
+	}
+	if apiCalled {
+		t.Fatal("GitHub API was called but should not have been for new non-default branch with no PRs")
+	}
+}
+
+func TestCheckSuiteNewBranchWithPRsProcessed(t *testing.T) {
+	got := []*github.CreateCheckRunOptions{}
+
+	prFilesHit := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v3/repos/foo/bar/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		opt := new(github.CreateCheckRunOptions)
+		if err := json.NewDecoder(r.Body).Decode(opt); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		got = append(got, opt)
+	})
+	mux.HandleFunc("/api/v3/repos/foo/bar/pulls/42/files", func(w http.ResponseWriter, r *http.Request) {
+		prFilesHit = true
+		path := filepath.Join("testdata", r.URL.Path)
+		f, err := os.Open(path)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		defer f.Close()
+		io.Copy(w, f)
+	})
+	// The zeroHash path does GetContents for the directory listing even
+	// when PRs are present, so we need to serve that response.
+	mux.HandleFunc("GET /api/v3/repos/foo/bar/contents/.github/chainguard", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Return an empty directory — the PR files handler provides the STS file.
+		json.NewEncoder(w).Encode([]*github.RepositoryContent{})
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		path := filepath.Join("testdata", r.URL.Path)
+		f, err := os.Open(path)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		defer f.Close()
+		io.Copy(w, f)
+	})
+	gh := httptest.NewServer(mux)
+	defer gh.Close()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr := ghinstallation.NewAppsTransportFromPrivateKey(gh.Client().Transport, 1234, key)
+	tr.BaseURL = gh.URL
+
+	secret := []byte("hunter2")
+	v := &Validator{
+		Transport:     tr,
+		WebhookSecret: [][]byte{secret},
+	}
+	srv := httptest.NewServer(v)
+	defer srv.Close()
+
+	body, err := json.Marshal(github.CheckSuiteEvent{
+		Installation: &github.Installation{
+			ID: github.Ptr(int64(1111)),
+		},
+		Repo: &github.Repository{
+			Owner: &github.User{
+				Login: github.Ptr("foo"),
+			},
+			Name:          github.Ptr("bar"),
+			FullName:      github.Ptr("foo/bar"),
+			DefaultBranch: github.Ptr("main"),
+		},
+		Sender: &github.User{Login: github.Ptr("test-user")},
+		Action: github.Ptr("requested"),
+		CheckSuite: &github.CheckSuite{
+			ID:         github.Ptr(int64(1)),
+			HeadSHA:    github.Ptr("deadbeef"),
+			HeadBranch: github.Ptr("feature-x"),
+			BeforeSHA:  github.Ptr(zeroHash),
+			PullRequests: []*github.PullRequest{
+				{Number: github.Ptr(42)},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest(http.MethodPost, srv.URL, bytes.NewBuffer(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Hub-Signature", signature(secret, body))
+	req.Header.Set("X-GitHub-Event", "check_suite")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req.WithContext(slogtest.Context(t)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		out, _ := httputil.DumpResponse(resp, true)
+		t.Fatalf("expected 200, got\n%s", string(out))
+	}
+	if !prFilesHit {
+		t.Fatal("PR files API was not called but should have been for new branch with PRs")
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 check run, got %d", len(got))
+	}
+	if *got[0].Conclusion != "success" {
+		t.Fatalf("expected success, got %s", *got[0].Conclusion)
+	}
+}
+
+func TestCheckSuiteDefaultBranchProcessed(t *testing.T) {
+	got := []*github.CreateCheckRunOptions{}
+
+	dirScanHit := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v3/repos/foo/bar/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		opt := new(github.CreateCheckRunOptions)
+		if err := json.NewDecoder(r.Body).Decode(opt); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		got = append(got, opt)
+	})
+	mux.HandleFunc("GET /api/v3/repos/foo/bar/contents/.github/chainguard", func(w http.ResponseWriter, r *http.Request) {
+		dirScanHit = true
+		// Return a directory listing with one STS file.
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]*github.RepositoryContent{
+			{
+				Type: github.Ptr("file"),
+				Name: github.Ptr("test.sts.yaml"),
+				Path: github.Ptr(".github/chainguard/test.sts.yaml"),
+			},
+		})
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		path := filepath.Join("testdata", r.URL.Path)
+		f, err := os.Open(path)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		defer f.Close()
+		io.Copy(w, f)
+	})
+	gh := httptest.NewServer(mux)
+	defer gh.Close()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr := ghinstallation.NewAppsTransportFromPrivateKey(gh.Client().Transport, 1234, key)
+	tr.BaseURL = gh.URL
+
+	secret := []byte("hunter2")
+	v := &Validator{
+		Transport:     tr,
+		WebhookSecret: [][]byte{secret},
+	}
+	srv := httptest.NewServer(v)
+	defer srv.Close()
+
+	body, err := json.Marshal(github.CheckSuiteEvent{
+		Installation: &github.Installation{
+			ID: github.Ptr(int64(1111)),
+		},
+		Repo: &github.Repository{
+			Owner: &github.User{
+				Login: github.Ptr("foo"),
+			},
+			Name:          github.Ptr("bar"),
+			FullName:      github.Ptr("foo/bar"),
+			DefaultBranch: github.Ptr("main"),
+		},
+		Sender: &github.User{Login: github.Ptr("test-user")},
+		Action: github.Ptr("requested"),
+		CheckSuite: &github.CheckSuite{
+			ID:           github.Ptr(int64(1)),
+			HeadSHA:      github.Ptr("deadbeef"),
+			HeadBranch:   github.Ptr("main"),
+			BeforeSHA:    github.Ptr(zeroHash),
+			PullRequests: []*github.PullRequest{},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest(http.MethodPost, srv.URL, bytes.NewBuffer(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Hub-Signature", signature(secret, body))
+	req.Header.Set("X-GitHub-Event", "check_suite")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req.WithContext(slogtest.Context(t)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		out, _ := httputil.DumpResponse(resp, true)
+		t.Fatalf("expected 200, got\n%s", string(out))
+	}
+	if !dirScanHit {
+		t.Fatal("Directory scan API was not called but should have been for default branch initial commit")
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 check run, got %d", len(got))
+	}
+	if *got[0].Conclusion != "success" {
+		t.Fatalf("expected success, got %s", *got[0].Conclusion)
+	}
+}
+
+func TestCheckSuiteExistingBranchUsesCompare(t *testing.T) {
+	got := []*github.CreateCheckRunOptions{}
+
+	compareHit := false
+	dirScanHit := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v3/repos/foo/bar/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		opt := new(github.CreateCheckRunOptions)
+		if err := json.NewDecoder(r.Body).Decode(opt); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		got = append(got, opt)
+	})
+	mux.HandleFunc("/api/v3/repos/foo/bar/compare/", func(w http.ResponseWriter, r *http.Request) {
+		compareHit = true
+		path := filepath.Join("testdata", r.URL.Path)
+		f, err := os.Open(path)
+		if err != nil {
+			clog.FromContext(r.Context()).Errorf("%s not found", path)
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		defer f.Close()
+		io.Copy(w, f)
+	})
+	mux.HandleFunc("GET /api/v3/repos/foo/bar/contents/.github/chainguard", func(w http.ResponseWriter, r *http.Request) {
+		dirScanHit = true
+		t.Error("Directory scan should not be called for existing branch")
+		http.Error(w, "should not be called", http.StatusInternalServerError)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		path := filepath.Join("testdata", r.URL.Path)
+		f, err := os.Open(path)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		defer f.Close()
+		io.Copy(w, f)
+	})
+	gh := httptest.NewServer(mux)
+	defer gh.Close()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr := ghinstallation.NewAppsTransportFromPrivateKey(gh.Client().Transport, 1234, key)
+	tr.BaseURL = gh.URL
+
+	secret := []byte("hunter2")
+	v := &Validator{
+		Transport:     tr,
+		WebhookSecret: [][]byte{secret},
+	}
+	srv := httptest.NewServer(v)
+	defer srv.Close()
+
+	body, err := json.Marshal(github.CheckSuiteEvent{
+		Installation: &github.Installation{
+			ID: github.Ptr(int64(1111)),
+		},
+		Repo: &github.Repository{
+			Owner: &github.User{
+				Login: github.Ptr("foo"),
+			},
+			Name:          github.Ptr("bar"),
+			FullName:      github.Ptr("foo/bar"),
+			DefaultBranch: github.Ptr("main"),
+		},
+		Sender: &github.User{Login: github.Ptr("test-user")},
+		Action: github.Ptr("requested"),
+		CheckSuite: &github.CheckSuite{
+			ID:           github.Ptr(int64(1)),
+			HeadSHA:      github.Ptr("5678"),
+			HeadBranch:   github.Ptr("feature-y"),
+			BeforeSHA:    github.Ptr("abcd1234"),
+			PullRequests: []*github.PullRequest{},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest(http.MethodPost, srv.URL, bytes.NewBuffer(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Hub-Signature", signature(secret, body))
+	req.Header.Set("X-GitHub-Event", "check_suite")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req.WithContext(slogtest.Context(t)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		out, _ := httputil.DumpResponse(resp, true)
+		t.Fatalf("expected 200, got\n%s", string(out))
+	}
+	if !compareHit {
+		t.Fatal("Compare API was not called but should have been for existing branch")
+	}
+	if dirScanHit {
+		t.Fatal("Directory scan was called but should not have been for existing branch")
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 check run, got %d", len(got))
+	}
+	if *got[0].Conclusion != "success" {
+		t.Fatalf("expected success, got %s", *got[0].Conclusion)
+	}
+}


### PR DESCRIPTION
## What

When `handleCheckSuite` receives a `check_suite` event for a new branch (`BeforeSHA == zeroHash`) with no associated PRs, skip processing instead of listing the full `.github/chainguard/` directory and reading every policy file.

## Why

A new branch without associated PRs points at an already-validated commit — there are no policy file changes to validate. The current code reads all N policy files individually (N+1 API calls per event), which scales poorly on repos with many policy files and high branch creation rates, and provides no validation value.

## Notes

- New branches with associated PRs still go through the PR-file-diff path, which properly filters for `.sts.yaml` changes
- The non-branching path (`BeforeSHA != zeroHash`) is unchanged — it already filters via `CompareCommits`