### PR TITLE
Cache the installation client to stop minting a token per event

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -48,12 +48,13 @@ type Validator struct {
 
 	Organizations []string
 
-	// clients caches one client constructor per installation ID so the
-	// transport's token is reused (~1h) instead of re-minted per event. Keyed on
-	// installation ID alone: IDs are globally unique and the webhook serves one
-	// App. clientsMu guards the get-or-create; the OnceValues coalesces builds.
+	// clients caches one client per installation ID so the transport's token is
+	// reused (~1h) instead of re-minted per event. Keyed on installation ID
+	// alone: IDs are globally unique and the webhook serves one App. Building a
+	// client is cheap (the token is minted lazily on first use), so clientsMu
+	// can guard the whole get-or-create.
 	clientsMu sync.Mutex
-	clients   *lru.Cache[int64, func() (*github.Client, error)]
+	clients   *lru.Cache[int64, *github.Client]
 }
 
 // prActionsThatChangeFiles is the set of pull_request actions that can alter
@@ -169,31 +170,31 @@ func (e *Validator) validatePayload(r *http.Request) ([]byte, error) {
 // installation, reusing its token instead of minting one per event.
 func (e *Validator) clientForInstallation(installationID int64) (*github.Client, error) {
 	e.clientsMu.Lock()
+	defer e.clientsMu.Unlock()
+
 	if e.clients == nil {
-		cache, err := lru.New[int64, func() (*github.Client, error)](installationClientCacheSize)
+		cache, err := lru.New[int64, *github.Client](installationClientCacheSize)
 		if err != nil {
-			e.clientsMu.Unlock()
 			return nil, err
 		}
 		e.clients = cache
 	}
-	build, ok := e.clients.Get(installationID)
-	if !ok {
-		build = sync.OnceValues(func() (*github.Client, error) {
-			client := github.NewClient(&http.Client{
-				Transport: ghinstallation.NewFromAppsTransport(e.Transport, installationID),
-			})
-			if e.Transport.BaseURL != "" {
-				return client.WithEnterpriseURLs(e.Transport.BaseURL, e.Transport.BaseURL)
-			}
-			return client, nil
-		})
-		e.clients.Add(installationID, build)
+	if client, ok := e.clients.Get(installationID); ok {
+		return client, nil
 	}
-	e.clientsMu.Unlock()
 
-	// Build outside the lock so a slow mint doesn't serialize other lookups.
-	return build()
+	client := github.NewClient(&http.Client{
+		Transport: ghinstallation.NewFromAppsTransport(e.Transport, installationID),
+	})
+	if e.Transport.BaseURL != "" {
+		var err error
+		client, err = client.WithEnterpriseURLs(e.Transport.BaseURL, e.Transport.BaseURL)
+		if err != nil {
+			return nil, err
+		}
+	}
+	e.clients.Add(installationID, client)
+	return client, nil
 }
 
 func (e *Validator) handleSHA(ctx context.Context, client *github.Client, owner, repo, sha string, files []string) (*github.CheckRun, error) {

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -13,12 +13,14 @@ import (
 	"net/http"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/chainguard-dev/clog"
 	"github.com/google/go-github/v84/github"
 	"github.com/hashicorp/go-multierror"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/yaml"
 
@@ -45,6 +47,13 @@ type Validator struct {
 	WebhookSecret [][]byte
 
 	Organizations []string
+
+	// clients caches one client constructor per installation ID so the
+	// transport's token is reused (~1h) instead of re-minted per event. Keyed on
+	// installation ID alone: IDs are globally unique and the webhook serves one
+	// App. clientsMu guards the get-or-create; the OnceValues coalesces builds.
+	clientsMu sync.Mutex
+	clients   *lru.Cache[int64, func() (*github.Client, error)]
 }
 
 // prActionsThatChangeFiles is the set of pull_request actions that can alter
@@ -53,6 +62,10 @@ type Validator struct {
 // …) leaves the diff untouched, so there is nothing new for us to validate — we
 // don't skip drafts, so draft PRs are already validated on opened/synchronize.
 var prActionsThatChangeFiles = sets.New("opened", "synchronize", "reopened")
+
+// installationClientCacheSize matches the app's other LRUs (e.g. ghinstall,
+// octosts); entries are tiny and least-recently-used installations evict first.
+const installationClientCacheSize = 200
 
 func isBotSender(sender *github.User) bool {
 	return sender != nil && sender.Login != nil && strings.HasSuffix(sender.GetLogin(), "[bot]")
@@ -150,6 +163,37 @@ func (e *Validator) validatePayload(r *http.Request) ([]byte, error) {
 		}
 	}
 	return nil, errors.New("no matching secrets")
+}
+
+// clientForInstallation returns a cached (or freshly built) client for the
+// installation, reusing its token instead of minting one per event.
+func (e *Validator) clientForInstallation(installationID int64) (*github.Client, error) {
+	e.clientsMu.Lock()
+	if e.clients == nil {
+		cache, err := lru.New[int64, func() (*github.Client, error)](installationClientCacheSize)
+		if err != nil {
+			e.clientsMu.Unlock()
+			return nil, err
+		}
+		e.clients = cache
+	}
+	build, ok := e.clients.Get(installationID)
+	if !ok {
+		build = sync.OnceValues(func() (*github.Client, error) {
+			client := github.NewClient(&http.Client{
+				Transport: ghinstallation.NewFromAppsTransport(e.Transport, installationID),
+			})
+			if e.Transport.BaseURL != "" {
+				return client.WithEnterpriseURLs(e.Transport.BaseURL, e.Transport.BaseURL)
+			}
+			return client, nil
+		})
+		e.clients.Add(installationID, build)
+	}
+	e.clientsMu.Unlock()
+
+	// Build outside the lock so a slow mint doesn't serialize other lookups.
+	return build()
 }
 
 func (e *Validator) handleSHA(ctx context.Context, client *github.Client, owner, repo, sha string, files []string) (*github.CheckRun, error) {
@@ -264,15 +308,9 @@ func (e *Validator) handlePush(ctx context.Context, event *github.PushEvent) (*g
 		return nil, nil
 	}
 
-	client := github.NewClient(&http.Client{
-		Transport: ghinstallation.NewFromAppsTransport(e.Transport, installationID),
-	})
-	if e.Transport.BaseURL != "" {
-		var err error
-		client, err = client.WithEnterpriseURLs(e.Transport.BaseURL, e.Transport.BaseURL)
-		if err != nil {
-			return nil, err
-		}
+	client, err := e.clientForInstallation(installationID)
+	if err != nil {
+		return nil, err
 	}
 
 	var files []string
@@ -331,15 +369,9 @@ func (e *Validator) handlePullRequest(ctx context.Context, pr *github.PullReques
 		return nil, nil
 	}
 
-	client := github.NewClient(&http.Client{
-		Transport: ghinstallation.NewFromAppsTransport(e.Transport, installationID),
-	})
-	if e.Transport.BaseURL != "" {
-		var err error
-		client, err = client.WithEnterpriseURLs(e.Transport.BaseURL, e.Transport.BaseURL)
-		if err != nil {
-			return nil, err
-		}
+	client, err := e.clientForInstallation(installationID)
+	if err != nil {
+		return nil, err
 	}
 
 	// Check diff
@@ -393,15 +425,9 @@ func (e *Validator) handleCheckSuite(ctx context.Context, cs checkSuite) (*githu
 		return nil, nil
 	}
 
-	client := github.NewClient(&http.Client{
-		Transport: ghinstallation.NewFromAppsTransport(e.Transport, installationID),
-	})
-	if e.Transport.BaseURL != "" {
-		var err error
-		client, err = client.WithEnterpriseURLs(e.Transport.BaseURL, e.Transport.BaseURL)
-		if err != nil {
-			return nil, err
-		}
+	client, err := e.clientForInstallation(installationID)
+	if err != nil {
+		return nil, err
 	}
 
 	var files []string

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -18,7 +18,9 @@ import (
 	"net/http/httputil"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/chainguard-dev/clog"
@@ -1470,5 +1472,89 @@ func TestWebhookPullRequestActionSkipped(t *testing.T) {
 				t.Fatalf("expected 200 OK, got\n%s", string(out))
 			}
 		})
+	}
+}
+
+// TestWebhookInstallationTokenCached checks that two events for one
+// installation mint only a single token.
+func TestWebhookInstallationTokenCached(t *testing.T) {
+	var mints atomic.Int64
+
+	mux := http.NewServeMux()
+	// Count mints; return a token valid for an hour so the cached client reuses it.
+	mux.HandleFunc("POST /app/installations/1111/access_tokens", func(w http.ResponseWriter, _ *http.Request) {
+		mints.Add(1)
+		fmt.Fprintf(w, `{"token":"t","expires_at":%q}`, time.Now().Add(time.Hour).Format(time.RFC3339))
+	})
+	mux.HandleFunc("POST /api/v3/repos/foo/bar/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, "{}")
+	})
+	// Serve the trust-policy content fixture for everything else.
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		f, err := os.Open(filepath.Join("testdata", r.URL.Path))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		defer f.Close()
+		if _, err := io.Copy(w, f); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	})
+	gh := httptest.NewServer(mux)
+	defer gh.Close()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr := ghinstallation.NewAppsTransportFromPrivateKey(gh.Client().Transport, 1234, key)
+	tr.BaseURL = gh.URL
+
+	secret := []byte("hunter2")
+	v := &Validator{
+		Transport:     tr,
+		WebhookSecret: [][]byte{secret},
+	}
+	srv := httptest.NewServer(v)
+	defer srv.Close()
+
+	body, err := json.Marshal(github.PushEvent{
+		Installation: &github.Installation{ID: github.Ptr(int64(1111))},
+		Repo: &github.PushEventRepository{
+			Owner: &github.User{Login: github.Ptr("foo")},
+			Name:  github.Ptr("bar"),
+		},
+		Before: github.Ptr("1234"),
+		After:  github.Ptr("5678"),
+		Commits: []*github.HeadCommit{{
+			Added: []string{".github/chainguard/test.sts.yaml"},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Deliver the same event twice; the second must reuse the cached client.
+	for i := 0; i < 2; i++ {
+		req, err := http.NewRequest(http.MethodPost, srv.URL, bytes.NewBuffer(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("X-Hub-Signature", signature(secret, body))
+		req.Header.Set("X-GitHub-Event", "push")
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := srv.Client().Do(req.WithContext(slogtest.Context(t)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			out, _ := httputil.DumpResponse(resp, true)
+			t.Fatalf("delivery %d: expected 200 OK, got\n%s", i, string(out))
+		}
+	}
+
+	if got := mints.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 token mint across 2 events, got %d", got)
 	}
 }


### PR DESCRIPTION
Each webhook handler built a fresh github.Client via ghinstallation.NewFromAppsTransport on every event, and since that transport caches its installation token internally, throwing the client away after each event meant re-minting an access token on the first API call every single time — a large share of the webhook's REST traffic. Cache one client per installation ID instead: the transport then refreshes its token roughly hourly rather than on every event. The cache is a bounded LRU (size 200, matching the app's other caches) of sync.OnceValues constructors guarded by a mutex, so concurrent events for the same installation coalesce onto a single client and a single mint. Keying on installation ID alone is sufficient — GitHub installation IDs are globally unique and the webhook serves a single App.
