### PR TITLE
Webhook protection

### DIFF
--- a/pkg/octosts/octosts.go
+++ b/pkg/octosts/octosts.go
@@ -59,6 +59,7 @@ func NewSecurityTokenServiceServer(rrm ghinstall.Manager, sticky stickystore.Sto
 }
 
 var trustPolicies = expirablelru.NewLRU[cacheTrustPolicyKey, string](200, nil, time.Minute*5)
+var staleTrustPolicies = expirablelru.NewLRU[cacheTrustPolicyKey, string](200, nil, time.Hour)
 
 type sts struct {
 	pboidc.UnimplementedSecurityTokenServiceServer
@@ -414,10 +415,12 @@ func (s *sts) fetchTrustPolicyRaw(ctx context.Context, base *ghinstallation.Apps
 		var ghErr *github.ErrorResponse
 		if errors.As(err, &ghErr) && ghErr.Response != nil {
 			switch ghErr.Response.StatusCode {
-			case http.StatusForbidden:
-				return "", status.Errorf(codes.ResourceExhausted, "GitHub API rate limit exceeded (403) for %q", tpKey.identity)
-			case http.StatusTooManyRequests:
-				return "", status.Errorf(codes.ResourceExhausted, "GitHub API rate limit exceeded (429) for %q", tpKey.identity)
+			case http.StatusForbidden, http.StatusTooManyRequests:
+				if stale, ok := staleTrustPolicies.Get(tpKey); ok {
+					clog.InfoContextf(ctx, "rate-limited, serving stale cached trust policy for %s", tpKey)
+					return stale, nil
+				}
+				return "", status.Errorf(codes.ResourceExhausted, "GitHub API rate limit exceeded (%d) for %q", ghErr.Response.StatusCode, tpKey.identity)
 			case http.StatusNotFound:
 				trustPolicies.Add(tpKey, negativeCacheConst)
 			}
@@ -434,6 +437,7 @@ func (s *sts) fetchTrustPolicyRaw(ctx context.Context, base *ghinstallation.Apps
 	if evicted := trustPolicies.Add(tpKey, raw); evicted {
 		clog.InfoContextf(ctx, "evicted cachekey %s", tpKey)
 	}
+	staleTrustPolicies.Add(tpKey, raw)
 	return raw, nil
 }
 

--- a/pkg/octosts/octosts_test.go
+++ b/pkg/octosts/octosts_test.go
@@ -435,7 +435,11 @@ var _ ghinstall.Manager = (*sequentialInstallMgr)(nil)
 func TestPolicyReadUsesRoundRobin(t *testing.T) {
 	key := cacheTrustPolicyKey{owner: "org", repo: "repo", identity: "foo"}
 	trustPolicies.Remove(key)
-	t.Cleanup(func() { trustPolicies.Remove(key) })
+	staleTrustPolicies.Remove(key)
+	t.Cleanup(func() {
+		trustPolicies.Remove(key)
+		staleTrustPolicies.Remove(key)
+	})
 
 	ctx := context.Background()
 	rrmAtr := newGitHubClient(t, newFakeGitHub())
@@ -481,7 +485,11 @@ func TestPolicyReadUsesRoundRobin(t *testing.T) {
 func TestPolicyReadRetriesOnRateLimit(t *testing.T) {
 	key := cacheTrustPolicyKey{owner: "org", repo: "repo", identity: "foo"}
 	trustPolicies.Remove(key)
-	t.Cleanup(func() { trustPolicies.Remove(key) })
+	staleTrustPolicies.Remove(key)
+	t.Cleanup(func() {
+		trustPolicies.Remove(key)
+		staleTrustPolicies.Remove(key)
+	})
 
 	ctx := context.Background()
 	rateLimitedAtr := newGitHubClient(t, newFakeGitHubRateLimit(http.StatusForbidden))
@@ -531,7 +539,11 @@ func TestPolicyReadRetriesOnRateLimit(t *testing.T) {
 func TestPolicyReadAllRateLimitedReturnsError(t *testing.T) {
 	key := cacheTrustPolicyKey{owner: "org", repo: "repo", identity: "foo"}
 	trustPolicies.Remove(key)
-	t.Cleanup(func() { trustPolicies.Remove(key) })
+	staleTrustPolicies.Remove(key)
+	t.Cleanup(func() {
+		trustPolicies.Remove(key)
+		staleTrustPolicies.Remove(key)
+	})
 
 	ctx := context.Background()
 	rl1 := newGitHubClient(t, newFakeGitHubRateLimit(http.StatusForbidden))
@@ -682,6 +694,53 @@ func TestNegativeCacheSkipsInstallationTokenCreation(t *testing.T) {
 	st, ok := status.FromError(err)
 	if !ok || st.Code() != codes.NotFound {
 		t.Fatalf("expected gRPC NotFound from negative cache, got %v (managers should not have been called)", err)
+	}
+}
+
+func TestRateLimitServesStaleCache(t *testing.T) {
+	key := cacheTrustPolicyKey{owner: "org", repo: "repo", identity: "foo"}
+	trustPolicies.Remove(key)
+	staleTrustPolicies.Remove(key)
+	t.Cleanup(func() {
+		trustPolicies.Remove(key)
+		staleTrustPolicies.Remove(key)
+	})
+
+	ctx := context.Background()
+	workingGH := newFakeGitHub()
+	workingAtr := newGitHubClient(t, workingGH)
+
+	s := &sts{
+		rrm:      &fakeInstallMgr{atr: workingAtr},
+		appCount: 1,
+	}
+
+	// First call: populates both caches.
+	otp := &OrgTrustPolicy{}
+	otp.Repositories = []string{"repo"}
+	err := s.lookupTrustPolicy(ctx, workingAtr, 1234, key, &otp.TrustPolicy)
+	if err != nil {
+		t.Fatalf("first lookup failed: %v", err)
+	}
+
+	// Expire the primary cache to force a GitHub call on next lookup.
+	trustPolicies.Remove(key)
+
+	// Verify the stale cache was populated.
+	if _, ok := staleTrustPolicies.Get(key); !ok {
+		t.Fatal("stale cache should have been populated after successful fetch")
+	}
+
+	// Switch to a rate-limited GitHub backend.
+	rateLimitedAtr := newGitHubClient(t, newFakeGitHubRateLimit(http.StatusForbidden))
+	s.rrm = &fakeInstallMgr{atr: rateLimitedAtr}
+
+	// Second call: primary cache miss, GitHub 403, should fall back to stale cache.
+	otp2 := &OrgTrustPolicy{}
+	otp2.Repositories = []string{"repo"}
+	err = s.lookupTrustPolicy(ctx, rateLimitedAtr, 1234, key, &otp2.TrustPolicy)
+	if err != nil {
+		t.Fatalf("expected stale cache fallback on rate limit, got error: %v", err)
 	}
 }
 

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -47,6 +47,16 @@ type Validator struct {
 	Organizations []string
 }
 
+func isBotSender(sender *github.User) bool {
+	return sender != nil && sender.Login != nil && strings.HasSuffix(sender.GetLogin(), "[bot]")
+}
+
+func isGitHubRateLimited(err error) bool {
+	var rateLimitErr *github.RateLimitError
+	var abuseRateLimitErr *github.AbuseRateLimitError
+	return errors.As(err, &rateLimitErr) || errors.As(err, &abuseRateLimitErr)
+}
+
 func (e *Validator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	log := clog.FromContext(r.Context()).With(
 		HeaderDelivery, r.Header.Get(HeaderDelivery),
@@ -78,8 +88,18 @@ func (e *Validator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case *github.PushEvent:
 		cr, err = e.handlePush(ctx, event)
 	case *github.CheckSuiteEvent:
+		if isBotSender(event.GetSender()) {
+			log.Infof("skipping bot-triggered check_suite from %s", event.GetSender().GetLogin())
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
 		cr, err = e.handleCheckSuite(ctx, event)
 	case *github.CheckRunEvent:
+		if isBotSender(event.GetSender()) {
+			log.Infof("skipping bot-triggered check_run from %s", event.GetSender().GetLogin())
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
 		cr, err = e.handleCheckSuite(ctx, &fauxCheckSuite{event})
 	// TODO: CheckRun retry
 	default:
@@ -134,6 +154,11 @@ func (e *Validator) handleSHA(ctx context.Context, client *github.Client, owner,
 	}
 
 	err := validatePolicies(ctx, client, owner, repo, sha, files)
+	// If we were rate-limited, bail out immediately without creating a
+	// CheckRun — the API call would likely fail too.
+	if isGitHubRateLimited(err) {
+		return nil, err
+	}
 	// Whether or not the commit is verified, we still create a CheckRun.
 	// The only difference is whether it shows up to the user as success or
 	// failure.
@@ -177,6 +202,10 @@ func validatePolicies(ctx context.Context, client *github.Client, owner, repo st
 		resp, _, _, err := client.Repositories.GetContents(ctx, owner, repo, f, &github.RepositoryContentGetOptions{Ref: sha})
 		if err != nil {
 			log.Infof("failed to get content for: %v", err)
+			if isGitHubRateLimited(err) {
+				log.Warnf("rate-limited, aborting remaining policy validations")
+				return fmt.Errorf("%s: %w", f, err)
+			}
 			merr = multierror.Append(merr, fmt.Errorf("%s: %w", f, err))
 			continue
 		}

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -1197,3 +1197,213 @@ func TestCheckSuiteExistingBranchUsesCompare(t *testing.T) {
 		t.Fatalf("expected success, got %s", *got[0].Conclusion)
 	}
 }
+
+func TestWebhookCheckSuiteBotSkipped(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("GitHub API should not be called for bot check_suite events, got %s %s", r.Method, r.URL.Path)
+		http.Error(w, "should not be called", http.StatusInternalServerError)
+	})
+	gh := httptest.NewServer(mux)
+	defer gh.Close()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr := ghinstallation.NewAppsTransportFromPrivateKey(gh.Client().Transport, 1234, key)
+	tr.BaseURL = gh.URL
+
+	secret := []byte("hunter2")
+	v := &Validator{
+		Transport:     tr,
+		WebhookSecret: [][]byte{secret},
+	}
+	srv := httptest.NewServer(v)
+	defer srv.Close()
+
+	body, err := json.Marshal(github.CheckSuiteEvent{
+		Action: github.Ptr("requested"),
+		Installation: &github.Installation{
+			ID: github.Ptr(int64(1111)),
+		},
+		Repo: &github.Repository{
+			Owner: &github.User{Login: github.Ptr("foo")},
+			Name:  github.Ptr("bar"),
+		},
+		Sender: &github.User{
+			Login: github.Ptr("octo-sts[bot]"),
+		},
+		CheckSuite: &github.CheckSuite{
+			HeadSHA:   github.Ptr("abc123"),
+			BeforeSHA: github.Ptr("def456"),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, srv.URL, bytes.NewBuffer(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Hub-Signature", signature(secret, body))
+	req.Header.Set("X-GitHub-Event", "check_suite")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req.WithContext(slogtest.Context(t)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusAccepted {
+		out, _ := httputil.DumpResponse(resp, true)
+		t.Fatalf("expected 202 Accepted for bot sender, got\n%s", string(out))
+	}
+}
+
+func TestWebhookCheckRunBotSkipped(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("GitHub API should not be called for bot check_run events, got %s %s", r.Method, r.URL.Path)
+		http.Error(w, "should not be called", http.StatusInternalServerError)
+	})
+	gh := httptest.NewServer(mux)
+	defer gh.Close()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr := ghinstallation.NewAppsTransportFromPrivateKey(gh.Client().Transport, 1234, key)
+	tr.BaseURL = gh.URL
+
+	secret := []byte("hunter2")
+	v := &Validator{
+		Transport:     tr,
+		WebhookSecret: [][]byte{secret},
+	}
+	srv := httptest.NewServer(v)
+	defer srv.Close()
+
+	body, err := json.Marshal(github.CheckRunEvent{
+		Action: github.Ptr("created"),
+		Installation: &github.Installation{
+			ID: github.Ptr(int64(1111)),
+		},
+		Repo: &github.Repository{
+			Owner: &github.User{Login: github.Ptr("foo")},
+			Name:  github.Ptr("bar"),
+		},
+		Sender: &github.User{
+			Login: github.Ptr("some-other-app[bot]"),
+		},
+		CheckRun: &github.CheckRun{
+			CheckSuite: &github.CheckSuite{
+				HeadSHA:   github.Ptr("abc123"),
+				BeforeSHA: github.Ptr("def456"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, srv.URL, bytes.NewBuffer(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Hub-Signature", signature(secret, body))
+	req.Header.Set("X-GitHub-Event", "check_run")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req.WithContext(slogtest.Context(t)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusAccepted {
+		out, _ := httputil.DumpResponse(resp, true)
+		t.Fatalf("expected 202 Accepted for bot sender, got\n%s", string(out))
+	}
+}
+
+func TestWebhookPushAbortOnRateLimit(t *testing.T) {
+	contentHits := 0
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v3/repos/foo/bar/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		t.Error("CheckRun should not be created when rate-limited")
+		http.Error(w, "should not be called", http.StatusInternalServerError)
+	})
+	mux.HandleFunc("/api/v3/repos/foo/bar/contents/", func(w http.ResponseWriter, r *http.Request) {
+		contentHits++
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		w.Header().Set("X-RateLimit-Limit", "5000")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(map[string]string{
+			"message": "API rate limit exceeded",
+		})
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		path := filepath.Join("testdata", r.URL.Path)
+		f, err := os.Open(path)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		defer f.Close()
+		io.Copy(w, f)
+	})
+	gh := httptest.NewServer(mux)
+	defer gh.Close()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr := ghinstallation.NewAppsTransportFromPrivateKey(gh.Client().Transport, 1234, key)
+	tr.BaseURL = gh.URL
+
+	secret := []byte("hunter2")
+	v := &Validator{
+		Transport:     tr,
+		WebhookSecret: [][]byte{secret},
+	}
+	srv := httptest.NewServer(v)
+	defer srv.Close()
+
+	body, err := json.Marshal(github.PushEvent{
+		Installation: &github.Installation{
+			ID: github.Ptr(int64(1111)),
+		},
+		Repo: &github.PushEventRepository{
+			Owner: &github.User{Login: github.Ptr("foo")},
+			Name:  github.Ptr("bar"),
+		},
+		Before: github.Ptr("1234"),
+		After:  github.Ptr("5678"),
+		Commits: []*github.HeadCommit{{
+			Added: []string{
+				".github/chainguard/a.sts.yaml",
+				".github/chainguard/b.sts.yaml",
+				".github/chainguard/c.sts.yaml",
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest(http.MethodPost, srv.URL, bytes.NewBuffer(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Hub-Signature", signature(secret, body))
+	req.Header.Set("X-GitHub-Event", "push")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req.WithContext(slogtest.Context(t)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp
+	if contentHits > 1 {
+		t.Fatalf("expected at most 1 content fetch before aborting, got %d", contentHits)
+	}
+}


### PR DESCRIPTION
Break the check_suite webhook feedback loop by skipping events from bot senders (login ending in [bot]). Previously, creating a CheckRun triggered a new check_suite event from octo-sts[bot], which was processed again — amplifying a single push into hundreds of API calls.

Abort webhook policy validation on the first rate-limit error (403/429) instead of continuing to fetch all remaining STS files. Also skip the CheckRun creation call when validation was rate-limited.

Add a stale trust policy cache (1h TTL) alongside the existing 5-minute primary cache. When a rate-limited GitHub API call prevents fetching a trust policy, fall back to the stale cache so token exchanges can continue serving recently-known policies instead of failing.