### PR TITLE
feat(ghinstall): add GetAllFresh and let the cache pair own its invariant

### DIFF
--- a/pkg/ghinstall/ghinstall.go
+++ b/pkg/ghinstall/ghinstall.go
@@ -65,11 +65,29 @@ type Manager interface {
 	// installation this process has observed, not every installation that
 	// currently exists. An App uninstalled from an org keeps appearing here
 	// indefinitely; a newly-installed App stays invisible until any negative
-	// cache entry for it expires.
+	// cache entry for it expires. That missing App is reported as a nil error, so
+	// an incomplete enumeration is indistinguishable from a complete one; a caller
+	// whose conclusion becomes UNSAFE when an App is missing must confirm with
+	// GetAllFresh.
 	//
 	// Callers must test len(), not nil-ness: implementations differ in whether
 	// an empty result is a nil or a zero-length slice.
 	GetAll(ctx context.Context, owner string) ([]Installation, error)
+
+	// GetAllFresh enumerates like GetAll but does NOT consult the negative
+	// (not-installed) cache, so an App installed within the last negativeTTL is
+	// visible. The positive cache IS still consulted, so after an
+	// uninstall/reinstall this can report a stale ID; that fails closed, since
+	// the stale ID's token mint fails rather than agreeing. It bypasses this
+	// process's negative cache, not GitHub's replication, so it narrows the
+	// window rather than eliminating it.
+	//
+	// Use it to CONFIRM an absence conclusion GetAll can only support over
+	// observed state. It costs one ListInstallations walk per App with no
+	// positive cache entry, so it does not belong on a hot path. Like GetAll, a
+	// non-nil error means the enumeration is NOT exhaustive even if the returned
+	// slice is non-empty, and callers must test len() rather than nil-ness.
+	GetAllFresh(ctx context.Context, owner string) ([]Installation, error)
 }
 
 const defaultNegativeTTL = 5 * time.Minute
@@ -115,28 +133,21 @@ func NewWithOptions(atr *ghinstallation.AppsTransport, negativeTTL time.Duration
 	}, nil
 }
 
-// Get returns the AppsTransport and installation ID for the given owner.
-// scope and identity are unused by the single-app manager; routing across
-// apps is handled by the roundRobin manager.
-func (m *manager) Get(ctx context.Context, owner, _, _ string) (*ghinstallation.AppsTransport, int64, error) {
-	cacheKey := fmt.Sprintf("%d/%s", m.atr.AppID(), owner)
-	if _, ok := m.negativeCache.Get(cacheKey); ok {
-		clog.InfoContextf(ctx, "negative install cache hit for %s", cacheKey)
-		return nil, 0, status.Errorf(codes.NotFound, "no installation found for %q", owner)
-	}
-	if v, ok := m.cache.Get(cacheKey); ok {
-		clog.InfoContextf(ctx, "found installation in cache for %s", cacheKey)
-		return m.atr, v, nil
-	}
-
+// lookupInstallation walks this App's installations looking for owner.
+//
+// It consults and populates no caches, which lets Get and GetAllFresh share the
+// walk while disagreeing about the negative cache. A false found with a nil error
+// is a complete answer (not installed); a failed walk is not.
+func (m *manager) lookupInstallation(ctx context.Context, owner string) (int64, bool, error) {
 	opts := []github.ClientOptionsFunc{github.WithTransport(m.atr)}
 	if m.baseURL != "" {
 		opts = append(opts, github.WithEnterpriseURLs(m.baseURL, m.baseURL))
 	}
 	client, err := github.NewClient(opts...)
 	if err != nil {
-		return nil, 0, status.Errorf(codes.Internal, "creating GitHub client: %v", err)
+		return 0, false, status.Errorf(codes.Internal, "creating GitHub client: %v", err)
 	}
+
 	// Walk through the pages of installations looking for an organization
 	// matching owner.
 	page := 1
@@ -146,20 +157,72 @@ func (m *manager) Get(ctx context.Context, owner, _, _ string) (*ghinstallation.
 			PerPage: 100,
 		})
 		if err != nil {
-			return nil, 0, status.Errorf(codes.Internal, "listing installations for app %d: %v", m.atr.AppID(), err)
+			return 0, false, status.Errorf(codes.Internal, "listing installations for app %d: %v", m.atr.AppID(), err)
 		}
 
 		for _, install := range installs {
 			if install.Account.GetLogin() == owner {
-				installID := install.GetID()
-				m.cache.Add(cacheKey, installID)
-				return m.atr, installID, nil
+				return install.GetID(), true, nil
 			}
 		}
 		page = resp.NextPage
 	}
+	return 0, false, nil
+}
+
+// cacheKey is the shared key for both of manager's caches. Get and GetAllFresh
+// MUST agree on it: GetAllFresh clears the negative entry Get reads, so a
+// divergence here silently restores the shadowing described on setInstalled.
+func (m *manager) cacheKey(owner string) string {
+	return fmt.Sprintf("%d/%s", m.atr.AppID(), owner)
+}
+
+// setInstalled records that owner IS installed, clearing any negative entry that
+// would shadow it: Get reads the negative cache before the positive one, so a
+// negative entry left alongside a positive one means NotFound for the rest of the
+// negative TTL. Remove precedes Add because manager has no mutex — a concurrent
+// reader landing between the two sees neither entry and does a fresh walk,
+// whereas the other order leaves it reading the stale negative entry.
+//
+// This narrows that window rather than closing it, and establishes no global
+// invariant: a Get whose walk finished before the install can still call
+// setNotInstalled afterwards and re-shadow this entry. The residual fails safe as
+// a spurious NotFound, so routing rejects rather than grants.
+func (m *manager) setInstalled(cacheKey string, id int64) {
+	m.negativeCache.Remove(cacheKey)
+	m.cache.Add(cacheKey, id)
+}
+
+// setNotInstalled records that owner is NOT installed. Only ever called after a
+// completed walk found nothing — a failed walk is ignorance, not absence.
+func (m *manager) setNotInstalled(cacheKey string) {
 	m.negativeCache.Add(cacheKey, true)
-	return nil, 0, status.Errorf(codes.NotFound, "no installation found for %q", owner)
+}
+
+// Get returns the AppsTransport and installation ID for the given owner.
+// scope and identity are unused by the single-app manager; routing across
+// apps is handled by the roundRobin manager.
+func (m *manager) Get(ctx context.Context, owner, _, _ string) (*ghinstallation.AppsTransport, int64, error) {
+	cacheKey := m.cacheKey(owner)
+	if _, ok := m.negativeCache.Get(cacheKey); ok {
+		clog.InfoContextf(ctx, "negative install cache hit for %s", cacheKey)
+		return nil, 0, status.Errorf(codes.NotFound, "no installation found for %q", owner)
+	}
+	if v, ok := m.cache.Get(cacheKey); ok {
+		clog.InfoContextf(ctx, "found installation in cache for %s", cacheKey)
+		return m.atr, v, nil
+	}
+
+	id, found, err := m.lookupInstallation(ctx, owner)
+	if err != nil {
+		return nil, 0, err
+	}
+	if !found {
+		m.setNotInstalled(cacheKey)
+		return nil, 0, status.Errorf(codes.NotFound, "no installation found for %q", owner)
+	}
+	m.setInstalled(cacheKey, id)
+	return m.atr, id, nil
 }
 
 // GetByInstallation returns this app's transport if its installation for
@@ -190,6 +253,31 @@ func (m *manager) GetAll(ctx context.Context, owner string) ([]Installation, err
 		return nil, err
 	}
 	return []Installation{{Transport: atr, ID: id, AppID: m.atr.AppID()}}, nil
+}
+
+// GetAllFresh implements Manager. See the interface for the contract.
+func (m *manager) GetAllFresh(ctx context.Context, owner string) ([]Installation, error) {
+	cacheKey := m.cacheKey(owner)
+	if v, ok := m.cache.Get(cacheKey); ok {
+		// Re-assert rather than read through: otherwise a negative entry armed
+		// after an earlier confirm cleared it is never repaired.
+		m.setInstalled(cacheKey, v)
+		return []Installation{{Transport: m.atr, ID: v, AppID: m.atr.AppID()}}, nil
+	}
+
+	id, found, err := m.lookupInstallation(ctx, owner)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		// A confirmed absence is as cacheable here as in Get; without this every
+		// confirm pays a full walk.
+		m.setNotInstalled(cacheKey)
+		return nil, nil
+	}
+
+	m.setInstalled(cacheKey, id)
+	return []Installation{{Transport: m.atr, ID: id, AppID: m.atr.AppID()}}, nil
 }
 
 // QuotaConfig configures three-tier capacity-aware selection for the
@@ -305,6 +393,23 @@ func (rr *roundRobin) GetByInstallation(ctx context.Context, owner string, insta
 // returned alongside the aggregate error: the list is real but incomplete,
 // and a caller that needs exhaustiveness must not treat it as the whole set.
 func (rr *roundRobin) GetAll(ctx context.Context, owner string) ([]Installation, error) {
+	return rr.enumerate(ctx, owner, "GetAll", Manager.GetAll)
+}
+
+// GetAllFresh implements Manager. See the interface for the contract. It
+// aggregates exactly as GetAll does.
+func (rr *roundRobin) GetAllFresh(ctx context.Context, owner string) ([]Installation, error) {
+	return rr.enumerate(ctx, owner, "GetAllFresh", Manager.GetAllFresh)
+}
+
+// enumerate runs one enumeration method across every manager, concatenating in
+// managers order and deduplicating on installation ID. each takes the Manager
+// before ctx because that is the shape of an interface method expression.
+func (rr *roundRobin) enumerate(
+	ctx context.Context,
+	owner, label string,
+	each func(Manager, context.Context, string) ([]Installation, error),
+) ([]Installation, error) {
 	out := make([]Installation, 0, len(rr.managers))
 	var errs []error
 	seen := make(map[int64]struct{}, len(rr.managers))
@@ -317,7 +422,7 @@ func (rr *roundRobin) GetAll(ctx context.Context, owner string) ([]Installation,
 			break
 		}
 
-		installs, err := m.GetAll(ctx, owner)
+		installs, err := each(m, ctx, owner)
 		if err != nil {
 			errs = append(errs, err)
 			// installs may still be non-empty (a nested roundRobin or future
@@ -335,8 +440,8 @@ func (rr *roundRobin) GetAll(ctx context.Context, owner string) ([]Installation,
 
 	if len(errs) > 0 {
 		err := status.Errorf(codes.Unavailable, "enumerating installations for %q: %v", owner, errors.Join(errs...))
-		clog.WarnContextf(ctx, "ghinstall: GetAll enumeration incomplete for %q: %d of %d managers failed; "+
-			"callers requiring exhaustiveness must treat this as unknown: %v", owner, len(errs), len(rr.managers), err)
+		clog.WarnContextf(ctx, "ghinstall: %s enumeration incomplete for %q: %d of %d managers failed; "+
+			"callers requiring exhaustiveness must treat this as unknown: %v", label, owner, len(errs), len(rr.managers), err)
 		return out, err
 	}
 	return out, nil

--- a/pkg/ghinstall/ghinstall_test.go
+++ b/pkg/ghinstall/ghinstall_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -734,6 +735,15 @@ func TestManagerGetAllPropagatesFailure(t *testing.T) {
 type stubManager struct {
 	installs []Installation
 	err      error
+
+	// freshInstalls / freshErr are what GetAllFresh returns, full stop. They are
+	// deliberately NOT defaulted to installs / err: a test that means "the fresh
+	// enumeration sees nothing" must be able to say so and get nothing, rather
+	// than silently falling back to installs and passing vacuously. Set them to
+	// a superset of installs to model an App that the negative cache hides from
+	// GetAll but not from GetAllFresh.
+	freshInstalls []Installation
+	freshErr      error
 }
 
 func (s *stubManager) Get(_ context.Context, _, _, _ string) (*ghinstallation.AppsTransport, int64, error) {
@@ -754,6 +764,10 @@ func (s *stubManager) GetByInstallation(_ context.Context, _ string, id int64) (
 
 func (s *stubManager) GetAll(_ context.Context, _ string) ([]Installation, error) {
 	return s.installs, s.err
+}
+
+func (s *stubManager) GetAllFresh(_ context.Context, _ string) ([]Installation, error) {
+	return s.freshInstalls, s.freshErr
 }
 
 var _ Manager = (*stubManager)(nil)
@@ -891,5 +905,314 @@ func TestRoundRobinGetAllWithRealManagers(t *testing.T) {
 	}
 	if len(none) != 0 {
 		t.Errorf("GetAll(unserved owner) returned %d installations, want 0", len(none))
+	}
+}
+
+// TestManagerGetAllFreshBypassesNegativeCache is the regression test for the
+// window this whole change exists to close.
+//
+// Sequence: the App is not installed, so a Get arms the negative cache. The App
+// is then installed. GetAll still reports nothing — with a NIL error, because
+// manager.GetAll maps NotFound to (nil, nil) — which is exactly what would let a
+// caller conclude "no installation can see this" and grant allow-all.
+// GetAllFresh must see the truth.
+func TestManagerGetAllFreshBypassesNegativeCache(t *testing.T) {
+	const installID = int64(4321)
+	var installed atomic.Bool
+
+	atr := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/app/installations" {
+			if !installed.Load() {
+				_ = json.NewEncoder(w).Encode([]github.Installation{})
+				return
+			}
+			_ = json.NewEncoder(w).Encode([]github.Installation{{
+				ID:      github.Ptr(installID),
+				Account: &github.User{Login: github.Ptr("org")},
+			}})
+			return
+		}
+		w.WriteHeader(http.StatusNotImplemented)
+	}))
+	m, err := New(atr)
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	// Arm the negative cache the way ordinary routing traffic does.
+	if _, _, err := m.Get(context.Background(), "org", "", ""); err == nil {
+		t.Fatal("Get() = nil error, want NotFound before the App is installed")
+	}
+
+	installed.Store(true)
+
+	// GetAll is still blind, and reports no error while being blind.
+	stale, err := m.GetAll(context.Background(), "org")
+	if err != nil {
+		t.Fatalf("GetAll() = %v, want nil (a negative-cache hit is not an error)", err)
+	}
+	if len(stale) != 0 {
+		t.Fatalf("GetAll() returned %d installations; this test is vacuous unless the negative cache hides the install", len(stale))
+	}
+
+	// GetAllFresh must not be fooled.
+	fresh, err := m.GetAllFresh(context.Background(), "org")
+	if err != nil {
+		t.Fatalf("GetAllFresh() = %v, want nil", err)
+	}
+	if len(fresh) != 1 {
+		t.Fatalf("GetAllFresh() returned %d installations, want 1 — the negative cache must not hide a real install", len(fresh))
+	}
+	if fresh[0].ID != installID {
+		t.Errorf("ID = %d, want %d", fresh[0].ID, installID)
+	}
+	if fresh[0].AppID != atr.AppID() {
+		t.Errorf("AppID = %d, want %d", fresh[0].AppID, atr.AppID())
+	}
+	if fresh[0].Transport == nil {
+		t.Error("Transport = nil, want the app transport")
+	}
+
+	// Get checks the negative cache BEFORE the positive one, so discovering the
+	// installation without clearing the negative entry would fix enforcement
+	// while leaving routing broken for the rest of the TTL.
+	if _, id, err := m.Get(context.Background(), "org", "", ""); err != nil {
+		t.Errorf("Get() = %v, want the installation GetAllFresh just confirmed exists", err)
+	} else if id != installID {
+		t.Errorf("Get() id = %d, want %d", id, installID)
+	}
+}
+
+// TestManagerGetAllFreshUsesPositiveCache pins that the confirm path is cheap
+// once warm: GetAllFresh skips only the NEGATIVE cache. A stale positive entry
+// yields a superset, which is the conservative direction for a caller deciding
+// whether NO installation can see something.
+func TestManagerGetAllFreshUsesPositiveCache(t *testing.T) {
+	const installID = int64(99)
+	var listCalls atomic.Int32
+
+	atr := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/app/installations" {
+			listCalls.Add(1)
+			_ = json.NewEncoder(w).Encode([]github.Installation{{
+				ID:      github.Ptr(installID),
+				Account: &github.User{Login: github.Ptr("org")},
+			}})
+			return
+		}
+		w.WriteHeader(http.StatusNotImplemented)
+	}))
+	m, err := New(atr)
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	if _, _, err := m.Get(context.Background(), "org", "", ""); err != nil {
+		t.Fatalf("Get() = %v", err)
+	}
+	before := listCalls.Load()
+
+	got, err := m.GetAllFresh(context.Background(), "org")
+	if err != nil {
+		t.Fatalf("GetAllFresh() = %v", err)
+	}
+	if len(got) != 1 || got[0].ID != installID {
+		t.Fatalf("GetAllFresh() = %v, want the cached installation %d", got, installID)
+	}
+	if listCalls.Load() != before {
+		t.Errorf("GetAllFresh() made %d extra ListInstallations calls, want 0 — the positive cache must still short-circuit", listCalls.Load()-before)
+	}
+}
+
+// TestManagerGetAllFreshPropagatesFailure: a failed walk must not look like
+// not-installed, or a caller would treat it as a complete answer.
+func TestManagerGetAllFreshPropagatesFailure(t *testing.T) {
+	atr := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/app/installations" {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNotImplemented)
+	}))
+	m, err := New(atr)
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	got, err := m.GetAllFresh(context.Background(), "org")
+	if err == nil {
+		t.Fatal("GetAllFresh() = nil error, want an error when the API call fails")
+	}
+	if st, ok := status.FromError(err); !ok || st.Code() == codes.NotFound {
+		t.Errorf("GetAllFresh() code = %v, want anything but NotFound (that would be indistinguishable from not-installed)", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("GetAllFresh() returned %d installations, want 0", len(got))
+	}
+}
+
+// TestManagerGetAllFreshNotInstalledArmsNegativeCache: a genuine miss must still
+// leave a negative entry, or every confirm would pay a full walk.
+func TestManagerGetAllFreshNotInstalledArmsNegativeCache(t *testing.T) {
+	var listCalls atomic.Int32
+	atr := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/app/installations" {
+			listCalls.Add(1)
+			_ = json.NewEncoder(w).Encode([]github.Installation{})
+			return
+		}
+		w.WriteHeader(http.StatusNotImplemented)
+	}))
+	m, err := New(atr)
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	got, err := m.GetAllFresh(context.Background(), "org")
+	if err != nil {
+		t.Fatalf("GetAllFresh() = %v, want nil for a not-installed owner", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("GetAllFresh() returned %d installations, want 0", len(got))
+	}
+
+	before := listCalls.Load()
+	if _, _, err := m.Get(context.Background(), "org", "", ""); err == nil {
+		t.Fatal("Get() = nil error, want NotFound")
+	}
+	if listCalls.Load() != before {
+		t.Errorf("Get() made %d extra ListInstallations calls, want 0 — GetAllFresh must arm the negative cache on a genuine miss", listCalls.Load()-before)
+	}
+}
+
+func TestRoundRobinGetAllFresh(t *testing.T) {
+	t.Run("concatenates and dedups", func(t *testing.T) {
+		rr := NewRoundRobin([]Manager{
+			&stubManager{freshInstalls: []Installation{{ID: 1, AppID: 10}}},
+			&stubManager{freshInstalls: []Installation{{ID: 2, AppID: 20}, {ID: 1, AppID: 10}}},
+		})
+		got, err := rr.GetAllFresh(context.Background(), "org")
+		if err != nil {
+			t.Fatalf("GetAllFresh() = %v, want nil", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("GetAllFresh() returned %d installations, want 2 (deduped)", len(got))
+		}
+		if got[0].ID != 1 || got[1].ID != 2 {
+			t.Errorf("GetAllFresh() = %v, want stable order [1 2]", []int64{got[0].ID, got[1].ID})
+		}
+	})
+
+	t.Run("one manager failing yields a partial result AND an error", func(t *testing.T) {
+		rr := NewRoundRobin([]Manager{
+			&stubManager{freshInstalls: []Installation{{ID: 1, AppID: 10}}},
+			&stubManager{freshErr: errors.New("boom")},
+		})
+		got, err := rr.GetAllFresh(context.Background(), "org")
+		if err == nil {
+			t.Fatal("GetAllFresh() = nil error, want an error for a partial enumeration")
+		}
+		if len(got) != 1 {
+			t.Errorf("GetAllFresh() returned %d installations, want the 1 that succeeded", len(got))
+		}
+	})
+
+	t.Run("an unserved owner is not an error", func(t *testing.T) {
+		rr := NewRoundRobin([]Manager{&stubManager{}, &stubManager{}})
+		got, err := rr.GetAllFresh(context.Background(), "org")
+		if err != nil {
+			t.Fatalf("GetAllFresh() = %v, want nil", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("GetAllFresh() returned %d installations, want 0", len(got))
+		}
+	})
+
+	// GetAll and GetAllFresh share one aggregation helper, so this covers the
+	// cancellation bail-out for both.
+	t.Run("a cancelled context bails instead of collecting N identical errors", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		rr := NewRoundRobin([]Manager{
+			&stubManager{freshInstalls: []Installation{{ID: 1, AppID: 10}}},
+			&stubManager{freshInstalls: []Installation{{ID: 2, AppID: 20}}},
+		})
+		got, err := rr.GetAllFresh(ctx, "org")
+		if err == nil {
+			t.Fatal("GetAllFresh() = nil error, want the cancellation")
+		}
+		if len(got) != 0 {
+			t.Errorf("GetAllFresh() returned %d installations, want 0 — it must bail before querying any manager", len(got))
+		}
+	})
+}
+
+// TestManagerGetAllFreshRepairsCoexistingCacheEntries pins the invariant that a
+// positive cache entry implies no negative entry, on the positive-cache-HIT path
+// specifically.
+//
+// The two entries can coexist in production: GetAllFresh writes the positive
+// entry, then a concurrent Get whose walk STARTED before the install completes
+// and arms the negative entry afterwards. Because Get checks the negative cache
+// first, routing then returns NotFound for the rest of the TTL — and every later
+// GetAllFresh short-circuits on the positive hit, so without an unconditional
+// Remove there the state never self-heals.
+//
+// Racing to that interleaving would be flaky, so this test seeds the resulting
+// state directly (it is an in-package test) and asserts the repair. It covers
+// the state, not the schedule that produces it.
+func TestManagerGetAllFreshRepairsCoexistingCacheEntries(t *testing.T) {
+	const installID = int64(777)
+	var listCalls atomic.Int32
+
+	atr := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/app/installations" {
+			listCalls.Add(1)
+			_ = json.NewEncoder(w).Encode([]github.Installation{{
+				ID:      github.Ptr(installID),
+				Account: &github.User{Login: github.Ptr("org")},
+			}})
+			return
+		}
+		w.WriteHeader(http.StatusNotImplemented)
+	}))
+	mgr, err := New(atr)
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+	m, ok := mgr.(*manager)
+	if !ok {
+		t.Fatalf("New() returned %T, want *manager", mgr)
+	}
+
+	// Seed the coexistence state a lost race would leave behind.
+	key := m.cacheKey("org")
+	m.cache.Add(key, installID)
+	m.negativeCache.Add(key, true)
+
+	// Sanity: routing really is broken in this state, so the repair below is
+	// load-bearing rather than decorative.
+	if _, _, err := m.Get(context.Background(), "org", "", ""); err == nil {
+		t.Fatal("Get() = nil error; this test is vacuous unless the negative entry shadows the positive one")
+	}
+
+	before := listCalls.Load()
+	got, err := m.GetAllFresh(context.Background(), "org")
+	if err != nil {
+		t.Fatalf("GetAllFresh() = %v, want nil", err)
+	}
+	if len(got) != 1 || got[0].ID != installID {
+		t.Fatalf("GetAllFresh() = %v, want the cached installation %d", got, installID)
+	}
+	if listCalls.Load() != before {
+		t.Errorf("GetAllFresh() made %d extra ListInstallations calls, want 0 — this must be the positive-cache-hit path", listCalls.Load()-before)
+	}
+
+	// The repair: routing recovers immediately instead of at TTL expiry.
+	if _, id, err := m.Get(context.Background(), "org", "", ""); err != nil {
+		t.Errorf("Get() = %v, want the installation — GetAllFresh must clear the negative entry on a positive-cache hit too", err)
+	} else if id != installID {
+		t.Errorf("Get() id = %d, want %d", id, installID)
 	}
 }

--- a/pkg/ghinstall/picker_test.go
+++ b/pkg/ghinstall/picker_test.go
@@ -55,6 +55,15 @@ func (f *fakePickerManager) GetAll(_ context.Context, _ string) ([]Installation,
 	return []Installation{{ID: f.installID}}, nil
 }
 
+// GetAllFresh just delegates: these tests do not distinguish the two
+// enumerations, so this fake cannot model a negative cache hiding an install
+// from GetAll but not GetAllFresh. A test that needs that distinction must use a
+// fake that models the two separately — stubManager here, or enumMgr in
+// pkg/octosts — otherwise it is a regression test that cannot fail.
+func (f *fakePickerManager) GetAllFresh(ctx context.Context, owner string) ([]Installation, error) {
+	return f.GetAll(ctx, owner)
+}
+
 func newFakePickerManagers(installIDs ...int64) []Manager {
 	out := make([]Manager, len(installIDs))
 	for i, id := range installIDs {

--- a/pkg/octosts/octosts_test.go
+++ b/pkg/octosts/octosts_test.go
@@ -63,6 +63,11 @@ func (f *fakeInstallMgr) GetAll(_ context.Context, _ string) ([]ghinstall.Instal
 	return []ghinstall.Installation{{Transport: f.atr, ID: 1234, AppID: f.atr.AppID()}}, nil
 }
 
+// GetAllFresh delegates: these tests exercise routing, not cache freshness.
+func (f *fakeInstallMgr) GetAllFresh(ctx context.Context, owner string) ([]ghinstall.Installation, error) {
+	return f.GetAll(ctx, owner)
+}
+
 var _ ghinstall.Manager = (*fakeInstallMgr)(nil)
 
 type fakeGitHub struct {
@@ -420,6 +425,11 @@ func (f *failInstallMgr) GetAll(_ context.Context, _ string) ([]ghinstall.Instal
 	return nil, fmt.Errorf("kms unavailable")
 }
 
+// GetAllFresh delegates: these tests exercise routing, not cache freshness.
+func (f *failInstallMgr) GetAllFresh(ctx context.Context, owner string) ([]ghinstall.Installation, error) {
+	return f.GetAll(ctx, owner)
+}
+
 var _ ghinstall.Manager = (*failInstallMgr)(nil)
 
 // sequentialInstallMgr returns transports in order on successive Get calls.
@@ -451,6 +461,11 @@ func (s *sequentialInstallMgr) GetAll(_ context.Context, _ string) ([]ghinstall.
 		out = append(out, ghinstall.Installation{Transport: atr, ID: int64(1234 + i), AppID: atr.AppID()})
 	}
 	return out, nil
+}
+
+// GetAllFresh delegates: these tests exercise routing, not cache freshness.
+func (s *sequentialInstallMgr) GetAllFresh(ctx context.Context, owner string) ([]ghinstall.Installation, error) {
+	return s.GetAll(ctx, owner)
 }
 
 var _ ghinstall.Manager = (*sequentialInstallMgr)(nil)


### PR DESCRIPTION
Tracked by #1546. Split out of #901 so the feature there is easier to review on its own. This is the `pkg/ghinstall` half: an enumeration primitive plus a cache fix, both of which stand on their own merits and neither of which mentions trusted issuers.

**Merge #901 first, then this.** I originally claimed "either order" here and that was wrong — I verified it by merging them both ways locally. This PR adds `GetAllFresh` to the `ghinstall.Manager` interface; #901 adds two fakes implementing `Manager` (`enumMgr`, `notInstalledMgr`) in a file that does not exist on `main`, so this PR cannot stub them. Whichever merges second leaves `main` with `*enumMgr does not implement ghinstall.Manager (missing method GetAllFresh)`. It fails quietly: `go build ./...` passes either way, there is no textual conflict, and GitHub reports both MERGEABLE — only the test build breaks, so the first merge is green and the damage shows on the second.

**So this PR needs one small change before it merges:** once #901 is in, add those two stub methods to `pkg/octosts/org_trusted_issuers_store_test.go`. They cannot be added now — without this PR's interface method they are unused methods on unexported types, which fails `golangci-lint`. Reviewing the two independently is still fine; only the merge order is constrained.

The change that needs both PRs — a confirmation step calling `GetAllFresh` before concluding no installation can read `.github` — is deliberately held back as a follow-up rather than coupling them. **That means `GetAllFresh` merges here with no production caller**, tests only; #1546 tracks that gap and the fail-open it exists to close.

## The problem

`Manager.GetAll` is exhaustive only over *observed* state. `manager.GetAll` maps a `NotFound` to `(nil, nil)`, and a `NotFound` served from the negative (not-installed) cache is indistinguishable from a real one — so an App installed within the last `negativeTTL` is **absent from the enumeration with no error to show for it**. An incomplete result that reads as a complete one.

That is harmless for a caller that needs *some* installation. It is unsafe for one whose conclusion flips when an App is missing.

## `GetAllFresh`

Enumerates without consulting the negative cache, so a recently-installed App is visible. Contract:

- The positive cache **is** still consulted, and a hit short-circuits the walk — so after an uninstall/reinstall it can report a stale installation ID *instead of* the current one. That fails closed rather than open: the stale ID's token mint fails, which is a failure rather than an agreement.
- It bypasses **this process's** negative cache, not GitHub's replication. An installation GitHub has not yet propagated is invisible here too, so this narrows a window rather than eliminating one.
- Like `GetAll`, a non-nil error means the enumeration is **not** exhaustive even when the returned slice is non-empty, and callers test `len()` rather than nil-ness.
- It costs one `ListInstallations` walk per App with no positive cache entry, so it is not for hot paths.

It is on the `Manager` interface rather than behind a type assertion for the same reason `GetAll` is (#1525): a `Manager` that silently failed the assertion would quietly lose whatever precondition the caller was checking.

## The cache fix

`Get`'s success path did not clear the negative cache entry, and `Get` reads the negative cache **before** the positive one.

`manager` has no mutex, so a `Get` whose walk finished before an install can arm a negative entry *after* another goroutine recorded the installation, leaving a negative entry shadowing a positive one that already holds the truth — and `Get` returning `NotFound` for an installation it knows exists.

**Correcting an overstatement I made above:** I called this "a routing bug reachable on `main` today", which oversells it. Sequentially it is unconstructible on `main` — `Get` returns early on a negative-cache hit, and the only positive-cache write happens after that check, so a positive entry cannot be created while a negative one is live. It needs a concurrent interleaving, and `Remove`-before-`Add` narrows that window rather than closing it (the losing goroutine's write still lands last), which is what `setInstalled`'s own comment says. So on `main` alone this fix has little standalone value; its real role is as a **prerequisite for `GetAllFresh`**, the first path that bypasses the negative cache and can therefore observe and repair the shadowed state. That is why it ships here rather than separately.

All four cache writes now route through `setInstalled` / `setNotInstalled`, with `Remove` before `Add` so a concurrent reader sees neither entry and re-walks — returning the correct answer, just slower — rather than reading the stale negative.

**This narrows the window rather than closing it, and the doc comment says so explicitly.** Check/walk/commit is not atomic, so a `Get` whose walk finished earlier can still re-shadow via `setNotInstalled`; closing it needs per-owner serialization or versioned observations, neither of which belongs in this PR. The residual fails safe: a spurious `NotFound` rejects exchanges rather than granting anything.

I would rather ship an honest narrowing with the remaining gap named than a comment claiming an invariant the code does not hold. An earlier revision of this change did claim it, and an adversarial review caught it.

## Also here

`roundRobin.GetAll` and `GetAllFresh` share one `enumerate` helper, so the cancellation bail-out, the dedup-on-installation-ID, and the partial-result-plus-error contract cannot drift between them. `manager.Get`'s `ListInstallations` walk moved into `lookupInstallation`, which caches nothing and reports `found` separately from `err` — a completed walk that found nothing is a complete answer; a failed walk is not.

Test fakes across `pkg/ghinstall` and `pkg/octosts` gain the method because they implement `Manager`. The five that delegate to their own `GetAll` say so: those tests exercise routing, not cache freshness.

## Testing

`TestManagerGetAllFreshBypassesNegativeCache` is the regression test: arm the negative cache the way ordinary routing traffic does, install the App, then assert `GetAll` is *still* blind while reporting no error — the test fails as vacuous if the negative cache is not actually hiding the install — and that `GetAllFresh` is not fooled. It also asserts the subsequent `Get` recovers, which is what pins the shadowing repair.

`TestManagerGetAllFreshRepairsCoexistingCacheEntries` seeds the positive+negative coexistence state directly (in-package, via a type assertion) rather than racing to it, asserts routing really is broken in that state so it cannot go vacuous, then asserts the repair. It covers the resulting *state*, not the schedule that produces it — the interleaving itself is not deterministically testable without locking or injected synchronization, and I did not want a flaky test standing in for a real one.

Alongside those: positive-cache short-circuit (asserted by request count), a genuine miss still arming the negative entry, a failed walk propagating as non-`NotFound`, and `roundRobin.GetAllFresh` covering dedup, partial-plus-error, unserved owner, and cancellation.

`golangci-lint run ./...` reports zero issues; `go test ./...` passes; `go test -race` is clean on `pkg/ghinstall` and `pkg/octosts`. `GetAllFresh` (both implementations), `enumerate`, `cacheKey`, and `setInstalled` are at 100% statement coverage. The negative-entry removal was mutation-tested: deleting it fails two tests.

## Not in scope

Making enumeration authoritative — invalidating on installation webhooks so the positive cache cannot report an uninstalled App — is the real fix for the other half of `GetAll`'s staleness and is deliberately not here.



