### PR TITLE
fix(app): don't panic at startup when EVENT_INGRESS_URI is unset

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -116,11 +116,13 @@ func main() {
 	)
 
 	var ceclient cloudevents.Client
-	if baseCfg.Metrics {
+	if baseCfg.Metrics && appConfig.EventingIngress != "" {
 		ceclient, err = mce.NewClientHTTP("octo-sts", mce.WithTarget(ctx, appConfig.EventingIngress)...)
 		if err != nil {
 			log.Panicf("failed to create cloudevents client: %v", err)
 		}
+	} else if baseCfg.Metrics {
+		clog.FromContext(ctx).Warn("EVENT_INGRESS_URI unset; exchange events will not be emitted")
 	}
 
 	pboidc.RegisterSecurityTokenServiceServer(d.Server, octosts.NewSecurityTokenServiceServer(rrm, sticky, len(managers), ceclient, appConfig.Domain, baseCfg.Metrics, baseCfg.GitHubBaseURL))

--- a/pkg/octosts/octosts.go
+++ b/pkg/octosts/octosts.go
@@ -106,7 +106,7 @@ func (s *sts) Exchange(ctx context.Context, request *pboidc.ExchangeRequest) (_ 
 		UserAgent: extractUserAgent(ctx),
 	}
 
-	if s.metrics {
+	if s.metrics && s.ceclient != nil {
 		defer func() {
 			event := cloudevents.NewEvent()
 			event.SetType("dev.octo-sts.exchange")


### PR DESCRIPTION
## Problem

`METRICS` defaults to `true` (`pkg/envconfig/envconfig.go`), and the cloudevents client was constructed solely on that flag:

```go
if baseCfg.Metrics {
    ceclient, err = mce.NewClientHTTP("octo-sts", mce.WithTarget(ctx, appConfig.EventingIngress)...)
    if err != nil {
        log.Panicf("failed to create cloudevents client: %v", err)
    }
}
```

`EVENT_INGRESS_URI` is `required:"false"`, but when it is empty `cehttp.WithTarget("")` returns `http target option was empty string`, which `mce.NewClientHTTP` propagates. The result is `log.Panicf` before the server ever starts listening.

So any deployment that doesn't wire up an eventing ingress — local development, self-hosted installs, anything not using `modules/app` — has to explicitly set `METRICS=false` just to boot, which also switches off metrics serving and tracing as a side effect. The two concerns are not actually related.

## Change

Construct the client only when metrics are enabled **and** an ingress URI is configured, and guard the send path on the client itself rather than on the metrics flag:

- `cmd/app/main.go`: `if baseCfg.Metrics && appConfig.EventingIngress != ""`, with a warning logged when eventing is inactive so a misconfiguration is visible in logs rather than silent.
- `pkg/octosts/octosts.go`: `if s.metrics && s.ceclient != nil` around the deferred event emission.

The `ceclient != nil` guard is the important half. Without it, gating client construction on the URI while leaving the send gated on `s.metrics` turns a startup panic into a nil-interface dereference inside a deferred function on the gRPC handler goroutine — and `duplex` registers no recovery interceptor, so that crashes the process on the first `Exchange` call instead of at boot. The guard makes the send path safe regardless of how the two conditions drift in future.

## Compatibility

| `METRICS` | `EVENT_INGRESS_URI` | Before | After |
|---|---|---|---|
| true | set | events emitted | unchanged |
| true | unset | **panic at startup** | starts, warns, no events |
| false | set | no events | unchanged |
| false | unset | no events | unchanged |

Only the previously-crashing combination behaves differently, so no working deployment is affected. `modules/app/main.tf` always sets `EVENT_INGRESS_URI`, so the production path is untouched.

`METRICS=false` continues to suppress event emission, so it remains usable as a kill switch. No exported signatures change and `s.metrics` is still read, so `unparam` stays quiet.

## Testing

- `go build ./...`
- `go vet ./cmd/app/... ./pkg/octosts/...`
- `go test ./pkg/octosts/... ./pkg/envconfig/...`