### PR TITLE
Skip pull_request events that can't change the file diff

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -47,6 +47,13 @@ type Validator struct {
 	Organizations []string
 }
 
+// prActionsThatChangeFiles is the set of pull_request actions that can alter
+// the file diff (and therefore introduce or modify a trust policy). Every other
+// action (labeled, edited, assigned, review_requested, closed, ready_for_review,
+// …) leaves the diff untouched, so there is nothing new for us to validate — we
+// don't skip drafts, so draft PRs are already validated on opened/synchronize.
+var prActionsThatChangeFiles = sets.New("opened", "synchronize", "reopened")
+
 func isBotSender(sender *github.User) bool {
 	return sender != nil && sender.Login != nil && strings.HasSuffix(sender.GetLogin(), "[bot]")
 }
@@ -313,6 +320,14 @@ func (e *Validator) handlePullRequest(ctx context.Context, pr *github.PullReques
 	// Skip if the organization is not in the list of organizations to validate.
 	if e.shouldSkipOrganization(owner) {
 		log.Infof("skipping organization %s", owner)
+		return nil, nil
+	}
+
+	// Only actions that can change the PR's file diff can introduce or modify
+	// a trust policy. Skipping the rest avoids a ListFiles call (and its token
+	// mint) on the ~99% of PR events that can't affect policy.
+	if !prActionsThatChangeFiles.Has(pr.GetAction()) {
+		log.Infof("skipping pull_request action %q: cannot change file diff", pr.GetAction())
 		return nil, nil
 	}
 

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -1407,3 +1407,68 @@ func TestWebhookPushAbortOnRateLimit(t *testing.T) {
 		t.Fatalf("expected at most 1 content fetch before aborting, got %d", contentHits)
 	}
 }
+
+func TestWebhookPullRequestActionSkipped(t *testing.T) {
+	// Actions that can't change the file diff must not reach the GitHub API.
+	for _, action := range []string{"labeled", "edited", "assigned", "review_requested", "closed", "ready_for_review"} {
+		t.Run(action, func(t *testing.T) {
+			mux := http.NewServeMux()
+			mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+				t.Errorf("GitHub API should not be called for pull_request action %q, got %s %s", action, r.Method, r.URL.Path)
+				http.Error(w, "should not be called", http.StatusInternalServerError)
+			})
+			gh := httptest.NewServer(mux)
+			defer gh.Close()
+
+			key, err := rsa.GenerateKey(rand.Reader, 2048)
+			if err != nil {
+				t.Fatal(err)
+			}
+			tr := ghinstallation.NewAppsTransportFromPrivateKey(gh.Client().Transport, 1234, key)
+			tr.BaseURL = gh.URL
+
+			secret := []byte("hunter2")
+			v := &Validator{
+				Transport:     tr,
+				WebhookSecret: [][]byte{secret},
+			}
+			srv := httptest.NewServer(v)
+			defer srv.Close()
+
+			body, err := json.Marshal(github.PullRequestEvent{
+				Action: github.Ptr(action),
+				Number: github.Ptr(1),
+				Installation: &github.Installation{
+					ID: github.Ptr(int64(1111)),
+				},
+				Repo: &github.Repository{
+					Owner: &github.User{Login: github.Ptr("foo")},
+					Name:  github.Ptr("bar"),
+				},
+				PullRequest: &github.PullRequest{
+					Head: &github.PullRequestBranch{SHA: github.Ptr("abc123")},
+				},
+				Sender: &github.User{Login: github.Ptr("someone")},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			req, err := http.NewRequest(http.MethodPost, srv.URL, bytes.NewBuffer(body))
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Set("X-Hub-Signature", signature(secret, body))
+			req.Header.Set("X-GitHub-Event", "pull_request")
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := srv.Client().Do(req.WithContext(slogtest.Context(t)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if resp.StatusCode != http.StatusOK {
+				out, _ := httputil.DumpResponse(resp, true)
+				t.Fatalf("expected 200 OK, got\n%s", string(out))
+			}
+		})
+	}
+}


### PR DESCRIPTION
The webhook called ListFiles on every pull_request event regardless of action, then bailed when no .sts.yaml had changed — which is ~99% of the time. pull_request is 72% of our API traffic, so most of it is spent discovering that nothing relevant changed. Only opened/synchronize/reopened can alter the diff and therefore introduce or modify a trust policy; every other action (labeled, edited, assigned, review_requested, closed, ready_for_review, …) leaves it untouched, and since we don't skip drafts, draft PRs are already validated on opened/synchronize. Early-returning on those actions before the transport is built skips both the ListFiles call and the per-event token mint, while keeping opened/synchronize in so fork-PR policy changes are still caught.
