### PR TITLE
fix(webhook): consolidate validated-path matching and filter the policy-directory scan

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -466,8 +466,15 @@ func (e *Validator) handleCheckSuite(ctx context.Context, cs checkSuite) (*githu
 		if err != nil {
 			return nil, err
 		}
+		// This branch lists the policy directory rather than diffing it, so the
+		// entries are everything the directory holds — not just trust policies.
+		// Filter here as every diff-based path already does, otherwise unrelated
+		// files (a README, a .gitkeep) get fetched and parsed as trust policies
+		// and fail the check run.
 		for _, file := range dirContents {
-			files = append(files, file.GetPath())
+			if isValidatedPath(file.GetPath()) {
+				files = append(files, file.GetPath())
+			}
 		}
 	} else {
 		resp, _, err := client.Repositories.CompareCommits(ctx, owner, repo, cs.GetCheckSuite().GetBeforeSHA(), sha, &github.ListOptions{})

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -340,7 +340,7 @@ func (e *Validator) handlePush(ctx context.Context, event *github.PushEvent) (*g
 			return nil, err
 		}
 		for _, file := range resp.Files {
-			if ok, err := filepath.Match(".github/chainguard/*.sts.yaml", file.GetFilename()); err == nil && ok {
+			if isValidatedPath(file.GetFilename()) {
 				if file.GetStatus() != "removed" {
 					files = append(files, file.GetFilename())
 				}
@@ -396,7 +396,7 @@ func (e *Validator) handlePullRequest(ctx context.Context, pr *github.PullReques
 		return nil, err
 	}
 	for _, file := range resp {
-		if ok, err := filepath.Match(".github/chainguard/*.sts.yaml", file.GetFilename()); err == nil && ok {
+		if isValidatedPath(file.GetFilename()) {
 			if file.GetStatus() != "removed" {
 				files = append(files, file.GetFilename())
 			}
@@ -475,7 +475,7 @@ func (e *Validator) handleCheckSuite(ctx context.Context, cs checkSuite) (*githu
 			return nil, err
 		}
 		for _, file := range resp.Files {
-			if ok, err := filepath.Match(".github/chainguard/*.sts.yaml", file.GetFilename()); err == nil && ok {
+			if isValidatedPath(file.GetFilename()) {
 				if file.GetStatus() != "removed" {
 					files = append(files, file.GetFilename())
 				}
@@ -489,7 +489,7 @@ func (e *Validator) handleCheckSuite(ctx context.Context, cs checkSuite) (*githu
 			return nil, err
 		}
 		for _, file := range resp {
-			if ok, err := filepath.Match(".github/chainguard/*.sts.yaml", file.GetFilename()); err == nil && ok {
+			if isValidatedPath(file.GetFilename()) {
 				if file.GetStatus() != "removed" {
 					files = append(files, file.GetFilename())
 				}
@@ -525,11 +525,18 @@ func (e *Validator) shouldSkipOrganization(org string) bool {
 	return true
 }
 
-func (e *Validator) filterSTSFiles(files []string) []string {
+// isValidatedPath reports whether octo-sts validates the given file.
+func isValidatedPath(path string) bool {
+	ok, err := filepath.Match(".github/chainguard/*.sts.yaml", path)
+	return err == nil && ok
+}
+
+// filterValidatedFiles returns the subset of files octo-sts validates.
+func filterValidatedFiles(files []string) []string {
 	var filtered []string
-	for _, file := range files {
-		if ok, err := filepath.Match(".github/chainguard/*.sts.yaml", file); err == nil && ok {
-			filtered = append(filtered, file)
+	for _, f := range files {
+		if isValidatedPath(f) {
+			filtered = append(filtered, f)
 		}
 	}
 	return filtered
@@ -538,8 +545,8 @@ func (e *Validator) filterSTSFiles(files []string) []string {
 func (e *Validator) filesFromPushEvent(event *github.PushEvent) []string {
 	var files []string //nolint:prealloc // size depends on file content, not commit count
 	for _, commit := range event.Commits {
-		files = append(files, e.filterSTSFiles(commit.Added)...)
-		files = append(files, e.filterSTSFiles(commit.Modified)...)
+		files = append(files, filterValidatedFiles(commit.Added)...)
+		files = append(files, filterValidatedFiles(commit.Modified)...)
 	}
 	return files
 }

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -19,6 +19,8 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1140,6 +1142,145 @@ func TestCheckSuiteDefaultBranchProcessed(t *testing.T) {
 	}
 	if *got[0].Conclusion != "success" {
 		t.Fatalf("expected success, got %s", *got[0].Conclusion)
+	}
+}
+
+// TestCheckSuiteDefaultBranchSkipsNonPolicyFiles exercises the zeroHash /
+// initial-commit branch of handleCheckSuite, which lists the policy directory
+// instead of diffing it. The listing contains a README.md alongside the trust
+// policy; only the policy may be fetched and validated.
+func TestCheckSuiteDefaultBranchSkipsNonPolicyFiles(t *testing.T) {
+	got := []*github.CreateCheckRunOptions{}
+
+	dirScanHit := false
+	var fetchedMu sync.Mutex
+	var fetched []string
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v3/repos/foo/bar/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		opt := new(github.CreateCheckRunOptions)
+		if err := json.NewDecoder(r.Body).Decode(opt); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		got = append(got, opt)
+	})
+	mux.HandleFunc("GET /api/v3/repos/foo/bar/contents/.github/chainguard", func(w http.ResponseWriter, r *http.Request) {
+		dirScanHit = true
+		// A real policy directory can hold non-policy files too.
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode([]*github.RepositoryContent{
+			{
+				Type: github.Ptr("file"),
+				Name: github.Ptr("test.sts.yaml"),
+				Path: github.Ptr(".github/chainguard/test.sts.yaml"),
+			},
+			{
+				Type: github.Ptr("file"),
+				Name: github.Ptr("README.md"),
+				Path: github.Ptr(".github/chainguard/README.md"),
+			},
+		}); err != nil {
+			t.Error(err)
+		}
+	})
+	// Record every individual content fetch under the policy directory.
+	mux.HandleFunc("GET /api/v3/repos/foo/bar/contents/.github/chainguard/", func(w http.ResponseWriter, r *http.Request) {
+		fetchedMu.Lock()
+		fetched = append(fetched, strings.TrimPrefix(r.URL.Path, "/api/v3/repos/foo/bar/contents/"))
+		fetchedMu.Unlock()
+
+		f, err := os.Open(filepath.Join("testdata", r.URL.Path))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		defer f.Close()
+		io.Copy(w, f)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		path := filepath.Join("testdata", r.URL.Path)
+		f, err := os.Open(path)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		defer f.Close()
+		io.Copy(w, f)
+	})
+	gh := httptest.NewServer(mux)
+	defer gh.Close()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr := ghinstallation.NewAppsTransportFromPrivateKey(gh.Client().Transport, 1234, key)
+	tr.BaseURL = gh.URL
+
+	secret := []byte("hunter2")
+	v := &Validator{
+		Transport:     tr,
+		WebhookSecret: [][]byte{secret},
+	}
+	srv := httptest.NewServer(v)
+	defer srv.Close()
+
+	body, err := json.Marshal(github.CheckSuiteEvent{
+		Installation: &github.Installation{
+			ID: github.Ptr(int64(1111)),
+		},
+		Repo: &github.Repository{
+			Owner: &github.User{
+				Login: github.Ptr("foo"),
+			},
+			Name:          github.Ptr("bar"),
+			FullName:      github.Ptr("foo/bar"),
+			DefaultBranch: github.Ptr("main"),
+		},
+		Sender: &github.User{Login: github.Ptr("test-user")},
+		Action: github.Ptr("requested"),
+		CheckSuite: &github.CheckSuite{
+			ID:           github.Ptr(int64(1)),
+			HeadSHA:      github.Ptr("deadbeef"),
+			HeadBranch:   github.Ptr("main"),
+			BeforeSHA:    github.Ptr(zeroHash),
+			PullRequests: []*github.PullRequest{},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest(http.MethodPost, srv.URL, bytes.NewBuffer(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Hub-Signature", signature(secret, body))
+	req.Header.Set("X-GitHub-Event", "check_suite")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req.WithContext(slogtest.Context(t)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		out, _ := httputil.DumpResponse(resp, true)
+		t.Fatalf("expected 200, got\n%s", string(out))
+	}
+	if !dirScanHit {
+		t.Fatal("directory scan API was not called but should have been for default branch initial commit")
+	}
+
+	fetchedMu.Lock()
+	defer fetchedMu.Unlock()
+	want := []string{".github/chainguard/test.sts.yaml"}
+	if !slices.Equal(want, fetched) {
+		t.Errorf("fetched content paths = %v, want %v", fetched, want)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 check run, got %d", len(got))
+	}
+	if *got[0].Conclusion != "success" {
+		t.Fatalf("expected success, got %s (summary: %s)", *got[0].Conclusion, got[0].Output.GetSummary())
 	}
 }
 

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -18,6 +18,7 @@ import (
 	"net/http/httputil"
 	"os"
 	"path/filepath"
+	"slices"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -246,17 +247,64 @@ func TestWebhookOK(t *testing.T) {
 	}
 }
 
-func TestFilterSTSFiles(t *testing.T) {
-	v := &Validator{}
+func TestIsValidatedPath(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		path string
+		want bool
+	}{
+		{
+			name: "trust policy",
+			path: ".github/chainguard/test.sts.yaml",
+			want: true,
+		},
+		{
+			name: "workflow not validated",
+			path: ".github/workflows/ci.yaml",
+			want: false,
+		},
+		{
+			name: "nested policy not validated: * does not cross a separator",
+			path: ".github/chainguard/sub/foo.sts.yaml",
+			want: false,
+		},
+		{
+			name: "top-level readme not validated",
+			path: "README.md",
+			want: false,
+		},
+		{
+			name: "readme inside the policy directory not validated",
+			path: ".github/chainguard/README.md",
+			want: false,
+		},
+		{
+			// Pins the ".sts." infix: a README does not match a looser
+			// ".github/chainguard/*.yaml" glob either, so it cannot tell the two
+			// apart on its own.
+			name: "non-policy yaml inside the policy directory not validated",
+			path: ".github/chainguard/config.yaml",
+			want: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isValidatedPath(tc.path); got != tc.want {
+				t.Errorf("isValidatedPath(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFilterValidatedFiles(t *testing.T) {
 	for _, tc := range []struct {
 		name  string
 		input []string
 		want  []string
 	}{
 		{
-			name:  "matches sts.yaml files",
-			input: []string{".github/chainguard/test.sts.yaml", "README.md", ".github/chainguard/other.sts.yaml"},
-			want:  []string{".github/chainguard/test.sts.yaml", ".github/chainguard/other.sts.yaml"},
+			name:  "mixed list keeps only the policy",
+			input: []string{"README.md", ".github/chainguard/test.sts.yaml", ".github/chainguard/README.md", ".github/chainguard/config.yaml", "go.mod"},
+			want:  []string{".github/chainguard/test.sts.yaml"},
 		},
 		{
 			name:  "no matches",
@@ -273,11 +321,16 @@ func TestFilterSTSFiles(t *testing.T) {
 			input: []string{".github/chainguard/subdir/test.sts.yaml"},
 			want:  nil,
 		},
+		{
+			name:  "order preserved",
+			input: []string{".github/chainguard/test.sts.yaml", "README.md", ".github/chainguard/other.sts.yaml"},
+			want:  []string{".github/chainguard/test.sts.yaml", ".github/chainguard/other.sts.yaml"},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := v.filterSTSFiles(tc.input)
-			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("filterSTSFiles() mismatch (-want +got):\n%s", diff)
+			got := filterValidatedFiles(tc.input)
+			if !slices.Equal(tc.want, got) {
+				t.Errorf("filterValidatedFiles(%v) = %v, want %v", tc.input, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #1530.

Split out of #901 at @jmeridth's request. Two commits, reviewable separately: a no-behaviour-change refactor, then the fix.

## `e7775b0` — one predicate instead of five copies

The `.github/chainguard/*.sts.yaml` glob was inlined at four call sites plus a `filterSTSFiles` helper (a method that never used its receiver). Now:

```go
func isValidatedPath(path string) bool
func filterValidatedFiles(files []string) []string
```

`isValidatedPath` is the only `filepath.Match` left in `pkg/webhook/webhook.go`. Each converted site keeps its other conditions exactly — a couple also check `file.GetStatus() != "removed"`, and those are untouched. `TestFilterSTSFiles` is renamed and `TestFilesFromPushEvent` updated for the new signature; that churn is mechanical.

No `repo` parameter, deliberately. #901 adds a second, differently-scoped file to that directory and `isValidatedPath` will then need `repo` to decide whether it applies — but adding the parameter here would leave it unused, and `unparam` would rightly flag it. That's the next PR's job.

## `8f94cbc` — the fix, which changes behaviour

See #1530 for the full write-up. `handleCheckSuite`'s new-branch / initial-commit branch lists the policy directory rather than diffing it, and appended every entry unfiltered — so a `README.md` in `.github/chainguard` was fetched and parsed as a `TrustPolicy`, failing the check run.

**Reviewers: this is a behaviour change to an existing path.** Files in `.github/chainguard` that are not `*.sts.yaml` are no longer fetched or validated on that path. I believe that is what everyone already assumed was happening — the other four sites have always filtered — but it is a change and shouldn't slip past.

## On the tests

The bug lives at a *call site*, so a unit test on `filterValidatedFiles` would pass with the fix unimplemented. `TestCheckSuiteDefaultBranchSkipsNonPolicyFiles` drives the real handler through the zero-hash branch with a listing of `test.sts.yaml` + `README.md`, and asserts both which content paths were fetched and that the check run concludes `success`. Before the fix it fails with:

```
fetched content paths = [.github/chainguard/README.md .github/chainguard/test.sts.yaml], want [.github/chainguard/test.sts.yaml]
expected success, got failure (... * .github/chainguard/README.md: ... 404 [])
```

An existing test already drove that branch, but its listing contained only a `.sts.yaml`, so it was blind to the bug.

One test row worth explaining, since it looks redundant: `TestIsValidatedPath` asserts `.github/chainguard/config.yaml → false`. That row is what pins the `.sts.` infix. `README.md` matches neither `*.sts.yaml` nor a loosened `*.yaml`, so it cannot distinguish the two — loosening the glob is only caught by a `.yaml` file in the right directory. I had originally expected the `README.md` row to cover it; it doesn't.

`go build`, `gofmt -l`, `go vet`, `golangci-lint run ./...` (`0 issues`), and `go test ./... -race` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
