### PR TITLE
chore: remove tracked .vscode/settings.json in favor of inline schema headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@
 # ai
 **/.claude/*.local.*
 
+# Editor settings (schema mapping is handled by the inline yaml-language-server header)
+.vscode/
+
 # Go workspace file
 go.work
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "yaml.schemas": {
-        "./pkg/octosts/octosts.TrustPolicy.json": "/.github/chainguard/*"
-    }
-}


### PR DESCRIPTION
Closes #1547

## What/Why

Remove the editor-specific `.vscode/settings.json` (and gitignore `.vscode/`). Its `yaml.schemas` mapping is superseded by the editor-agnostic `# yaml-language-server: $schema=...` header already present in the README examples, and its `/.github/chainguard/*` glob is stale: it would misvalidate the new `trusted-token-issuers.yaml` (an org allowlist, not a TrustPolicy).

## Proof it works

Config/docs only, no code changed. The README already carries the inline header for both TrustPolicy and OrgTrustedIssuers, and its VSCode section recommends `vscode-yaml` reading that header rather than the settings file, so editor schema validation is unaffected by the deletion.

## Risk + AI role

low -- repo-tracked editor config only, no runtime or build impact. AI-assisted authoring; human-directed scope (delete + gitignore).

## Review focus

Whether any contributor workflow relied on the committed `.vscode/settings.json`.