### PR TITLE
fix: webhook 500 on pushes that create a new ref with 20+ commits

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -351,15 +351,27 @@ func (e *Validator) handlePush(ctx context.Context, event *github.PushEvent) (*g
 
 	// GitHub push payloads include up to 20 commits. When not truncated,
 	// use the payload directly to avoid a Compare API call.
-	//
-	// A push that creates a new ref carries the zero SHA as "before", which
-	// the Compare API rejects with a 404, so use the payload path there
-	// regardless of commit count. Policy files beyond the truncation point
-	// were validated when their commits were first pushed, and a brand-new
-	// default branch is covered by handleCheckSuite's zero-SHA directory scan.
-	if len(event.Commits) < 20 || event.GetBefore() == zeroHash {
+	switch {
+	case len(event.Commits) < 20:
 		files = e.filesFromPushEvent(repo, event)
-	} else {
+	case event.GetBefore() == zeroHash:
+		// A push that creates a new ref carries the zero SHA as "before",
+		// which the Compare API rejects with a 404 (previously surfacing as a
+		// webhook 500). The payload is also truncated, so commits beyond the
+		// first 20 could carry policy files never seen before. Scan the
+		// policy directory at the pushed SHA instead — the same approach as
+		// handleCheckSuite's zero-SHA path. A missing directory just means
+		// there are no policies to validate.
+		_, dirContents, resp, err := client.Repositories.GetContents(ctx, owner, repo, ".github/chainguard", &github.RepositoryContentGetOptions{Ref: sha})
+		if err != nil && (resp == nil || resp.StatusCode != http.StatusNotFound) {
+			return nil, err
+		}
+		for _, file := range dirContents {
+			if file.GetType() == "file" && isValidatedPath(repo, file.GetPath(), e.policyRepo()) {
+				files = append(files, file.GetPath())
+			}
+		}
+	default:
 		resp, _, err := client.Repositories.CompareCommits(ctx, owner, repo, event.GetBefore(), sha, &github.ListOptions{})
 		if err != nil {
 			return nil, err
@@ -372,6 +384,7 @@ func (e *Validator) handlePush(ctx context.Context, event *github.PushEvent) (*g
 			}
 		}
 	}
+
 	if len(files) == 0 {
 		return nil, nil
 	}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -351,7 +351,13 @@ func (e *Validator) handlePush(ctx context.Context, event *github.PushEvent) (*g
 
 	// GitHub push payloads include up to 20 commits. When not truncated,
 	// use the payload directly to avoid a Compare API call.
-	if len(event.Commits) < 20 {
+	//
+	// A push that creates a new ref carries the zero SHA as "before", which
+	// the Compare API rejects with a 404, so use the payload path there
+	// regardless of commit count. Policy files beyond the truncation point
+	// were validated when their commits were first pushed, and a brand-new
+	// default branch is covered by handleCheckSuite's zero-SHA directory scan.
+	if len(event.Commits) < 20 || event.GetBefore() == zeroHash {
 		files = e.filesFromPushEvent(repo, event)
 	} else {
 		resp, _, err := client.Repositories.CompareCommits(ctx, owner, repo, event.GetBefore(), sha, &github.ListOptions{})

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -355,16 +355,16 @@ func (e *Validator) handlePush(ctx context.Context, event *github.PushEvent) (*g
 	case len(event.Commits) < 20:
 		files = e.filesFromPushEvent(repo, event)
 	case event.GetBefore() == zeroHash:
-		// A push that creates a new ref carries the zero SHA as "before",
-		// which the Compare API rejects with a 404 (previously surfacing as a
-		// webhook 500). The payload is also truncated, so commits beyond the
-		// first 20 could carry policy files never seen before. Scan the
-		// policy directory at the pushed SHA instead — the same approach as
-		// handleCheckSuite's zero-SHA path. A missing directory just means
-		// there are no policies to validate.
+		// A new-ref push: the Compare API rejects the zero "before" SHA with
+		// a 404, and the truncated payload may omit policy files, so scan the
+		// policy directory at the pushed SHA instead. A missing directory
+		// means there are no policies to validate.
 		_, dirContents, resp, err := client.Repositories.GetContents(ctx, owner, repo, ".github/chainguard", &github.RepositoryContentGetOptions{Ref: sha})
-		if err != nil && (resp == nil || resp.StatusCode != http.StatusNotFound) {
-			return nil, err
+		if err != nil {
+			if resp == nil || resp.StatusCode != http.StatusNotFound {
+				return nil, err
+			}
+			log.Infof("no policy directory at %s, skipping validation", sha)
 		}
 		for _, file := range dirContents {
 			if file.GetType() == "file" && isValidatedPath(repo, file.GetPath(), e.policyRepo()) {

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -599,9 +599,10 @@ func TestWebhookPushTruncatedFallback(t *testing.T) {
 }
 
 // TestWebhookPushNewRefSkipsCompare verifies that a push creating a new ref
-// (Before is the zero SHA) uses the payload path even at 20+ commits: the
-// Compare API rejects the zero SHA with a 404, which would surface as a
-// webhook 500.
+// (Before is the zero SHA) scans the policy directory at the pushed SHA
+// instead of calling the Compare API at 20+ commits: Compare rejects the zero
+// SHA with a 404, which would surface as a webhook 500, and the truncated
+// payload may omit policy files entirely.
 func TestWebhookPushNewRefSkipsCompare(t *testing.T) {
 	got := []*github.CreateCheckRunOptions{}
 
@@ -619,6 +620,16 @@ func TestWebhookPushNewRefSkipsCompare(t *testing.T) {
 		// must not call Compare at all for a new-ref push.
 		t.Error("Compare API should not be called for a new-ref (zero SHA) push")
 		http.Error(w, "Not Found", http.StatusNotFound)
+	})
+	mux.HandleFunc("GET /api/v3/repos/foo/bar/contents/.github/chainguard", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]*github.RepositoryContent{{
+			Type: github.Ptr("file"),
+			Path: github.Ptr(".github/chainguard/test.sts.yaml"),
+		}, {
+			Type: github.Ptr("file"),
+			Path: github.Ptr(".github/chainguard/README.md"),
+		}})
 	})
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		path := filepath.Join("testdata", r.URL.Path)
@@ -653,16 +664,14 @@ func TestWebhookPushNewRefSkipsCompare(t *testing.T) {
 	defer srv.Close()
 
 	// 20 commits would normally force the Compare fallback; the zero-SHA
-	// Before must win and route through the payload path. The policy file in
-	// the first commit proves the payload was read.
+	// Before must win and route through the directory scan. The payload
+	// deliberately carries no policy files: the check run can only come from
+	// the directory listing, proving truncated commits can't hide policies.
 	commits := make([]*github.HeadCommit, 20)
 	for i := range commits {
 		commits[i] = &github.HeadCommit{
 			Added: []string{"README.md"},
 		}
-	}
-	commits[0] = &github.HeadCommit{
-		Added: []string{".github/chainguard/test2.sts.yaml"},
 	}
 
 	body, err := json.Marshal(github.PushEvent{
@@ -705,6 +714,99 @@ func TestWebhookPushNewRefSkipsCompare(t *testing.T) {
 	}
 	if *got[0].Conclusion != "success" {
 		t.Fatalf("expected success, got %s", *got[0].Conclusion)
+	}
+}
+
+// TestWebhookPushNewRefNoPolicyDir verifies that a new-ref push into a
+// repository without a policy directory is a no-op: the directory-scan 404 is
+// treated as "no policies" rather than an error.
+func TestWebhookPushNewRefNoPolicyDir(t *testing.T) {
+	got := []*github.CreateCheckRunOptions{}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v3/repos/foo/bar/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		opt := new(github.CreateCheckRunOptions)
+		if err := json.NewDecoder(r.Body).Decode(opt); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		got = append(got, opt)
+	})
+	mux.HandleFunc("GET /api/v3/repos/foo/bar/contents/.github/chainguard", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message": "Not Found"}`, http.StatusNotFound)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		path := filepath.Join("testdata", r.URL.Path)
+		f, err := os.Open(path)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		defer f.Close()
+		io.Copy(w, f)
+	})
+	gh := httptest.NewServer(mux)
+	defer gh.Close()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr := ghinstallation.NewAppsTransportFromPrivateKey(gh.Client().Transport, 1234, key)
+	tr.BaseURL = gh.URL
+
+	secret := []byte("hunter2")
+	v := &Validator{
+		Transport:     tr,
+		WebhookSecret: [][]byte{secret},
+	}
+	srv := httptest.NewServer(v)
+	defer srv.Close()
+
+	commits := make([]*github.HeadCommit, 20)
+	for i := range commits {
+		commits[i] = &github.HeadCommit{
+			Added: []string{"README.md"},
+		}
+	}
+
+	body, err := json.Marshal(github.PushEvent{
+		Installation: &github.Installation{
+			ID: github.Ptr(int64(1111)),
+		},
+		Organization: &github.Organization{
+			Login: github.Ptr("foo"),
+		},
+		Repo: &github.PushEventRepository{
+			Owner: &github.User{
+				Login: github.Ptr("foo"),
+			},
+			Name: github.Ptr("bar"),
+		},
+		Before:  github.Ptr(zeroHash),
+		After:   github.Ptr("4321"),
+		Commits: commits,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest(http.MethodPost, srv.URL, bytes.NewBuffer(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Hub-Signature", signature(secret, body))
+	req.Header.Set("X-GitHub-Event", "push")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req.WithContext(slogtest.Context(t)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		out, _ := httputil.DumpResponse(resp, true)
+		t.Fatalf("expected %d, got\n%s", 200, string(out))
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected 0 check runs without a policy directory, got %d", len(got))
 	}
 }
 

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -598,39 +598,31 @@ func TestWebhookPushTruncatedFallback(t *testing.T) {
 	}
 }
 
-// TestWebhookPushNewRefSkipsCompare verifies that a push creating a new ref
-// (Before is the zero SHA) scans the policy directory at the pushed SHA
-// instead of calling the Compare API at 20+ commits: Compare rejects the zero
-// SHA with a 404, which would surface as a webhook 500, and the truncated
-// payload may omit policy files entirely.
-func TestWebhookPushNewRefSkipsCompare(t *testing.T) {
-	got := []*github.CreateCheckRunOptions{}
+// newRefPushBody marshals a push event for foo/bar with the given commits and
+// a zero "before" SHA, i.e. a push that creates a new ref.
+func newRefPushBody(t *testing.T, commits []*github.HeadCommit) []byte {
+	t.Helper()
+	body, err := json.Marshal(github.PushEvent{
+		Installation: &github.Installation{ID: github.Ptr(int64(1111))},
+		Organization: &github.Organization{Login: github.Ptr("foo")},
+		Repo: &github.PushEventRepository{
+			Owner: &github.User{Login: github.Ptr("foo")},
+			Name:  github.Ptr("bar"),
+		},
+		Before:  github.Ptr(zeroHash),
+		After:   github.Ptr("4321"),
+		Commits: commits,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("POST /api/v3/repos/foo/bar/check-runs", func(w http.ResponseWriter, r *http.Request) {
-		opt := new(github.CreateCheckRunOptions)
-		if err := json.NewDecoder(r.Body).Decode(opt); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		got = append(got, opt)
-	})
-	mux.HandleFunc("GET /api/v3/repos/foo/bar/compare/", func(w http.ResponseWriter, r *http.Request) {
-		// GitHub responds 404 to a compare against the zero SHA; the handler
-		// must not call Compare at all for a new-ref push.
-		t.Error("Compare API should not be called for a new-ref (zero SHA) push")
-		http.Error(w, "Not Found", http.StatusNotFound)
-	})
-	mux.HandleFunc("GET /api/v3/repos/foo/bar/contents/.github/chainguard", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode([]*github.RepositoryContent{{
-			Type: github.Ptr("file"),
-			Path: github.Ptr(".github/chainguard/test.sts.yaml"),
-		}, {
-			Type: github.Ptr("file"),
-			Path: github.Ptr(".github/chainguard/README.md"),
-		}})
-	})
+// newRefPushServer wires a Validator to the given GitHub mux and posts the
+// push body, returning the HTTP response.
+func newRefPushServer(t *testing.T, mux *http.ServeMux, body []byte) *http.Response {
+	t.Helper()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		path := filepath.Join("testdata", r.URL.Path)
 		f, err := os.Open(path)
@@ -640,13 +632,10 @@ func TestWebhookPushNewRefSkipsCompare(t *testing.T) {
 			return
 		}
 		defer f.Close()
-		if _, err := io.Copy(w, f); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
+		io.Copy(w, f)
 	})
 	gh := httptest.NewServer(mux)
-	defer gh.Close()
+	t.Cleanup(gh.Close)
 
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
@@ -661,39 +650,8 @@ func TestWebhookPushNewRefSkipsCompare(t *testing.T) {
 		WebhookSecret: [][]byte{secret},
 	}
 	srv := httptest.NewServer(v)
-	defer srv.Close()
+	t.Cleanup(srv.Close)
 
-	// 20 commits would normally force the Compare fallback; the zero-SHA
-	// Before must win and route through the directory scan. The payload
-	// deliberately carries no policy files: the check run can only come from
-	// the directory listing, proving truncated commits can't hide policies.
-	commits := make([]*github.HeadCommit, 20)
-	for i := range commits {
-		commits[i] = &github.HeadCommit{
-			Added: []string{"README.md"},
-		}
-	}
-
-	body, err := json.Marshal(github.PushEvent{
-		Installation: &github.Installation{
-			ID: github.Ptr(int64(1111)),
-		},
-		Organization: &github.Organization{
-			Login: github.Ptr("foo"),
-		},
-		Repo: &github.PushEventRepository{
-			Owner: &github.User{
-				Login: github.Ptr("foo"),
-			},
-			Name: github.Ptr("bar"),
-		},
-		Before:  github.Ptr(zeroHash),
-		After:   github.Ptr("4321"),
-		Commits: commits,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
 	req, err := http.NewRequest(http.MethodPost, srv.URL, bytes.NewBuffer(body))
 	if err != nil {
 		t.Fatal(err)
@@ -705,24 +663,14 @@ func TestWebhookPushNewRefSkipsCompare(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resp.StatusCode != 200 {
-		out, _ := httputil.DumpResponse(resp, true)
-		t.Fatalf("expected %d, got\n%s", 200, string(out))
-	}
-	if len(got) != 1 {
-		t.Fatalf("expected 1 check run, got %d", len(got))
-	}
-	if *got[0].Conclusion != "success" {
-		t.Fatalf("expected success, got %s", *got[0].Conclusion)
-	}
+	return resp
 }
 
-// TestWebhookPushNewRefNoPolicyDir verifies that a new-ref push into a
-// repository without a policy directory is a no-op: the directory-scan 404 is
-// treated as "no policies" rather than an error.
-func TestWebhookPushNewRefNoPolicyDir(t *testing.T) {
-	got := []*github.CreateCheckRunOptions{}
-
+// checkRunCollector returns a mux preloaded with a check-run capture handler
+// and a compare handler that fails the test if the Compare API is touched.
+func checkRunCollector(t *testing.T) (*http.ServeMux, *[]*github.CreateCheckRunOptions) {
+	t.Helper()
+	got := &[]*github.CreateCheckRunOptions{}
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/v3/repos/foo/bar/check-runs", func(w http.ResponseWriter, r *http.Request) {
 		opt := new(github.CreateCheckRunOptions)
@@ -730,83 +678,127 @@ func TestWebhookPushNewRefNoPolicyDir(t *testing.T) {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		got = append(got, opt)
+		*got = append(*got, opt)
 	})
-	mux.HandleFunc("GET /api/v3/repos/foo/bar/contents/.github/chainguard", func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, `{"message": "Not Found"}`, http.StatusNotFound)
+	mux.HandleFunc("GET /api/v3/repos/foo/bar/compare/", func(w http.ResponseWriter, r *http.Request) {
+		// GitHub responds 404 to a compare against the zero SHA; the handler
+		// must not call Compare at all for a new-ref push.
+		t.Error("Compare API should not be called for a new-ref (zero SHA) push")
+		http.Error(w, "Not Found", http.StatusNotFound)
 	})
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		path := filepath.Join("testdata", r.URL.Path)
-		f, err := os.Open(path)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusNotFound)
-			return
-		}
-		defer f.Close()
-		io.Copy(w, f)
-	})
-	gh := httptest.NewServer(mux)
-	defer gh.Close()
+	return mux, got
+}
 
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		t.Fatal(err)
-	}
-	tr := ghinstallation.NewAppsTransportFromPrivateKey(gh.Client().Transport, 1234, key)
-	tr.BaseURL = gh.URL
-
-	secret := []byte("hunter2")
-	v := &Validator{
-		Transport:     tr,
-		WebhookSecret: [][]byte{secret},
-	}
-	srv := httptest.NewServer(v)
-	defer srv.Close()
-
-	commits := make([]*github.HeadCommit, 20)
+// readmeCommits returns n commits carrying only non-policy files.
+func readmeCommits(n int) []*github.HeadCommit {
+	commits := make([]*github.HeadCommit, n)
 	for i := range commits {
 		commits[i] = &github.HeadCommit{
 			Added: []string{"README.md"},
 		}
 	}
+	return commits
+}
 
-	body, err := json.Marshal(github.PushEvent{
-		Installation: &github.Installation{
-			ID: github.Ptr(int64(1111)),
-		},
-		Organization: &github.Organization{
-			Login: github.Ptr("foo"),
-		},
-		Repo: &github.PushEventRepository{
-			Owner: &github.User{
-				Login: github.Ptr("foo"),
-			},
-			Name: github.Ptr("bar"),
-		},
-		Before:  github.Ptr(zeroHash),
-		After:   github.Ptr("4321"),
-		Commits: commits,
+// TestWebhookPushNewRefSkipsCompare verifies that a push creating a new ref
+// (Before is the zero SHA) scans the policy directory at the pushed SHA
+// instead of calling the Compare API at 20+ commits: Compare rejects the zero
+// SHA with a 404 that would bubble up as a webhook 500, and the truncated
+// payload may omit policy files entirely.
+func TestWebhookPushNewRefSkipsCompare(t *testing.T) {
+	mux, got := checkRunCollector(t)
+	mux.HandleFunc("GET /api/v3/repos/foo/bar/contents/.github/chainguard", func(w http.ResponseWriter, r *http.Request) {
+		if ref := r.URL.Query().Get("ref"); ref != "4321" {
+			t.Errorf("directory scan must use the pushed SHA, got ref=%q", ref)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]*github.RepositoryContent{{
+			Type: github.Ptr("file"),
+			Path: github.Ptr(".github/chainguard/test.sts.yaml"),
+		}, {
+			Type: github.Ptr("file"),
+			Path: github.Ptr(".github/chainguard/README.md"),
+		}})
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	req, err := http.NewRequest(http.MethodPost, srv.URL, bytes.NewBuffer(body))
-	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header.Set("X-Hub-Signature", signature(secret, body))
-	req.Header.Set("X-GitHub-Event", "push")
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := srv.Client().Do(req.WithContext(slogtest.Context(t)))
-	if err != nil {
-		t.Fatal(err)
-	}
+
+	// 20 commits would normally force the Compare fallback; the zero-SHA
+	// Before must win and route through the directory scan. The payload
+	// deliberately carries no policy files: the check run can only come from
+	// the directory listing, proving truncated commits can't hide policies.
+	resp := newRefPushServer(t, mux, newRefPushBody(t, readmeCommits(20)))
 	if resp.StatusCode != 200 {
 		out, _ := httputil.DumpResponse(resp, true)
 		t.Fatalf("expected %d, got\n%s", 200, string(out))
 	}
-	if len(got) != 0 {
-		t.Fatalf("expected 0 check runs without a policy directory, got %d", len(got))
+	if len(*got) != 1 {
+		t.Fatalf("expected 1 check run, got %d", len(*got))
+	}
+	if (*got)[0].Conclusion == nil || *(*got)[0].Conclusion != "success" {
+		t.Fatalf("expected success, got %v", (*got)[0].Conclusion)
+	}
+}
+
+// TestWebhookPushNewRefNoPolicyDir verifies that a new-ref push into a
+// repository without a policy directory is a no-op: the directory-scan 404 is
+// treated as "no policies" rather than an error.
+func TestWebhookPushNewRefNoPolicyDir(t *testing.T) {
+	mux, got := checkRunCollector(t)
+	mux.HandleFunc("GET /api/v3/repos/foo/bar/contents/.github/chainguard", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message": "Not Found"}`, http.StatusNotFound)
+	})
+
+	resp := newRefPushServer(t, mux, newRefPushBody(t, readmeCommits(20)))
+	if resp.StatusCode != 200 {
+		out, _ := httputil.DumpResponse(resp, true)
+		t.Fatalf("expected %d, got\n%s", 200, string(out))
+	}
+	if len(*got) != 0 {
+		t.Fatalf("expected 0 check runs without a policy directory, got %d", len(*got))
+	}
+}
+
+// TestWebhookPushNewRefContentsError verifies that only a 404 from the
+// directory scan is tolerated: any other GetContents failure must propagate
+// as a webhook 500 so transient GitHub errors aren't silently treated as
+// "no policies to validate".
+func TestWebhookPushNewRefContentsError(t *testing.T) {
+	mux, got := checkRunCollector(t)
+	mux.HandleFunc("GET /api/v3/repos/foo/bar/contents/.github/chainguard", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message": "boom"}`, http.StatusInternalServerError)
+	})
+
+	resp := newRefPushServer(t, mux, newRefPushBody(t, readmeCommits(20)))
+	if resp.StatusCode != http.StatusInternalServerError {
+		out, _ := httputil.DumpResponse(resp, true)
+		t.Fatalf("expected 500, got\n%s", string(out))
+	}
+	if len(*got) != 0 {
+		t.Fatalf("expected 0 check runs on contents error, got %d", len(*got))
+	}
+}
+
+// TestWebhookPushNewRefUnder20UsesPayload pins the switch ordering in
+// handlePush: a new-ref push with fewer than 20 commits has a complete
+// payload, so it must use the payload path — not the directory scan, which
+// would validate every policy in the repository on every small branch push.
+func TestWebhookPushNewRefUnder20UsesPayload(t *testing.T) {
+	mux, got := checkRunCollector(t)
+	mux.HandleFunc("GET /api/v3/repos/foo/bar/contents/.github/chainguard", func(w http.ResponseWriter, r *http.Request) {
+		t.Error("directory scan must not run for a <20-commit new-ref push")
+		http.Error(w, "should not be called", http.StatusInternalServerError)
+	})
+
+	commits := readmeCommits(5)
+	commits[0] = &github.HeadCommit{
+		Added: []string{".github/chainguard/test2.sts.yaml"},
+	}
+	resp := newRefPushServer(t, mux, newRefPushBody(t, commits))
+	if resp.StatusCode != 200 {
+		out, _ := httputil.DumpResponse(resp, true)
+		t.Fatalf("expected %d, got\n%s", 200, string(out))
+	}
+	if len(*got) != 1 {
+		t.Fatalf("expected 1 check run from the payload path, got %d", len(*got))
 	}
 }
 

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -598,6 +598,116 @@ func TestWebhookPushTruncatedFallback(t *testing.T) {
 	}
 }
 
+// TestWebhookPushNewRefSkipsCompare verifies that a push creating a new ref
+// (Before is the zero SHA) uses the payload path even at 20+ commits: the
+// Compare API rejects the zero SHA with a 404, which would surface as a
+// webhook 500.
+func TestWebhookPushNewRefSkipsCompare(t *testing.T) {
+	got := []*github.CreateCheckRunOptions{}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v3/repos/foo/bar/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		opt := new(github.CreateCheckRunOptions)
+		if err := json.NewDecoder(r.Body).Decode(opt); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		got = append(got, opt)
+	})
+	mux.HandleFunc("GET /api/v3/repos/foo/bar/compare/", func(w http.ResponseWriter, r *http.Request) {
+		// GitHub responds 404 to a compare against the zero SHA; the handler
+		// must not call Compare at all for a new-ref push.
+		t.Error("Compare API should not be called for a new-ref (zero SHA) push")
+		http.Error(w, "Not Found", http.StatusNotFound)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		path := filepath.Join("testdata", r.URL.Path)
+		f, err := os.Open(path)
+		if err != nil {
+			clog.FromContext(r.Context()).Errorf("%s not found", path)
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		defer f.Close()
+		if _, err := io.Copy(w, f); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	})
+	gh := httptest.NewServer(mux)
+	defer gh.Close()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr := ghinstallation.NewAppsTransportFromPrivateKey(gh.Client().Transport, 1234, key)
+	tr.BaseURL = gh.URL
+
+	secret := []byte("hunter2")
+	v := &Validator{
+		Transport:     tr,
+		WebhookSecret: [][]byte{secret},
+	}
+	srv := httptest.NewServer(v)
+	defer srv.Close()
+
+	// 20 commits would normally force the Compare fallback; the zero-SHA
+	// Before must win and route through the payload path. The policy file in
+	// the first commit proves the payload was read.
+	commits := make([]*github.HeadCommit, 20)
+	for i := range commits {
+		commits[i] = &github.HeadCommit{
+			Added: []string{"README.md"},
+		}
+	}
+	commits[0] = &github.HeadCommit{
+		Added: []string{".github/chainguard/test2.sts.yaml"},
+	}
+
+	body, err := json.Marshal(github.PushEvent{
+		Installation: &github.Installation{
+			ID: github.Ptr(int64(1111)),
+		},
+		Organization: &github.Organization{
+			Login: github.Ptr("foo"),
+		},
+		Repo: &github.PushEventRepository{
+			Owner: &github.User{
+				Login: github.Ptr("foo"),
+			},
+			Name: github.Ptr("bar"),
+		},
+		Before:  github.Ptr(zeroHash),
+		After:   github.Ptr("4321"),
+		Commits: commits,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest(http.MethodPost, srv.URL, bytes.NewBuffer(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Hub-Signature", signature(secret, body))
+	req.Header.Set("X-GitHub-Event", "push")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req.WithContext(slogtest.Context(t)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		out, _ := httputil.DumpResponse(resp, true)
+		t.Fatalf("expected %d, got\n%s", 200, string(out))
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 check run, got %d", len(got))
+	}
+	if *got[0].Conclusion != "success" {
+		t.Fatalf("expected success, got %s", *got[0].Conclusion)
+	}
+}
+
 func TestWebhookPushNoSTSFiles(t *testing.T) {
 	got := []*github.CreateCheckRunOptions{}
 


### PR DESCRIPTION
Pushes that create a new ref carry the zero SHA as `before`. At 20+ commits the handler falls back to the Compare API, which 404s on the zero SHA, and the webhook returns 500. Under 20 commits the payload path works fine, so this only hits big pushes: repo imports, first push of a long-lived branch, etc.

Can't just use the payload for these since it's truncated at 20 commits and the missing commits may contain policy files that were never validated. So scan the policy directory at the pushed SHA instead, same as handleCheckSuite already does for zero-SHA check suites. A 404 for the directory just means no policies (logged), any other error still fails the delivery. Small pushes keep using the payload path.

Tests: no Compare call for a 20-commit new-ref push (the check run comes from the directory listing), missing directory is a no-op, non-404 scan errors still 500, and <20-commit new-ref pushes stay on the payload path.
