### PR TITLE
fix(webhook): treat a missing policy directory as no-op in handleCheckSuite

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -483,9 +483,16 @@ func (e *Validator) handleCheckSuite(ctx context.Context, cs checkSuite) (*githu
 			log.Infof("skipping new non-default branch with no PRs")
 			return nil, nil
 		}
-		_, dirContents, _, err := client.Repositories.GetContents(ctx, owner, repo, ".github/chainguard", &github.RepositoryContentGetOptions{Ref: sha})
+		_, dirContents, resp, err := client.Repositories.GetContents(ctx, owner, repo, ".github/chainguard", &github.RepositoryContentGetOptions{Ref: sha})
 		if err != nil {
-			return nil, err
+			// A missing policy directory means there are no policies to
+			// validate; only a non-404 (or transport) error should fail the
+			// delivery. Otherwise an initial commit to a repo without
+			// .github/chainguard would 500 and GitHub would redeliver.
+			if resp == nil || resp.StatusCode != http.StatusNotFound {
+				return nil, err
+			}
+			log.Infof("no policy directory at %s, skipping validation", sha)
 		}
 		// This branch lists the policy directory rather than diffing it, so the
 		// entries are everything the directory holds — not just trust policies.

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -1104,6 +1104,190 @@ func TestCheckSuiteDefaultBranchProcessed(t *testing.T) {
 	}
 }
 
+// TestCheckSuiteNoPolicyDirSkipped exercises the zeroHash / initial-commit
+// branch of handleCheckSuite when the repository has no .github/chainguard
+// directory: the directory scan 404s, which must be treated as "no policies"
+// (logged, no check run) rather than failing the delivery with a 500.
+func TestCheckSuiteNoPolicyDirSkipped(t *testing.T) {
+	got := []*github.CreateCheckRunOptions{}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v3/repos/foo/bar/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		opt := new(github.CreateCheckRunOptions)
+		if err := json.NewDecoder(r.Body).Decode(opt); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		got = append(got, opt)
+	})
+	mux.HandleFunc("GET /api/v3/repos/foo/bar/contents/.github/chainguard", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message": "Not Found"}`, http.StatusNotFound)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		path := filepath.Join("testdata", r.URL.Path)
+		f, err := os.Open(path)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		defer f.Close()
+		io.Copy(w, f)
+	})
+	gh := httptest.NewServer(mux)
+	defer gh.Close()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr := ghinstallation.NewAppsTransportFromPrivateKey(gh.Client().Transport, 1234, key)
+	tr.BaseURL = gh.URL
+
+	secret := []byte("hunter2")
+	v := &Validator{
+		Transport:     tr,
+		WebhookSecret: [][]byte{secret},
+	}
+	srv := httptest.NewServer(v)
+	defer srv.Close()
+
+	body, err := json.Marshal(github.CheckSuiteEvent{
+		Installation: &github.Installation{
+			ID: github.Ptr(int64(1111)),
+		},
+		Repo: &github.Repository{
+			Owner: &github.User{
+				Login: github.Ptr("foo"),
+			},
+			Name:          github.Ptr("bar"),
+			FullName:      github.Ptr("foo/bar"),
+			DefaultBranch: github.Ptr("main"),
+		},
+		Sender: &github.User{Login: github.Ptr("test-user")},
+		Action: github.Ptr("requested"),
+		CheckSuite: &github.CheckSuite{
+			ID:           github.Ptr(int64(1)),
+			HeadSHA:      github.Ptr("deadbeef"),
+			HeadBranch:   github.Ptr("main"),
+			BeforeSHA:    github.Ptr(zeroHash),
+			PullRequests: []*github.PullRequest{},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest(http.MethodPost, srv.URL, bytes.NewBuffer(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Hub-Signature", signature(secret, body))
+	req.Header.Set("X-GitHub-Event", "check_suite")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req.WithContext(slogtest.Context(t)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		out, _ := httputil.DumpResponse(resp, true)
+		t.Fatalf("expected 200, got\n%s", string(out))
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected 0 check runs when policy directory is missing, got %d", len(got))
+	}
+}
+
+// TestCheckSuiteNonNotFoundDirScanError verifies that a non-404 error from the
+// policy-directory scan still fails the delivery (so it is redelivered) rather
+// than being swallowed like a missing directory.
+func TestCheckSuiteNonNotFoundDirScanError(t *testing.T) {
+	got := []*github.CreateCheckRunOptions{}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v3/repos/foo/bar/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		opt := new(github.CreateCheckRunOptions)
+		if err := json.NewDecoder(r.Body).Decode(opt); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		got = append(got, opt)
+	})
+	mux.HandleFunc("GET /api/v3/repos/foo/bar/contents/.github/chainguard", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message": "Internal Server Error"}`, http.StatusInternalServerError)
+	})
+	// Catch-all serves the installation token mint (and anything else) from
+	// testdata so the request reaches the directory scan above.
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		path := filepath.Join("testdata", r.URL.Path)
+		f, err := os.Open(path)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		defer f.Close()
+		io.Copy(w, f)
+	})
+	gh := httptest.NewServer(mux)
+	defer gh.Close()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr := ghinstallation.NewAppsTransportFromPrivateKey(gh.Client().Transport, 1234, key)
+	tr.BaseURL = gh.URL
+
+	secret := []byte("hunter2")
+	v := &Validator{
+		Transport:     tr,
+		WebhookSecret: [][]byte{secret},
+	}
+	srv := httptest.NewServer(v)
+	defer srv.Close()
+
+	body, err := json.Marshal(github.CheckSuiteEvent{
+		Installation: &github.Installation{
+			ID: github.Ptr(int64(1111)),
+		},
+		Repo: &github.Repository{
+			Owner: &github.User{
+				Login: github.Ptr("foo"),
+			},
+			Name:          github.Ptr("bar"),
+			FullName:      github.Ptr("foo/bar"),
+			DefaultBranch: github.Ptr("main"),
+		},
+		Sender: &github.User{Login: github.Ptr("test-user")},
+		Action: github.Ptr("requested"),
+		CheckSuite: &github.CheckSuite{
+			ID:           github.Ptr(int64(1)),
+			HeadSHA:      github.Ptr("deadbeef"),
+			HeadBranch:   github.Ptr("main"),
+			BeforeSHA:    github.Ptr(zeroHash),
+			PullRequests: []*github.PullRequest{},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest(http.MethodPost, srv.URL, bytes.NewBuffer(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Hub-Signature", signature(secret, body))
+	req.Header.Set("X-GitHub-Event", "check_suite")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req.WithContext(slogtest.Context(t)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode == 200 {
+		t.Fatal("expected non-200 for a non-404 directory scan error, got 200")
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected 0 check runs on scan error, got %d", len(got))
+	}
+}
+
 // TestCheckSuiteDefaultBranchSkipsNonPolicyFiles exercises the zeroHash /
 // initial-commit branch of handleCheckSuite, which lists the policy directory
 // instead of diffing it. The listing contains a README.md alongside the trust


### PR DESCRIPTION
Closes #1596

## What/Why

`handleCheckSuite`'s zero-SHA directory scan returned every error, so an initial commit (or a new default-branch / PR check_suite) on a repo without a `.github/chainguard` directory 404d the scan and surfaced as a webhook HTTP 500 that GitHub then redelivered. This swallows the 404 as "no policies to validate" (logged) while non-404 and transport errors still fail the delivery, mirroring the `handlePush` fix in #1591.

## Proof it works

Full `pkg/webhook` suite passes. Two new tests: `TestCheckSuiteNoPolicyDirSkipped` (dir 404 -> HTTP 200, zero check runs) and `TestCheckSuiteNonNotFoundDirScanError` (dir 500 -> non-200, and verified it reaches the real `GetContents` path rather than short-circuiting at the token mint).

## Risk + AI role

low -- narrows one error path on an advisory check run; enforcement is unchanged since token exchange re-reads the policy independently. AI-assisted authoring; human-directed.

## Review focus

The 404-vs-other error classification (`resp == nil || resp.StatusCode != http.StatusNotFound`) and whether swallowing the 404 here is the intended parity with `handlePush`.