### PR TITLE
fix(bootstrap): trust deploy-prod.yaml for the production deploy WIF binding

### DIFF
--- a/env/octo-sts/bootstrap/main.tf
+++ b/env/octo-sts/bootstrap/main.tf
@@ -54,9 +54,11 @@ module "github_identity" {
   name       = "github-identity"
   wif-pool   = module.github-wif.pool_name
 
-  repository   = "octo-sts/app"
-  refspec      = "refs/heads/main"
-  workflow_ref = ".github/workflows/deploy.yaml"
+  repository = "octo-sts/app"
+  refspec    = "refs/heads/main"
+  # Production deploys run from deploy-prod.yaml (split out so prod can be
+  # disabled independently in the Actions UI). Staging stays on deploy.yaml.
+  workflow_ref = ".github/workflows/deploy-prod.yaml"
 
   notification_channels = local.notification_channels
 }


### PR DESCRIPTION
## What/Why
The production deploy now runs from `.github/workflows/deploy-prod.yaml` (split out so prod can be disabled independently in the Actions UI). Point the `github-identity` service account's Workload Identity Federation binding at that workflow ref so the production dispatch can federate. Staging is unchanged (still `deploy.yaml`).

Pairs with the workflow split in octo-sts/app#1562.

## Proof it works
`terraform fmt` clean. This must be **applied before the first production dispatch** of `deploy-prod.yaml`, otherwise the prod auth step 403s (the same failure class that #1561 reverted). Staging is unaffected by this change, so there is no window on the auto-deploy path.

## Risk + AI role
low -- one-line WIF binding update (plus a `terraform fmt` realignment), applied via the octo-sts bootstrap. No effect on staging. AI-assisted authoring.

## Review focus
- The production deploy entry point is `deploy-prod.yaml` and the binding now matches it; the staging binding (managed in the infra repo) intentionally stays on `deploy.yaml`.
