### PR TITLE
refactor(octosts): route GitHub client construction through one constructor

### DIFF
--- a/pkg/octosts/client.go
+++ b/pkg/octosts/client.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Chainguard, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package octosts
+
+import (
+	"net/http"
+
+	"github.com/google/go-github/v88/github"
+)
+
+// newGitHubClient builds a GitHub client that talks through transport to
+// baseURL, which is empty for github.com and set to an API endpoint for GitHub
+// Enterprise Server.
+//
+// Every client-construction site in this package must go through this. An
+// earlier revision of the org-allowlist read constructed its own client without
+// the enterprise option, which sent the read to api.github.com on a GHES
+// deployment; because an unreadable .github repository is treated as "this
+// installation cannot see the file", that silently disabled issuer enforcement
+// for the entire deployment.
+//
+// The returned error is plain: each caller wraps it in the form its own
+// signature requires.
+func newGitHubClient(transport http.RoundTripper, baseURL string) (*github.Client, error) {
+	opts := []github.ClientOptionsFunc{github.WithTransport(transport)}
+	if baseURL != "" {
+		opts = append(opts, github.WithEnterpriseURLs(baseURL, baseURL))
+	}
+	return github.NewClient(opts...)
+}

--- a/pkg/octosts/client_test.go
+++ b/pkg/octosts/client_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Chainguard, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package octosts
+
+import (
+	"bytes"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestNewGitHubClientBaseURL pins the base URL every client in this package is
+// built with. The expected strings were determined empirically from go-github
+// v88 rather than assumed: WithEnterpriseURLs appends /api/v3/ when the given
+// URL does not already end in it, and always leaves a trailing slash.
+//
+// This exists because an earlier revision of the org-allowlist read built its
+// own client without the enterprise option, so on a GitHub Enterprise Server
+// deployment the read went to api.github.com, failed, and was classified as
+// "this installation cannot see .github" — which silently disabled issuer
+// enforcement for the whole deployment.
+func TestNewGitHubClientBaseURL(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		baseURL string
+		want    string
+	}{{
+		name:    "empty base URL uses the github.com default",
+		baseURL: "",
+		want:    "https://api.github.com/",
+	}, {
+		name:    "enterprise host gains the /api/v3/ suffix",
+		baseURL: "https://ghes.example.com",
+		want:    "https://ghes.example.com/api/v3/",
+	}, {
+		name:    "enterprise API endpoint is preserved",
+		baseURL: "https://ghes.example.com/api/v3/",
+		want:    "https://ghes.example.com/api/v3/",
+	}, {
+		name:    "enterprise API endpoint without a trailing slash",
+		baseURL: "https://ghes.example.com/api/v3",
+		want:    "https://ghes.example.com/api/v3/",
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			client, err := newGitHubClient(http.DefaultTransport, tc.baseURL)
+			if err != nil {
+				t.Fatalf("newGitHubClient() = %v", err)
+			}
+			if got := client.BaseURL(); got != tc.want {
+				t.Errorf("BaseURL() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestGitHubClientHasOneConstructor enforces that newGitHubClient is the only
+// place this package builds a GitHub client.
+//
+// It is a convention test rather than a behavior test, and deliberately so: the
+// property it protects is invisible to every other test here. The fakes inject a
+// transport that rewrites requests to a local server, so a client built WITHOUT
+// github.WithEnterpriseURLs still reaches the fake and the whole suite stays
+// green. That is not hypothetical — it is how the defect described on
+// TestNewGitHubClientBaseURL reached a pushed branch, and it was found by a
+// rebase rather than by a test.
+//
+// TestNewGitHubClientBaseURL pins the helper's behavior; this pins that the
+// helper is actually used. Only non-test files are checked, since the property
+// is about the code paths that ship.
+func TestGitHubClientHasOneConstructor(t *testing.T) {
+	const constructor = "github.NewClient("
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("ReadDir(.) = %v", err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") ||
+			strings.HasSuffix(name, "_test.go") || name == "client.go" {
+			continue
+		}
+		b, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatalf("ReadFile(%s) = %v", name, err)
+		}
+		if bytes.Contains(b, []byte(constructor)) {
+			t.Errorf("%s calls %s directly; use newGitHubClient instead, or a GitHub Enterprise Server deployment will silently send this request to api.github.com", name, constructor)
+		}
+	}
+
+	// Guard the guard. If client.go stopped containing the call — renamed,
+	// refactored, moved — the loop above would pass while asserting nothing, and
+	// the invariant this test is named for would no longer exist.
+	b, err := os.ReadFile("client.go")
+	if err != nil {
+		t.Fatalf("ReadFile(client.go) = %v", err)
+	}
+	if !bytes.Contains(b, []byte(constructor)) {
+		t.Errorf("client.go no longer calls %s, so this test has become vacuous", constructor)
+	}
+}

--- a/pkg/octosts/octosts.go
+++ b/pkg/octosts/octosts.go
@@ -408,11 +408,7 @@ func (s *sts) fetchTrustPolicyRaw(ctx context.Context, base *ghinstallation.Apps
 		}
 	}()
 
-	opts := []github.ClientOptionsFunc{github.WithTransport(atr)}
-	if s.baseURL != "" {
-		opts = append(opts, github.WithEnterpriseURLs(s.baseURL, s.baseURL))
-	}
-	client, err := github.NewClient(opts...)
+	client, err := newGitHubClient(atr, s.baseURL)
 	if err != nil {
 		return "", status.Errorf(codes.Internal, "creating GitHub client: %v", err)
 	}

--- a/pkg/octosts/octosts_test.go
+++ b/pkg/octosts/octosts_test.go
@@ -115,7 +115,7 @@ func (f *fakeGitHub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func TestExchange(t *testing.T) {
 	ctx := context.Background()
-	atr := newGitHubClient(t, newFakeGitHub())
+	atr := newAppsTransport(t, newFakeGitHub())
 
 	pk, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
@@ -202,7 +202,7 @@ func TestExchange(t *testing.T) {
 
 func TestExchangeValidation(t *testing.T) {
 	ctx := context.Background()
-	atr := newGitHubClient(t, newFakeGitHub())
+	atr := newAppsTransport(t, newFakeGitHub())
 
 	pk, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
@@ -343,7 +343,7 @@ func TestExchangeRateLimit(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
-			atr := newGitHubClient(t, newFakeGitHubRateLimit(tc.statusCode))
+			atr := newAppsTransport(t, newFakeGitHubRateLimit(tc.statusCode))
 
 			pk, err := rsa.GenerateKey(rand.Reader, 2048)
 			if err != nil {
@@ -442,7 +442,7 @@ func TestPolicyReadUsesRoundRobin(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	rrmAtr := newGitHubClient(t, newFakeGitHub())
+	rrmAtr := newAppsTransport(t, newFakeGitHub())
 
 	pk, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
@@ -492,8 +492,8 @@ func TestPolicyReadRetriesOnRateLimit(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	rateLimitedAtr := newGitHubClient(t, newFakeGitHubRateLimit(http.StatusForbidden))
-	workingAtr := newGitHubClient(t, newFakeGitHub())
+	rateLimitedAtr := newAppsTransport(t, newFakeGitHubRateLimit(http.StatusForbidden))
+	workingAtr := newAppsTransport(t, newFakeGitHub())
 
 	pk, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
@@ -546,8 +546,8 @@ func TestPolicyReadAllRateLimitedReturnsError(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	rl1 := newGitHubClient(t, newFakeGitHubRateLimit(http.StatusForbidden))
-	rl2 := newGitHubClient(t, newFakeGitHubRateLimit(http.StatusTooManyRequests))
+	rl1 := newAppsTransport(t, newFakeGitHubRateLimit(http.StatusForbidden))
+	rl2 := newAppsTransport(t, newFakeGitHubRateLimit(http.StatusTooManyRequests))
 
 	pk, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
@@ -640,7 +640,7 @@ func TestNegativeCachePreventsRepeatedGitHubCalls(t *testing.T) {
 	t.Cleanup(func() { trustPolicies.Remove(key) })
 
 	gh, counter := newFakeGitHubNotFoundCounter()
-	atr := newGitHubClient(t, gh)
+	atr := newAppsTransport(t, gh)
 
 	s := &sts{
 		rrm:      &fakeInstallMgr{atr: atr},
@@ -708,7 +708,7 @@ func TestRateLimitServesStaleCache(t *testing.T) {
 
 	ctx := context.Background()
 	workingGH := newFakeGitHub()
-	workingAtr := newGitHubClient(t, workingGH)
+	workingAtr := newAppsTransport(t, workingGH)
 
 	s := &sts{
 		rrm:      &fakeInstallMgr{atr: workingAtr},
@@ -732,7 +732,7 @@ func TestRateLimitServesStaleCache(t *testing.T) {
 	}
 
 	// Switch to a rate-limited GitHub backend.
-	rateLimitedAtr := newGitHubClient(t, newFakeGitHubRateLimit(http.StatusForbidden))
+	rateLimitedAtr := newAppsTransport(t, newFakeGitHubRateLimit(http.StatusForbidden))
 	s.rrm = &fakeInstallMgr{atr: rateLimitedAtr}
 
 	// Second call: primary cache miss, GitHub 403, should fall back to stale cache.
@@ -750,7 +750,7 @@ func TestRateLimitServesStaleCache(t *testing.T) {
 	}
 }
 
-func newGitHubClient(t *testing.T, h http.Handler) *ghinstallation.AppsTransport {
+func newAppsTransport(t *testing.T, h http.Handler) *ghinstallation.AppsTransport {
 	t.Helper()
 
 	tlsConfig, err := generateTLS(&x509.Certificate{


### PR DESCRIPTION
Fixes #1528.

Split out of #901 at @jmeridth's request. Pure refactor of pre-existing duplication in `pkg/octosts` — no behaviour change on github.com, and it closes a fail-open class on GHES.

See #1528 for why this matters more than style. Short version: a fourth copy of this block was added on #901 without `WithEnterpriseURLs`, which on a GHES deployment sent an allowlist read to `api.github.com`, and because an unreadable repository is classified as "this installation cannot see it", permitted every issuer for the whole deployment.

## What changes

`pkg/octosts/client.go`:

```go
func newGitHubClient(transport http.RoundTripper, baseURL string) (*github.Client, error)
```

`http.RoundTripper` rather than `*ghinstallation.AppsTransport` — it is what `github.WithTransport` takes, both call sites already satisfy it, and it lets the test pass `http.DefaultTransport` without standing up a signing key. It returns a plain error; the caller keeps its existing `status.Errorf(codes.Internal, ...)` wrapping verbatim.

`fetchTrustPolicyRaw` now calls it. That is the only construction site in this package, and the only behavioural change is that there is one fewer place to forget the option.

Deliberately **not** touching `pkg/ghinstall` or `pkg/webhook`. They are separate packages with their own base-URL sources (`m.baseURL`, `e.Transport.BaseURL`), and widening this across packages would make the diff harder to reason about than the problem warrants. Happy to follow up if you'd like them unified too.

## Two tests, because behaviour alone cannot pin this

**`TestNewGitHubClientBaseURL`** asserts the resulting base URL. The expected strings were determined empirically against go-github v88 rather than assumed, which taught me two things worth writing down: `BaseURL` is a *method* in v88, not a field, and `WithEnterpriseURLs` appends `/api/v3/` when the given URL lacks it.

| `baseURL` | `client.BaseURL()` |
|---|---|
| `""` | `https://api.github.com/` |
| `https://ghes.example.com` | `https://ghes.example.com/api/v3/` |
| `https://ghes.example.com/api/v3/` | `https://ghes.example.com/api/v3/` |
| `https://ghes.example.com/api/v3` | `https://ghes.example.com/api/v3/` |

The last two pin idempotence and trailing-slash normalisation, so nobody later "fixes" a doubled `/api/v3/api/v3/` that never existed.

**`TestGitHubClientHasOneConstructor`** is a convention test, and I want to flag it explicitly since it is unusual. It exists because the *wiring* cannot be pinned by behaviour: the fakes route requests through an injected transport, so a call site that bypasses the helper still passes every test. I confirmed that — reverting the call site to a direct `github.NewClient` leaves the whole suite green. So this test scans the package's non-test files for `github.NewClient(` and fails if one appears outside `client.go`. It also asserts that `client.go` still *contains* the call, so it cannot quietly become vacuous if the file is later refactored; I mutation-tested that branch specifically. If you'd rather enforce this with a lint rule than a test, I'm happy to switch.

## One rename you'll see in the diff

`octosts_test.go`'s helper `newGitHubClient(t, handler) *ghinstallation.AppsTransport` is renamed to `newAppsTransport` — it returns a transport, not a client, and it was occupying the name the production constructor wants. Mechanical, test-only.

`go build`, `gofmt -l`, `go vet`, `golangci-lint run ./...` (`0 issues`), and `go test ./... -race` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
