### PR TITLE
fix(octosts): single-flight org allowlist lookups per owner

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -126,7 +126,7 @@ require (
 	go.uber.org/zap v1.28.0 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
-	golang.org/x/sync v0.22.0 // indirect
+	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/pkg/octosts/octosts.go
+++ b/pkg/octosts/octosts.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-github/v88/github"
 	expirablelru "github.com/hashicorp/golang-lru/v2/expirable"
 
+	"golang.org/x/sync/singleflight"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -74,6 +75,10 @@ type sts struct {
 	metrics       bool
 	baseURL       string
 	orgPolicyRepo string
+
+	// orgIssuerFlight collapses concurrent org-allowlist lookups for the same
+	// owner into one enumeration. Its zero value is ready to use.
+	orgIssuerFlight singleflight.Group
 }
 
 func (s *sts) policyRepo() string {

--- a/pkg/octosts/org_trusted_issuers_store.go
+++ b/pkg/octosts/org_trusted_issuers_store.go
@@ -424,17 +424,60 @@ func (s *sts) confirmNoAccess(ctx context.Context, owner string, scanned []ghins
 	return orgIssuerEntry{}, false
 }
 
+// orgIssuerLookupTimeout bounds the shared enumeration a single-flight leader runs
+// on a cancellation-detached context, so a leader whose GitHub calls hang cannot
+// leak its goroutine. Waiters are already bounded by their own request context.
+// Generous relative to a mint + read per installation.
+const orgIssuerLookupTimeout = 30 * time.Second
+
 // orgIssuerLookup returns the effective allowlist entry for owner, enumerating EVERY
 // installation and stopping at the first definitive answer. Not s.rrm.Get: pickByQuota
 // is argmax(remaining) with no rotation, so a Get-based loop could see one blind
 // installation forever and wrongly cache allow-all for the whole org. A non-nil error
 // is a terminal gRPC status; a nil error with an Invalid entry means the config is
 // unusable and the caller surfaces entry.err.
+//
+// A cold-cache burst for one owner (many exchanges arriving just after a deploy) is
+// collapsed into a single enumeration via singleflight. Without it, every concurrent
+// miss re-walks GetAll (a mint + read per installation) at once, amplifying
+// rate-limit pressure enough to flip the org to fail-closed. Waiters share the
+// leader's result and honor their own context rather than blocking on the leader.
 func (s *sts) orgIssuerLookup(ctx context.Context, owner string) (orgIssuerEntry, error) {
+	// Fast path: a cached entry needs neither enumeration nor single-flight.
 	if e, ok := orgIssuers.Get(owner); ok {
 		return e, nil
 	}
 
+	ch := s.orgIssuerFlight.DoChan(owner, func() (interface{}, error) {
+		// A prior flight may have populated the cache between our miss and here.
+		if e, ok := orgIssuers.Get(owner); ok {
+			return e, nil
+		}
+		// Detach from the triggering caller's cancellation so one caller giving up
+		// cannot fail the shared walk for the others, and a completed walk still
+		// warms the cache; the timeout keeps a stuck walk from leaking the
+		// goroutine. WithoutCancel preserves values, so the rate-limit metric
+		// labels set on the context survive.
+		workCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), orgIssuerLookupTimeout)
+		defer cancel()
+		return s.orgIssuerLookupUncached(workCtx, owner)
+	})
+
+	select {
+	case <-ctx.Done():
+		// This caller gave up; the shared flight keeps running for the others.
+		return orgIssuerEntry{}, status.FromContextError(ctx.Err()).Err()
+	case res := <-ch:
+		if res.Err != nil {
+			return orgIssuerEntry{}, res.Err
+		}
+		return res.Val.(orgIssuerEntry), nil
+	}
+}
+
+// orgIssuerLookupUncached performs the enumeration behind orgIssuerLookup's cache
+// and single-flight; it is the walk whose amplification the flight exists to prevent.
+func (s *sts) orgIssuerLookupUncached(ctx context.Context, owner string) (orgIssuerEntry, error) {
 	installs, enumErr := s.rrm.GetAll(ctx, owner)
 
 	var t orgIssuerTally
@@ -455,7 +498,7 @@ func (s *sts) orgIssuerLookup(ctx context.Context, owner string) (orgIssuerEntry
 	if stale, ok := staleOrgIssuers.Get(owner); ok {
 		// Served but NOT reseeded into the primary: a fresh 5-minute TTL on an entry
 		// already up to an hour old would let an Absent survive past its stale bound.
-		// Costs a re-enumeration per exchange for the duration of the outage.
+		// Costs a re-enumeration per lookup for the duration of the outage.
 		clog.InfoContextf(ctx, "org issuer lookup incomplete for %s, serving stale entry", owner)
 		return stale, nil
 	}

--- a/pkg/octosts/org_trusted_issuers_store_test.go
+++ b/pkg/octosts/org_trusted_issuers_store_test.go
@@ -1928,3 +1928,123 @@ func TestStaleEntryIsNotReseededIntoPrimary(t *testing.T) {
 		t.Error("stale entry was reseeded into the primary cache; that extends the fail-open past the stale TTL")
 	}
 }
+
+// countingMgr wraps an enumMgr to count GetAll calls and optionally block the
+// first one, so a test can hold a single-flight leader inside the walk while
+// other callers pile up as waiters.
+type countingMgr struct {
+	*enumMgr
+	getAllN     atomic.Int32
+	block       chan struct{} // if non-nil, GetAll waits on it (closed to release)
+	entered     chan struct{} // if non-nil, closed once when GetAll is first entered
+	enteredOnce sync.Once
+}
+
+func (m *countingMgr) GetAll(ctx context.Context, owner string) ([]ghinstall.Installation, error) {
+	m.getAllN.Add(1)
+	if m.entered != nil {
+		m.enteredOnce.Do(func() { close(m.entered) })
+	}
+	if m.block != nil {
+		<-m.block
+	}
+	return m.enumMgr.GetAll(ctx, owner)
+}
+
+var _ ghinstall.Manager = (*countingMgr)(nil)
+
+// TestOrgIssuerLookupSingleFlightsColdBurst proves the mitigation: a burst of
+// concurrent lookups for the same cold-cache owner collapses to ONE enumeration
+// (GetAll + the confirm's GetAllFresh each run once), and every caller receives
+// the same definitive result. Without single-flight each concurrent miss would
+// re-walk GetAll, amplifying rate-limit pressure right after a deploy.
+func TestOrgIssuerLookupSingleFlightsColdBurst(t *testing.T) {
+	cleanupOrgIssuers(t, "orgallow")
+
+	// All installations are blind, so the walk confirms Absent via GetAllFresh —
+	// exercising the whole enumeration, not just the cheap path.
+	a := newAppsTransport(t, newOrgFakeGitHub(withNoGitHubRepoAccess()))
+	b := newAppsTransport(t, newOrgFakeGitHub(withNoGitHubRepoAccess()))
+	base := &enumMgr{installs: []ghinstall.Installation{
+		{Transport: a, ID: 1, AppID: 10},
+		{Transport: b, ID: 2, AppID: 20},
+	}}
+	release := make(chan struct{})
+	mgr := &countingMgr{enumMgr: base, block: release}
+	s := &sts{rrm: mgr, appCount: 2}
+
+	const n = 50
+	var wg sync.WaitGroup
+	results := make([]orgIssuerEntry, n)
+	errs := make([]error, n)
+	start := make(chan struct{})
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			results[i], errs[i] = s.orgIssuerLookup(t.Context(), "orgallow")
+		}(i)
+	}
+	close(start) // release all goroutines together so they collide on the cold cache
+	// Let every goroutine miss the cache and join the in-flight before the leader
+	// returns. Populating the cache happens only after GetAll unblocks, so a late
+	// caller either joins this flight or hits the warm cache — never a 2nd walk.
+	time.Sleep(100 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	if got := mgr.getAllN.Load(); got != 1 {
+		t.Errorf("GetAll ran %d times under a %d-way cold burst, want 1 (single-flight collapse)", got, n)
+	}
+	if got := base.freshCalls.Load(); got != 1 {
+		t.Errorf("GetAllFresh ran %d times, want 1", got)
+	}
+	for i := range n {
+		if errs[i] != nil {
+			t.Fatalf("caller %d: %v", i, errs[i])
+		}
+		if results[i].state != orgIssuerAbsent {
+			t.Fatalf("caller %d: state %v, want the shared orgIssuerAbsent result", i, results[i].state)
+		}
+	}
+}
+
+// TestOrgIssuerLookupWaiterHonorsOwnContext proves a waiter joining an in-flight
+// lookup returns on its OWN deadline rather than blocking until the leader
+// finishes — the reason the mitigation uses DoChan plus a context select.
+func TestOrgIssuerLookupWaiterHonorsOwnContext(t *testing.T) {
+	cleanupOrgIssuers(t, "orgallow")
+
+	a := newAppsTransport(t, newOrgFakeGitHub(withNoGitHubRepoAccess()))
+	base := &enumMgr{installs: []ghinstall.Installation{{Transport: a, ID: 1, AppID: 10}}}
+	release := make(chan struct{})
+	entered := make(chan struct{})
+	mgr := &countingMgr{enumMgr: base, block: release, entered: entered}
+	s := &sts{rrm: mgr, appCount: 1}
+
+	// Leader: starts the flight on a background context and blocks inside GetAll.
+	leaderDone := make(chan struct{})
+	go func() {
+		defer close(leaderDone)
+		_, _ = s.orgIssuerLookup(context.Background(), "orgallow")
+	}()
+	<-entered // the flight is active and parked in GetAll
+
+	// Waiter with a short deadline must return promptly, not block on the leader.
+	wctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	begin := time.Now()
+	_, err := s.orgIssuerLookup(wctx, "orgallow")
+	elapsed := time.Since(begin)
+
+	if status.Code(err) != codes.DeadlineExceeded {
+		t.Fatalf("waiter err = %v (code %v), want DeadlineExceeded", err, status.Code(err))
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("waiter blocked %v; it must honor its own context, not the leader's walk", elapsed)
+	}
+
+	close(release) // let the leader finish so its goroutine does not linger
+	<-leaderDone
+}


### PR DESCRIPTION
Relates to #1550

**In short:** right after a deploy the cache is empty, so a burst of token requests each call GitHub to check the org allowlist at once, tripping the rate limit and getting denied. This makes one request do that lookup while the rest reuse its result.

## What/Why
Collapse concurrent org trusted-issuer allowlist lookups for the same owner into a single enumeration. On a cold cache (right after a deploy or restart), a high-traffic org with multiple installed Apps otherwise has every concurrent exchange re-walk `GetAll` (a token mint + `.github` read per installation) at the same time. That amplifies rate-limit pressure enough that the fail-closed allowlist check denies a burst of exchanges until the cache warms; the single-flight removes that amplification.

## Proof it works
New `-race` tests:
- a 50-way cold-cache burst for one owner runs `GetAll` (and the confirm's `GetAllFresh`) exactly once, and all 50 callers receive the same result;
- a waiter joining an in-flight lookup returns on its own 50ms deadline instead of blocking until the leader's walk finishes.

Full `pkg/octosts` suite passes with `-race`. The enumeration body is unchanged (extracted into `orgIssuerLookupUncached`), so the allowlist decision and the existing fail-safe semantics are untouched.

## Risk + AI role
low -- a resilience change around the org-issuer lookup; no change to the allowlist decision path. AI-assisted authoring. The fast-path cache check and the walk are preserved; only the concurrency wrapper is new.

## Review focus
- The single-flight context handling: the leader runs the shared walk on `context.WithoutCancel` + a 30s timeout (so one caller cancelling cannot fail the shared walk, and a completed walk warms the cache), while waiters select on their own request context via `DoChan`.
