### PR TITLE
fix: list check_suite PR files from the PR's base repository

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"mime"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -80,6 +81,25 @@ var prActionsThatChangeFiles = sets.New("opened", "synchronize", "reopened")
 // installationClientCacheSize matches the app's other LRUs (e.g. ghinstall,
 // octosts); entries are tiny and least-recently-used installations evict first.
 const installationClientCacheSize = 200
+
+// repoFromAPIURL extracts the owner and repository name from a GitHub API
+// repository URL such as https://api.github.com/repos/{owner}/{repo} (or the
+// GitHub Enterprise Server .../api/v3/repos/{owner}/{repo} variant).
+// check_suite payloads identify a pull request's base repository by API URL
+// only — the nested repo object carries no owner login.
+func repoFromAPIURL(apiURL string) (owner, repo string, ok bool) {
+	u, err := url.Parse(apiURL)
+	if err != nil {
+		return "", "", false
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	for i := 0; i+2 < len(parts); i++ {
+		if parts[i] == "repos" {
+			return parts[i+1], parts[i+2], true
+		}
+	}
+	return "", "", false
+}
 
 func isBotSender(sender *github.User) bool {
 	return sender != nil && sender.Login != nil && strings.HasSuffix(sender.GetLogin(), "[bot]")
@@ -514,8 +534,26 @@ func (e *Validator) handleCheckSuite(ctx context.Context, cs checkSuite) (*githu
 	}
 
 	for _, pr := range cs.GetCheckSuite().PullRequests {
-		resp, _, err := client.PullRequests.ListFiles(ctx, owner, repo, pr.GetNumber(), &github.ListOptions{})
+		// A PR raised from a fork lives in the base repository and its number
+		// is only meaningful there. When this event fires in the fork, listing
+		// files against the event repo 404s, so resolve the PR's home from the
+		// base repo API URL carried in the payload.
+		prOwner, prRepo := owner, repo
+		if o, r, ok := repoFromAPIURL(pr.GetBase().GetRepo().GetURL()); ok {
+			prOwner, prRepo = o, r
+		}
+		resp, _, err := client.PullRequests.ListFiles(ctx, prOwner, prRepo, pr.GetNumber(), &github.ListOptions{})
 		if err != nil {
+			// The installation may still be unable to see the PR's home (e.g.
+			// the base repo belongs to another owner where this app is not
+			// installed). There is nothing to validate from this side — the
+			// base repo's own check_suite covers the PR — so skip it rather
+			// than fail the whole event with a 5xx.
+			var ghErr *github.ErrorResponse
+			if errors.As(err, &ghErr) && ghErr.Response != nil && ghErr.Response.StatusCode == http.StatusNotFound {
+				log.Warnf("skipping inaccessible PR %s/%s#%d: %v", prOwner, prRepo, pr.GetNumber(), err)
+				continue
+			}
 			return nil, err
 		}
 		for _, file := range resp {

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -1000,6 +1000,255 @@ func TestCheckSuiteNewBranchWithPRsProcessed(t *testing.T) {
 	}
 }
 
+// TestRepoFromAPIURL unit-tests owner/name extraction from the repository API
+// URLs carried in check_suite payloads.
+func TestRepoFromAPIURL(t *testing.T) {
+	for _, tc := range []struct {
+		url       string
+		wantOwner string
+		wantRepo  string
+		wantOK    bool
+	}{
+		{"https://api.github.com/repos/foo/parent", "foo", "parent", true},
+		{"https://ghe.example.com/api/v3/repos/foo/parent", "foo", "parent", true},
+		{"", "", "", false},
+		{"https://api.github.com/orgs/foo", "", "", false},
+		{"https://api.github.com/repos/foo", "", "", false},
+	} {
+		owner, repo, ok := repoFromAPIURL(tc.url)
+		if owner != tc.wantOwner || repo != tc.wantRepo || ok != tc.wantOK {
+			t.Errorf("repoFromAPIURL(%q) = (%q, %q, %v), want (%q, %q, %v)",
+				tc.url, owner, repo, ok, tc.wantOwner, tc.wantRepo, tc.wantOK)
+		}
+	}
+}
+
+// TestCheckSuiteForkPRListsFilesFromBaseRepo verifies that a check_suite firing
+// in a fork resolves an associated PR to its base repository before listing
+// files: the PR number is only meaningful in the base repo, and listing against
+// the fork 404s (which would surface as a webhook 500).
+func TestCheckSuiteForkPRListsFilesFromBaseRepo(t *testing.T) {
+	got := []*github.CreateCheckRunOptions{}
+
+	parentFilesHit := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v3/repos/foo/bar/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		opt := new(github.CreateCheckRunOptions)
+		if err := json.NewDecoder(r.Body).Decode(opt); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		got = append(got, opt)
+	})
+	mux.HandleFunc("GET /api/v3/repos/foo/parent/pulls/7/files", func(w http.ResponseWriter, r *http.Request) {
+		parentFilesHit = true
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]*github.CommitFile{{
+			Filename: github.Ptr(".github/chainguard/test.sts.yaml"),
+			Status:   github.Ptr("added"),
+		}})
+	})
+	mux.HandleFunc("GET /api/v3/repos/foo/bar/pulls/7/files", func(w http.ResponseWriter, r *http.Request) {
+		t.Error("PR files must be listed from the base repo, not the fork")
+		http.Error(w, "Not Found", http.StatusNotFound)
+	})
+	// The zeroHash path does GetContents for the directory listing even
+	// when PRs are present; return an empty directory so only the PR file
+	// drives the check run.
+	mux.HandleFunc("GET /api/v3/repos/foo/bar/contents/.github/chainguard", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]*github.RepositoryContent{})
+	})
+	// The head SHA lives in the fork, so file contents are still fetched
+	// from the event repo (served from testdata by the fallback handler).
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		path := filepath.Join("testdata", r.URL.Path)
+		f, err := os.Open(path)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		defer f.Close()
+		io.Copy(w, f)
+	})
+	gh := httptest.NewServer(mux)
+	defer gh.Close()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr := ghinstallation.NewAppsTransportFromPrivateKey(gh.Client().Transport, 1234, key)
+	tr.BaseURL = gh.URL
+
+	secret := []byte("hunter2")
+	v := &Validator{
+		Transport:     tr,
+		WebhookSecret: [][]byte{secret},
+	}
+	srv := httptest.NewServer(v)
+	defer srv.Close()
+
+	body, err := json.Marshal(github.CheckSuiteEvent{
+		Installation: &github.Installation{
+			ID: github.Ptr(int64(1111)),
+		},
+		Repo: &github.Repository{
+			Owner: &github.User{
+				Login: github.Ptr("foo"),
+			},
+			Name:          github.Ptr("bar"),
+			FullName:      github.Ptr("foo/bar"),
+			DefaultBranch: github.Ptr("main"),
+		},
+		Sender: &github.User{Login: github.Ptr("test-user")},
+		Action: github.Ptr("requested"),
+		CheckSuite: &github.CheckSuite{
+			ID:         github.Ptr(int64(1)),
+			HeadSHA:    github.Ptr("deadbeef"),
+			HeadBranch: github.Ptr("feature-x"),
+			BeforeSHA:  github.Ptr(zeroHash),
+			PullRequests: []*github.PullRequest{{
+				Number: github.Ptr(7),
+				Base: &github.PullRequestBranch{
+					Repo: &github.Repository{
+						URL: github.Ptr("https://api.github.com/repos/foo/parent"),
+					},
+				},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest(http.MethodPost, srv.URL, bytes.NewBuffer(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Hub-Signature", signature(secret, body))
+	req.Header.Set("X-GitHub-Event", "check_suite")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req.WithContext(slogtest.Context(t)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		out, _ := httputil.DumpResponse(resp, true)
+		t.Fatalf("expected 200, got\n%s", string(out))
+	}
+	if !parentFilesHit {
+		t.Fatal("PR files were not listed from the base repo")
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 check run, got %d", len(got))
+	}
+	if *got[0].Conclusion != "success" {
+		t.Fatalf("expected success, got %s", *got[0].Conclusion)
+	}
+}
+
+// TestCheckSuiteInaccessiblePRSkipped verifies that a 404 listing an associated
+// PR's files (e.g. the base repo is outside the installation's reach) skips
+// that PR instead of failing the whole event with a 5xx.
+func TestCheckSuiteInaccessiblePRSkipped(t *testing.T) {
+	got := []*github.CreateCheckRunOptions{}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v3/repos/foo/bar/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		opt := new(github.CreateCheckRunOptions)
+		if err := json.NewDecoder(r.Body).Decode(opt); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		got = append(got, opt)
+	})
+	mux.HandleFunc("GET /api/v3/repos/other/parent/pulls/7/files", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message": "Not Found"}`, http.StatusNotFound)
+	})
+	mux.HandleFunc("GET /api/v3/repos/foo/bar/contents/.github/chainguard", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]*github.RepositoryContent{})
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		path := filepath.Join("testdata", r.URL.Path)
+		f, err := os.Open(path)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		defer f.Close()
+		io.Copy(w, f)
+	})
+	gh := httptest.NewServer(mux)
+	defer gh.Close()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr := ghinstallation.NewAppsTransportFromPrivateKey(gh.Client().Transport, 1234, key)
+	tr.BaseURL = gh.URL
+
+	secret := []byte("hunter2")
+	v := &Validator{
+		Transport:     tr,
+		WebhookSecret: [][]byte{secret},
+	}
+	srv := httptest.NewServer(v)
+	defer srv.Close()
+
+	body, err := json.Marshal(github.CheckSuiteEvent{
+		Installation: &github.Installation{
+			ID: github.Ptr(int64(1111)),
+		},
+		Repo: &github.Repository{
+			Owner: &github.User{
+				Login: github.Ptr("foo"),
+			},
+			Name:          github.Ptr("bar"),
+			FullName:      github.Ptr("foo/bar"),
+			DefaultBranch: github.Ptr("main"),
+		},
+		Sender: &github.User{Login: github.Ptr("test-user")},
+		Action: github.Ptr("requested"),
+		CheckSuite: &github.CheckSuite{
+			ID:         github.Ptr(int64(1)),
+			HeadSHA:    github.Ptr("deadbeef"),
+			HeadBranch: github.Ptr("feature-x"),
+			BeforeSHA:  github.Ptr(zeroHash),
+			PullRequests: []*github.PullRequest{{
+				Number: github.Ptr(7),
+				Base: &github.PullRequestBranch{
+					Repo: &github.Repository{
+						URL: github.Ptr("https://api.github.com/repos/other/parent"),
+					},
+				},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest(http.MethodPost, srv.URL, bytes.NewBuffer(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Hub-Signature", signature(secret, body))
+	req.Header.Set("X-GitHub-Event", "check_suite")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req.WithContext(slogtest.Context(t)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		out, _ := httputil.DumpResponse(resp, true)
+		t.Fatalf("expected 200, got\n%s", string(out))
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected 0 check runs for inaccessible PR, got %d", len(got))
+	}
+}
+
 func TestCheckSuiteDefaultBranchProcessed(t *testing.T) {
 	got := []*github.CreateCheckRunOptions{}
 


### PR DESCRIPTION
A check_suite event firing in a fork can carry an associated pull request that lives in the parent (base) repository — the PR number is only meaningful there. handleCheckSuite listed the PR's files against the event repo, so for fork PRs the call returned a 404 that surfaced as an HTTP 500 from the webhook, on every push to the PR's head branch.

Resolve the PR's home from the base-repo API URL carried in the payload (the nested repo object has no owner login, so the URL is parsed) and list files there. Same-repo PRs resolve to the event repo as before, and the head SHA still lives in the event repo, so content validation is unchanged.

If the base repo is genuinely out of the installation's reach, a 404 now skips that PR with a warning instead of failing the whole event: the base repository's own check_suite covers validating the PR.