### PR TITLE
ci: split production deploy into its own workflow (staging keeps deploy.yaml)

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -1,0 +1,31 @@
+# Copyright 2024 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Production deploys are manual only, and this workflow is intentionally kept
+# separate from staging so it can be disabled from the Actions UI without
+# affecting the staging auto-deploy on merge to main.
+#
+# NOTE: the production Workload Identity Federation binding must trust this
+# workflow ref (.github/workflows/deploy-prod.yaml) before the first dispatch;
+# see env/octo-sts/bootstrap/main.tf.
+name: Deploy (production)
+
+on:
+  workflow_dispatch:
+
+# Serialize production deploys and never cancel one in progress.
+concurrency: deploy-octo-sts
+
+permissions: {}
+
+jobs:
+  production:
+    permissions:
+      contents: read # clone the repository contents (in the reusable workflow)
+      id-token: write # federate with GCP via Workload Identity (in the reusable workflow)
+    uses: ./.github/workflows/deploy-reusable.yaml
+    with:
+      environment: octo-sts
+    # Pass only the secret the reusable workflow needs, not `secrets: inherit`.
+    secrets:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy-reusable.yaml
+++ b/.github/workflows/deploy-reusable.yaml
@@ -1,0 +1,167 @@
+# Copyright 2024 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Reusable deploy body. Invoked by deploy.yaml (staging) and deploy-prod.yaml
+# (production). The triggering entry-point workflows are kept as their own files
+# so production can be disabled from the Actions UI independently of staging, and
+# so the Workload Identity Federation bindings (pinned to the entry-point
+# workflow ref) stay stable: staging keeps deploy.yaml, production is deploy-prod.yaml.
+name: Deploy to Cloud Run (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: "The environment to deploy to (octo-sts-staging or octo-sts)"
+        required: true
+        type: string
+    secrets:
+      SLACK_WEBHOOK:
+        description: "Slack webhook for failure notifications"
+        required: false
+
+permissions: {}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    if: github.repository == 'octo-sts/app'
+
+    permissions:
+      contents: read # clone the repository contents
+      id-token: write # federate with GCP via Workload Identity
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            *.blob.core.windows.net:443
+            *.githubapp.com:443
+            9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
+            api.github.com:443
+            bigquery.googleapis.com:443
+            bigquerydatatransfer.googleapis.com:443
+            cgr.dev:443
+            checkpoint-api.hashicorp.com:443
+            cloudbilling.googleapis.com:443
+            cloudkms.googleapis.com:443
+            cloudresourcemanager.googleapis.com:443
+            compute.googleapis.com:443
+            dl.google.com:443
+            dns.googleapis.com:443
+            firestore.googleapis.com:443
+            octo-staging.dev:443
+            octo-sts.dev:443
+            fulcio.sigstore.dev:443
+            gcr.io:443
+            github.com:443
+            go.dev:443
+            hooks.slack.com:443
+            iam.googleapis.com:443
+            iamcredentials.googleapis.com:443
+            logging.googleapis.com:443
+            monitoring.googleapis.com:443
+            objects.githubusercontent.com:443
+            openidconnect.googleapis.com:443
+            proxy.golang.org:443
+            pubsub.googleapis.com:443
+            registry.terraform.io:443
+            rekor.sigstore.dev:443
+            release-assets.githubusercontent.com:443
+            releases.hashicorp.com:443
+            run.googleapis.com:443
+            secretmanager.googleapis.com:443
+            serviceusage.googleapis.com:443
+            storage.googleapis.com:443
+            sts.googleapis.com:443
+            sum.golang.org:443
+            tuf-repo-cdn.sigstore.dev:443
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: "${{ github.workspace }}/.go-version"
+          check-latest: true
+          cache: "false"
+
+      - name: Resolve auth config
+        id: auth-config
+        env:
+          INPUT_ENVIRONMENT: ${{ inputs.environment }}
+        run: |
+          ENVIRONMENT="${INPUT_ENVIRONMENT}"
+          echo "environment=${ENVIRONMENT}" >> "$GITHUB_OUTPUT"
+          if [[ "${ENVIRONMENT}" == "octo-sts" ]]; then
+            echo "workload_identity_provider=projects/96355665038/locations/global/workloadIdentityPools/github-pool/providers/github-provider" >> "$GITHUB_OUTPUT"
+            echo "service_account=github-identity@octo-sts.iam.gserviceaccount.com" >> "$GITHUB_OUTPUT"
+          elif [[ "${ENVIRONMENT}" == "octo-sts-staging" ]]; then
+            echo "workload_identity_provider=projects/578801560891/locations/global/workloadIdentityPools/octo-sts-staging/providers/github-provider" >> "$GITHUB_OUTPUT"
+            echo "service_account=octo-sts-staging-ci@octo-sts-staging.iam.gserviceaccount.com" >> "$GITHUB_OUTPUT"
+          else
+            echo "Unknown environment: ${ENVIRONMENT}" >&2
+            exit 1
+          fi
+
+      - name: Log deployment target
+        env:
+          ENVIRONMENT: ${{ steps.auth-config.outputs.environment }}
+        run: |
+          echo "Deploying to environment: ${ENVIRONMENT}"
+
+      - uses: step-security/google-github-auth@775fc4c80760272ef389c9f9f8d98de7db0c170d # v3.0.2
+        id: auth
+        with:
+          token_format: "access_token"
+          project_id: "${{ steps.auth-config.outputs.environment }}"
+          workload_identity_provider: "${{ steps.auth-config.outputs.workload_identity_provider }}"
+          service_account: "${{ steps.auth-config.outputs.service_account }}"
+
+      - uses: "docker/login-action@dbcb813823bdd20940b903addbd779551569679f" # v4.6.0
+        with:
+          username: "oauth2accesstoken"
+          password: "${{ steps.auth.outputs.access_token }}"
+          registry: "gcr.io"
+
+      - uses: chainguard-dev/actions/setup-terraform@9d631658f55713e5f63ca0cc21ee168f81301fd9 # v1.6.30
+        with:
+          terraform-version-file: "${{ github.workspace }}/.terraform-version"
+          terraform-wrapper: false
+
+      - id: terraform-init
+        working-directory: "./env/${{ steps.auth-config.outputs.environment }}"
+        run: |
+          terraform init
+
+      - if: steps.terraform-init.outcome == 'success'
+        working-directory: "./env/${{ steps.auth-config.outputs.environment }}"
+        run: |
+          terraform plan
+
+          terraform apply -auto-approve
+
+      - name: Run smoke tests
+        if: steps.terraform-init.outcome == 'success'
+        env:
+          SMOKETEST_ENV: ${{ steps.auth-config.outputs.environment }}
+        run: |
+          go run ./hack/smoketest/ -config "hack/smoketest/testdata/${SMOKETEST_ENV}.yaml"
+
+      - uses: step-security/action-slack-notify@e4cdee14a905d9da46ba47ad9309704407d8cd79 # v2.4.0
+        if: ${{ failure() }}
+        env:
+          SLACK_ICON: http://github.com/chainguard-dev.png?size=48
+          SLACK_USERNAME: guardian
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_CHANNEL: "${{ steps.auth-config.outputs.environment }}-alerts" # Use a channel
+          SLACK_COLOR: "#8E1600"
+          MSG_MINIMAL: "true"
+          SLACK_TITLE: Deploying OctoSTS to Cloud Run failed
+          SLACK_MESSAGE: |
+            For detailed logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,170 +1,33 @@
 # Copyright 2024 Chainguard, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-name: Deploy to Cloud Run
+# Staging deploys: automatically on merge to main, and manually on demand.
+# Intentionally kept as deploy.yaml (the same entry-point path the staging
+# Workload Identity Federation binding trusts) so splitting production into its
+# own workflow does not change staging's OIDC identity. Production lives in
+# deploy-prod.yaml; the shared body is deploy-reusable.yaml.
+name: Deploy (staging)
 
 on:
   push:
     branches:
       - "main"
   workflow_dispatch:
-    inputs:
-      environment:
-        description: "The environment to deploy to"
-        required: true
-        default: "octo-sts-staging"
-        type: choice
-        options:
-          - octo-sts-staging
-          - octo-sts
 
-env:
-  DEFAULT_ENVIRONMENT: "octo-sts-staging"
-
-concurrency: deploy
+# Serialize staging deploys and never cancel one in progress: each merged commit
+# matters and a terraform apply must not be interrupted mid-run.
+concurrency: deploy-octo-sts-staging
 
 permissions: {}
 
 jobs:
-  deploy:
-    runs-on: ubuntu-latest
-
-    if: github.repository == 'octo-sts/app'
-
+  staging:
     permissions:
-      contents: read # clone the repository contents
-      id-token: write # federates with GCP
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
-        with:
-          egress-policy: block
-          allowed-endpoints: >
-            *.blob.core.windows.net:443
-            *.githubapp.com:443
-            9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
-            api.github.com:443
-            bigquery.googleapis.com:443
-            bigquerydatatransfer.googleapis.com:443
-            cgr.dev:443
-            checkpoint-api.hashicorp.com:443
-            cloudbilling.googleapis.com:443
-            cloudkms.googleapis.com:443
-            cloudresourcemanager.googleapis.com:443
-            compute.googleapis.com:443
-            dl.google.com:443
-            dns.googleapis.com:443
-            firestore.googleapis.com:443
-            octo-staging.dev:443
-            octo-sts.dev:443
-            fulcio.sigstore.dev:443
-            gcr.io:443
-            github.com:443
-            go.dev:443
-            hooks.slack.com:443
-            iam.googleapis.com:443
-            iamcredentials.googleapis.com:443
-            logging.googleapis.com:443
-            monitoring.googleapis.com:443
-            objects.githubusercontent.com:443
-            openidconnect.googleapis.com:443
-            proxy.golang.org:443
-            pubsub.googleapis.com:443
-            registry.terraform.io:443
-            rekor.sigstore.dev:443
-            release-assets.githubusercontent.com:443
-            releases.hashicorp.com:443
-            run.googleapis.com:443
-            secretmanager.googleapis.com:443
-            serviceusage.googleapis.com:443
-            storage.googleapis.com:443
-            sts.googleapis.com:443
-            sum.golang.org:443
-            tuf-repo-cdn.sigstore.dev:443
-
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version-file: "${{ github.workspace }}/.go-version"
-          check-latest: true
-          cache: "false"
-
-      - name: Resolve auth config
-        id: auth-config
-        env:
-          INPUT_ENVIRONMENT: ${{ inputs.environment || env.DEFAULT_ENVIRONMENT }}
-        run: |
-          ENVIRONMENT="${INPUT_ENVIRONMENT}"
-          echo "environment=${ENVIRONMENT}" >> "$GITHUB_OUTPUT"
-          if [[ "${ENVIRONMENT}" == "octo-sts" ]]; then
-            echo "workload_identity_provider=projects/96355665038/locations/global/workloadIdentityPools/github-pool/providers/github-provider" >> "$GITHUB_OUTPUT"
-            echo "service_account=github-identity@octo-sts.iam.gserviceaccount.com" >> "$GITHUB_OUTPUT"
-          elif [[ "${ENVIRONMENT}" == "octo-sts-staging" ]]; then
-            echo "workload_identity_provider=projects/578801560891/locations/global/workloadIdentityPools/octo-sts-staging/providers/github-provider" >> "$GITHUB_OUTPUT"
-            echo "service_account=octo-sts-staging-ci@octo-sts-staging.iam.gserviceaccount.com" >> "$GITHUB_OUTPUT"
-          else
-            echo "Unknown environment: ${ENVIRONMENT}" >&2
-            exit 1
-          fi
-
-      - name: Log deployment target
-        env:
-          ENVIRONMENT: ${{ steps.auth-config.outputs.environment }}
-        run: |
-          echo "Deploying to environment: ${ENVIRONMENT}"
-
-      - uses: step-security/google-github-auth@775fc4c80760272ef389c9f9f8d98de7db0c170d # v3.0.2
-        id: auth
-        with:
-          token_format: "access_token"
-          project_id: "${{ steps.auth-config.outputs.environment }}"
-          workload_identity_provider: "${{ steps.auth-config.outputs.workload_identity_provider }}"
-          service_account: "${{ steps.auth-config.outputs.service_account }}"
-
-      - uses: "docker/login-action@dbcb813823bdd20940b903addbd779551569679f" # v4.6.0
-        with:
-          username: "oauth2accesstoken"
-          password: "${{ steps.auth.outputs.access_token }}"
-          registry: "gcr.io"
-
-      - uses: chainguard-dev/actions/setup-terraform@9d631658f55713e5f63ca0cc21ee168f81301fd9 # v1.6.30
-        with:
-          terraform-version-file: "${{ github.workspace }}/.terraform-version"
-          terraform-wrapper: false
-
-      - id: terraform-init
-        working-directory: "./env/${{ steps.auth-config.outputs.environment }}"
-        run: |
-          terraform init
-
-      - if: steps.terraform-init.outcome == 'success'
-        working-directory: "./env/${{ steps.auth-config.outputs.environment }}"
-        run: |
-          terraform plan
-
-          terraform apply -auto-approve
-
-      - name: Run smoke tests
-        if: steps.terraform-init.outcome == 'success'
-        env:
-          SMOKETEST_ENV: ${{ steps.auth-config.outputs.environment }}
-        run: |
-          go run ./hack/smoketest/ -config "hack/smoketest/testdata/${SMOKETEST_ENV}.yaml"
-
-      - uses: step-security/action-slack-notify@e4cdee14a905d9da46ba47ad9309704407d8cd79 # v2.4.0
-        if: ${{ failure() }}
-        env:
-          SLACK_ICON: http://github.com/chainguard-dev.png?size=48
-          SLACK_USERNAME: guardian
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_CHANNEL: "${{ steps.auth-config.outputs.environment }}-alerts" # Use a channel
-          SLACK_COLOR: "#8E1600"
-          MSG_MINIMAL: "true"
-          SLACK_TITLE: Deploying OctoSTS to Cloud Run failed
-          SLACK_MESSAGE: |
-            For detailed logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      contents: read # clone the repository contents (in the reusable workflow)
+      id-token: write # federate with GCP via Workload Identity (in the reusable workflow)
+    uses: ./.github/workflows/deploy-reusable.yaml
+    with:
+      environment: octo-sts-staging
+    # Pass only the secret the reusable workflow needs, not `secrets: inherit`.
+    secrets:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
## What/Why
Give production deploys their own `workflow_dispatch`-only workflow (`deploy-prod.yaml`) so production can be disabled from the Actions UI independently of the staging auto-deploy on merge to main. Staging is intentionally kept in `deploy.yaml` (same entry-point path), and the shared deploy body moves to `deploy-reusable.yaml`.

This supersedes the earlier symmetric split (reverted in #1561), which renamed the staging entry point and broke the staging deploy's WIF auth.

## Proof it works
`actionlint` and `zizmor` clean. Staging keeps `deploy.yaml` with its `push` trigger, so its OIDC `workflow_ref` is unchanged and the staging Workload Identity Federation binding still matches, with no transition window on the auto-deploy path. Production is manual-dispatch only.

## Risk + AI role
low -- CI/workflow-only, no application code. AI-assisted authoring. Coordination note: the production WIF binding must trust `.github/workflows/deploy-prod.yaml` before the first production dispatch (separate one-line change to `env/octo-sts/bootstrap/main.tf`, opened alongside this).

## Review focus
- `deploy.yaml` stays the staging entry point (unchanged `workflow_ref`), so only production moves to a new file and only the production WIF binding needs updating; the staging auto-deploy is never on the critical path.
