### PR TITLE
fix(octosts): detect typed GitHub rate-limit errors on trust policy reads

### DIFF
--- a/pkg/octosts/octosts.go
+++ b/pkg/octosts/octosts.go
@@ -351,6 +351,38 @@ func isRateLimit(err error) bool {
 	return ok && st.Code() == codes.ResourceExhausted
 }
 
+// IsGitHubRateLimited reports whether err looks like a GitHub rate-limit
+// response, primary or secondary.
+//
+// The typed errors must be checked first: go-github returns *RateLimitError for
+// a 403 carrying X-RateLimit-Remaining: 0 and *AbuseRateLimitError for a
+// secondary limit, and NEITHER unwraps to *ErrorResponse. A status-code-only
+// check therefore misses every genuine rate limit from real GitHub — which is
+// the bug this function exists to fix.
+//
+// This is deliberately LENIENT: a bare 403 with no rate-limit marker also
+// counts. That is correct for both current callers, where a false positive
+// costs a retry or a redelivery rather than granting access. Anything that
+// gates access needs a stricter test.
+func IsGitHubRateLimited(err error) bool {
+	if err == nil {
+		return false
+	}
+	var rateLimitErr *github.RateLimitError
+	var abuseRateLimitErr *github.AbuseRateLimitError
+	if errors.As(err, &rateLimitErr) || errors.As(err, &abuseRateLimitErr) {
+		return true
+	}
+	var errResp *github.ErrorResponse
+	if errors.As(err, &errResp) && errResp.Response != nil {
+		switch errResp.Response.StatusCode {
+		case http.StatusForbidden, http.StatusTooManyRequests:
+			return true
+		}
+	}
+	return false
+}
+
 type trustPolicy interface {
 	Compile() error
 }
@@ -423,21 +455,19 @@ func (s *sts) fetchTrustPolicyRaw(ctx context.Context, base *ghinstallation.Apps
 	)
 	if err != nil {
 		clog.InfoContextf(ctx, "failed to find trust policy: %v", err)
-		var ghErr *github.ErrorResponse
-		if errors.As(err, &ghErr) && ghErr.Response != nil {
-			switch ghErr.Response.StatusCode {
-			case http.StatusForbidden, http.StatusTooManyRequests:
-				if stale, ok := staleTrustPolicies.Get(tpKey); ok {
-					clog.InfoContextf(ctx, "rate-limited, serving stale cached trust policy for %s", tpKey)
-					// Seed the primary cache so further exchanges during the
-					// rate-limit window hit it instead of re-probing GitHub.
-					trustPolicies.Add(tpKey, stale)
-					return stale, nil
-				}
-				return "", status.Errorf(codes.ResourceExhausted, "GitHub API rate limit exceeded (%d) for %q", ghErr.Response.StatusCode, tpKey.identity)
-			case http.StatusNotFound:
-				trustPolicies.Add(tpKey, negativeCacheConst)
+		if IsGitHubRateLimited(err) {
+			if stale, ok := staleTrustPolicies.Get(tpKey); ok {
+				clog.InfoContextf(ctx, "rate-limited, serving stale cached trust policy for %s", tpKey)
+				// Seed the primary cache so further exchanges during the
+				// rate-limit window hit it instead of re-probing GitHub.
+				trustPolicies.Add(tpKey, stale)
+				return stale, nil
 			}
+			return "", status.Errorf(codes.ResourceExhausted, "GitHub API rate limit exceeded for %q", tpKey.identity)
+		}
+		var ghErr *github.ErrorResponse
+		if errors.As(err, &ghErr) && ghErr.Response != nil && ghErr.Response.StatusCode == http.StatusNotFound {
+			trustPolicies.Add(tpKey, negativeCacheConst)
 		}
 		return "", status.Errorf(codes.NotFound, "unable to find trust policy for %q", tpKey.identity)
 	}

--- a/pkg/octosts/octosts_test.go
+++ b/pkg/octosts/octosts_test.go
@@ -308,6 +308,13 @@ func newFakeGitHubRateLimit(statusCode int) *fakeGitHub {
 	})
 	mux.HandleFunc("/repos/{org}/{repo}/contents/.github/chainguard/{identity}", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		// Real GitHub sends this on a primary rate limit, and it is what makes
+		// go-github return a *github.RateLimitError rather than a bare
+		// *github.ErrorResponse. Without it this fake cannot reproduce the
+		// production classification path at all.
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		w.Header().Set("X-RateLimit-Limit", "5000")
+		w.Header().Set("X-RateLimit-Reset", fmt.Sprintf("%d", time.Now().Add(time.Minute).Unix()))
 		w.WriteHeader(statusCode)
 		json.NewEncoder(w).Encode(github.ErrorResponse{
 			Response: &http.Response{StatusCode: statusCode},

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -72,24 +72,6 @@ func isBotSender(sender *github.User) bool {
 	return sender != nil && sender.Login != nil && strings.HasSuffix(sender.GetLogin(), "[bot]")
 }
 
-func isGitHubRateLimited(err error) bool {
-	var rateLimitErr *github.RateLimitError
-	var abuseRateLimitErr *github.AbuseRateLimitError
-	if errors.As(err, &rateLimitErr) || errors.As(err, &abuseRateLimitErr) {
-		return true
-	}
-	// Fall back to the status code for rate-limit responses that lack the
-	// typed markers, mirroring pkg/octosts' generic 403/429 handling.
-	var errResp *github.ErrorResponse
-	if errors.As(err, &errResp) && errResp.Response != nil {
-		switch errResp.Response.StatusCode {
-		case http.StatusForbidden, http.StatusTooManyRequests:
-			return true
-		}
-	}
-	return false
-}
-
 func (e *Validator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	log := clog.FromContext(r.Context()).With(
 		HeaderDelivery, r.Header.Get(HeaderDelivery),
@@ -221,7 +203,7 @@ func (e *Validator) handleSHA(ctx context.Context, client *github.Client, owner,
 	// If we were rate-limited, acknowledge the delivery and skip the CheckRun.
 	// Returning an error would surface as a 5xx, which GitHub treats as a
 	// failed delivery and redelivers — amplifying load on the rate-limited API.
-	if isGitHubRateLimited(err) {
+	if octosts.IsGitHubRateLimited(err) {
 		log.Warnf("rate-limited validating policies for %s/%s@%s; skipping CheckRun", owner, repo, sha)
 		return nil, nil
 	}
@@ -268,7 +250,7 @@ func validatePolicies(ctx context.Context, client *github.Client, owner, repo st
 		resp, _, _, err := client.Repositories.GetContents(ctx, owner, repo, f, &github.RepositoryContentGetOptions{Ref: sha})
 		if err != nil {
 			log.Infof("failed to get content for: %v", err)
-			if isGitHubRateLimited(err) {
+			if octosts.IsGitHubRateLimited(err) {
 				log.Warnf("rate-limited, aborting remaining policy validations")
 				return fmt.Errorf("%s: %w", f, err)
 			}

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/chainguard-dev/clog/slogtest"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-github/v88/github"
+
+	"github.com/octo-sts/app/pkg/octosts"
 )
 
 func TestValidatePolicy(t *testing.T) {
@@ -1450,8 +1452,8 @@ func TestIsGitHubRateLimited(t *testing.T) {
 		want: false,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := isGitHubRateLimited(tc.err); got != tc.want {
-				t.Errorf("isGitHubRateLimited() = %v, want %v", got, tc.want)
+			if got := octosts.IsGitHubRateLimited(tc.err); got != tc.want {
+				t.Errorf("IsGitHubRateLimited() = %v, want %v", got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #1526.

Split out of #901 at @jmeridth's request — independent of that feature, and cherry-pickable on its own.

See #1526 for the diagnosis, impact, and reproduction steps. In short: a real primary rate limit yields `*github.RateLimitError`, which does not unwrap to `*github.ErrorResponse`, so `fetchTrustPolicyRaw`'s rate-limit branch never ran in production — the stale-cache fallback and the cross-app retry were both dead, and callers got `NotFound` instead of `ResourceExhausted`.

## What this changes

**`IsGitHubRateLimited` in `pkg/octosts`**, checking the typed errors before falling back to status codes:

```go
var rateLimitErr *github.RateLimitError
var abuseRateLimitErr *github.AbuseRateLimitError
if errors.As(err, &rateLimitErr) || errors.As(err, &abuseRateLimitErr) {
	return true
}
// ...then 403/429 on a bare *ErrorResponse
```

It is deliberately **lenient** — a bare 403 with no rate-limit marker also counts. That is correct for both current callers, where a false positive costs a retry or a webhook redelivery rather than granting access. The doc comment says so explicitly, because anything that gates *access* needs a stricter test and should not reuse this.

**`pkg/webhook`'s local `isGitHubRateLimited` is deleted** and both of its call sites now use the shared helper. That copy already checked the typed errors correctly; its comment said it was "mirroring pkg/octosts' generic 403/429 handling", so the two had diverged and the weaker one was in the path that mattered. One implementation means they cannot drift again.

**Ordering:** the rate-limit check now runs *before* the 404 branch, so a rate-limited response can never be mistaken for a missing policy and negative-cached — which would have poisoned the cache for five minutes.

The `ResourceExhausted` message loses its `(%d)` status code, since with a typed `*RateLimitError` there is no `ghErr` to read it from. The status is already on the log line above.

## Reviewing the test change first

The commit adds `X-RateLimit-Remaining: 0` (plus `-Limit` and `-Reset`) to `newFakeGitHubRateLimit` **before** touching the classifier, because the fake's omission of that header is why four existing tests passed against a broken classifier. If you want to see the bug rather than take my word for it: check out this commit and revert just the body of `IsGitHubRateLimited` to a status-code-only check — `TestExchangeRateLimit`, `TestPolicyReadRetriesOnRateLimit`, `TestPolicyReadAllRateLimitedReturnsError`, and `TestRateLimitServesStaleCache` all go red.

`go build`, `gofmt -l`, `go vet`, `golangci-lint run ./...` (`0 issues`), and `go test ./... -race` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
