### PR TITLE
ci: split staging and prod deploys into separate workflows

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -1,0 +1,25 @@
+# Copyright 2024 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Production deploys are manual only, and this workflow is intentionally kept
+# separate from staging so it can be disabled from the Actions UI without
+# affecting the staging auto-deploy on merge to main.
+name: Deploy (production)
+
+on:
+  workflow_dispatch:
+
+# Serialize production deploys and never cancel one in progress.
+concurrency: deploy-octo-sts
+
+permissions: {}
+
+jobs:
+  production:
+    permissions:
+      contents: read # clone the repository contents (in the reusable workflow)
+      id-token: write # federate with GCP via Workload Identity (in the reusable workflow)
+    uses: ./.github/workflows/deploy.yaml
+    with:
+      environment: octo-sts
+    secrets: inherit

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -22,4 +22,6 @@ jobs:
     uses: ./.github/workflows/deploy.yaml
     with:
       environment: octo-sts
-    secrets: inherit
+    # Pass only the secret the reusable workflow needs, not `secrets: inherit`.
+    secrets:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -1,0 +1,27 @@
+# Copyright 2024 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Staging deploys: automatically on merge to main, and manually on demand.
+name: Deploy (staging)
+
+on:
+  push:
+    branches:
+      - "main"
+  workflow_dispatch:
+
+# Serialize staging deploys and never cancel one in progress: each merged commit
+# matters and a terraform apply must not be interrupted mid-run.
+concurrency: deploy-octo-sts-staging
+
+permissions: {}
+
+jobs:
+  staging:
+    permissions:
+      contents: read # clone the repository contents (in the reusable workflow)
+      id-token: write # federate with GCP via Workload Identity (in the reusable workflow)
+    uses: ./.github/workflows/deploy.yaml
+    with:
+      environment: octo-sts-staging
+    secrets: inherit

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -24,4 +24,6 @@ jobs:
     uses: ./.github/workflows/deploy.yaml
     with:
       environment: octo-sts-staging
-    secrets: inherit
+    # Pass only the secret the reusable workflow needs, not `secrets: inherit`.
+    secrets:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,27 +1,19 @@
 # Copyright 2024 Chainguard, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-name: Deploy to Cloud Run
+# Reusable deploy workflow. Do not add triggers here: it is invoked by
+# deploy-staging.yaml (push to main + manual) and deploy-prod.yaml (manual only).
+# Keeping prod in its own caller workflow lets it be disabled from the Actions UI
+# independently of the staging auto-deploy.
+name: Deploy to Cloud Run (reusable)
 
 on:
-  push:
-    branches:
-      - "main"
-  workflow_dispatch:
+  workflow_call:
     inputs:
       environment:
-        description: "The environment to deploy to"
+        description: "The environment to deploy to (octo-sts-staging or octo-sts)"
         required: true
-        default: "octo-sts-staging"
-        type: choice
-        options:
-          - octo-sts-staging
-          - octo-sts
-
-env:
-  DEFAULT_ENVIRONMENT: "octo-sts-staging"
-
-concurrency: deploy
+        type: string
 
 permissions: {}
 
@@ -33,7 +25,7 @@ jobs:
 
     permissions:
       contents: read # clone the repository contents
-      id-token: write # federates with GCP
+      id-token: write # federate with GCP via Workload Identity
 
     steps:
       - name: Harden Runner
@@ -97,7 +89,7 @@ jobs:
       - name: Resolve auth config
         id: auth-config
         env:
-          INPUT_ENVIRONMENT: ${{ inputs.environment || env.DEFAULT_ENVIRONMENT }}
+          INPUT_ENVIRONMENT: ${{ inputs.environment }}
         run: |
           ENVIRONMENT="${INPUT_ENVIRONMENT}"
           echo "environment=${ENVIRONMENT}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,6 +14,10 @@ on:
         description: "The environment to deploy to (octo-sts-staging or octo-sts)"
         required: true
         type: string
+    secrets:
+      SLACK_WEBHOOK:
+        description: "Slack webhook for failure notifications"
+        required: false
 
 permissions: {}
 


### PR DESCRIPTION
## What/Why
Split the single `deploy.yaml` into a reusable `workflow_call` workflow plus separate staging and production caller workflows, so **production deploys can be disabled from the Actions UI** independently of the staging auto-deploy on merge to main.

- `deploy.yaml` -> reusable (`workflow_call`, `environment` input + `SLACK_WEBHOOK` secret); holds the unchanged deploy body.
- `deploy-staging.yaml` -> `push: main` + `workflow_dispatch`, calls the reusable with `octo-sts-staging`.
- `deploy-prod.yaml` -> `workflow_dispatch` only, calls the reusable with `octo-sts`. This is the workflow to disable in the UI.

Each caller forwards only the `SLACK_WEBHOOK` secret the reusable uses (least privilege), rather than `secrets: inherit`.

## Proof it works
No change to the deploy body: staging still auto-deploys on merge to main; production remains manual (`workflow_dispatch`) only. The callers pass only `SLACK_WEBHOOK`, and the reusable-call inputs/secrets wiring validates cleanly. Manual verification after merge: confirm the two callers show as distinct entries in the Actions tab and that `Deploy (production)` can be toggled off there.

## Risk + AI role
low -- CI/workflow-only, no application code. The production deploy path is unchanged (still `workflow_dispatch`), just isolated into its own workflow so it can be toggled off in the UI. AI-assisted authoring; reviewed against our GitHub Actions standards (top-level `permissions: {}`, per-job permissions with comments, harden-runner first, `persist-credentials: false`, no `continue-on-error`, least-privilege secret passing).

## Review focus
- Reusable-call `permissions` and the explicit `SLACK_WEBHOOK` pass-through (in place of `secrets: inherit`) in the two callers.
- Per-env `concurrency` groups (`deploy-octo-sts-staging` / `deploy-octo-sts`) replacing the former global `deploy` group -- staging and production can now run concurrently, which is intended.
