### PR TITLE
fix(ci): GitHub Actions security hardening

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,6 +7,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 3
     groups:
       all:
         update-types:
@@ -17,6 +19,8 @@ updates:
     directory: "./"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 3
     groups:
       all:
         update-types:
@@ -29,6 +33,8 @@ updates:
       - "/modules/app"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 3
     groups:
       all:
         update-types:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -96,8 +96,10 @@ jobs:
 
       - name: Resolve auth config
         id: auth-config
+        env:
+          INPUT_ENVIRONMENT: ${{ inputs.environment || env.DEFAULT_ENVIRONMENT }}
         run: |
-          ENVIRONMENT="${{ inputs.environment || env.DEFAULT_ENVIRONMENT }}"
+          ENVIRONMENT="${INPUT_ENVIRONMENT}"
           echo "environment=${ENVIRONMENT}" >> "$GITHUB_OUTPUT"
           if [[ "${ENVIRONMENT}" == "octo-sts" ]]; then
             echo "workload_identity_provider=projects/96355665038/locations/global/workloadIdentityPools/github-pool/providers/github-provider" >> "$GITHUB_OUTPUT"
@@ -111,8 +113,10 @@ jobs:
           fi
 
       - name: Log deployment target
+        env:
+          ENVIRONMENT: ${{ steps.auth-config.outputs.environment }}
         run: |
-          echo "Deploying to environment: ${{ steps.auth-config.outputs.environment }}"
+          echo "Deploying to environment: ${ENVIRONMENT}"
 
       - uses: step-security/google-github-auth@775fc4c80760272ef389c9f9f8d98de7db0c170d # v3.0.2
         id: auth

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -50,7 +50,9 @@ jobs:
           terraform-version-file: "${{ github.workspace }}/.terraform-version"
           terraform-wrapper: false
 
-      - run: cp "$GITHUB_WORKSPACE/.github/testdata/backend_override.tf" "$GITHUB_WORKSPACE/${{ matrix.terraform-dir }}"
+      - env:
+          TERRAFORM_DIR: ${{ matrix.terraform-dir }}
+        run: cp "$GITHUB_WORKSPACE/.github/testdata/backend_override.tf" "$GITHUB_WORKSPACE/${TERRAFORM_DIR}"
       - working-directory: ${{ matrix.terraform-dir }}
         run: |
           terraform init

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -9,11 +9,15 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yaml'
+      - '.github/zizmor.yml'
   push:
     branches: ['main']
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yaml'
+      - '.github/zizmor.yml'
 
 permissions: {}
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,13 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+rules:
+  # Paired with `cooldown.default-days: 3` in .github/dependabot.yaml.
+  dependabot-cooldown:
+    config:
+      days: 3
+  # Cosmetic pedantic-only findings — suppressed across the campaign.
+  anonymous-definition:
+    disable: true
+  concurrency-limits:
+    disable: true


### PR DESCRIPTION
This PR applies GitHub Actions hardening fixes to the workflows in
`.github/workflows/`, surfaced by static analysis (zizmor).

## What this changes

- **Template-injection fix.** Context expressions interpolated directly into
  `run:` shell steps are moved into `env:` and referenced as quoted shell
  variables, so the shell handles them rather than the workflow templater.
- **Repo-level zizmor config + dependabot cooldown.** Disables cosmetic
  pedantic-only rules and adds a `dependabot-cooldown` threshold, paired with a
  `cooldown.default-days: 3` on the repo's existing `.github/dependabot.yaml`.

## Test plan

- `zizmor .github/` — clean after these changes.
- `actionlint` — workflows still parse with no errors.

Refs: PSEC-923