### PR TITLE
fix(provider): refuse OIDC discovery connections to non-public addresses

### DIFF
--- a/pkg/provider/dial.go
+++ b/pkg/provider/dial.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Chainguard, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package provider
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/chainguard-dev/terraform-infra-common/pkg/httpmetrics"
+)
+
+// dialTimeout bounds how long a single discovery connection may spend in
+// connect(2). Discovery targets are attacker-influenced, so a target that
+// accepts packets but never completes the handshake must not pin a request.
+const dialTimeout = 5 * time.Second
+
+// errNonPublicAddress is returned when a discovery connection resolves to an
+// address that is not on the public internet.
+var errNonPublicAddress = errors.New("refusing to dial non-public address")
+
+// reservedPrefixes are ranges that are not routable on the public internet but
+// which netip's classifiers do not already cover. Cloud instance metadata
+// services live in the link-local range, which IsLinkLocalUnicast catches.
+var reservedPrefixes = []netip.Prefix{
+	netip.MustParsePrefix("0.0.0.0/8"),       // "this network" (RFC 1122)
+	netip.MustParsePrefix("100.64.0.0/10"),   // carrier-grade NAT (RFC 6598)
+	netip.MustParsePrefix("192.0.0.0/24"),    // IETF protocol assignments
+	netip.MustParsePrefix("192.0.2.0/24"),    // TEST-NET-1
+	netip.MustParsePrefix("198.18.0.0/15"),   // benchmarking (RFC 2544)
+	netip.MustParsePrefix("198.51.100.0/24"), // TEST-NET-2
+	netip.MustParsePrefix("203.0.113.0/24"),  // TEST-NET-3
+	netip.MustParsePrefix("240.0.0.0/4"),     // reserved (RFC 1112)
+	netip.MustParsePrefix("100::/64"),        // discard-only (RFC 6666)
+	netip.MustParsePrefix("2001:db8::/32"),   // documentation (RFC 3849)
+}
+
+// isPublicAddress reports whether addr is routable on the public internet.
+//
+// IPv4-mapped IPv6 addresses are unmapped first so that, for example,
+// ::ffff:10.0.0.1 is classified as the private address it really is.
+func isPublicAddress(addr netip.Addr) bool {
+	addr = addr.Unmap()
+	if !addr.IsValid() {
+		return false
+	}
+	// IsPrivate covers RFC 1918 (IPv4) and RFC 4193 unique local (IPv6).
+	if addr.IsLoopback() || addr.IsPrivate() || addr.IsUnspecified() ||
+		addr.IsLinkLocalUnicast() || addr.IsLinkLocalMulticast() ||
+		addr.IsInterfaceLocalMulticast() || addr.IsMulticast() {
+		return false
+	}
+	for _, p := range reservedPrefixes {
+		if p.Contains(addr) {
+			return false
+		}
+	}
+	return true
+}
+
+// newRestrictedDialer returns a dialer that refuses to open a connection to an
+// address that is not on the public internet.
+//
+// The check runs in Control, which the runtime calls after name resolution and
+// immediately before connect(2), on the concrete address being dialed. That
+// placement matters: validating the issuer string alone cannot see where a
+// hostname actually points, and a name that resolves differently between
+// validation and dial (DNS rebinding) would slip past a string check.
+//
+// allowLoopback relaxes the rule for loopback destinations only. It is set
+// solely for issuers that are themselves explicitly loopback, preserving the
+// local-development and test carve-out that oidcvalidate.IsValidIssuer makes.
+func newRestrictedDialer(allowLoopback bool) *net.Dialer {
+	return &net.Dialer{
+		Timeout:   dialTimeout,
+		KeepAlive: 30 * time.Second,
+		Control: func(_, address string, _ syscall.RawConn) error {
+			host, _, err := net.SplitHostPort(address)
+			if err != nil {
+				return fmt.Errorf("parsing dial address %q: %w", address, err)
+			}
+			addr, err := netip.ParseAddr(host)
+			if err != nil {
+				return fmt.Errorf("parsing dial address %q: %w", host, err)
+			}
+			if allowLoopback && addr.Unmap().IsLoopback() {
+				return nil
+			}
+			if !isPublicAddress(addr) {
+				return fmt.Errorf("%w: %s", errNonPublicAddress, addr)
+			}
+			return nil
+		},
+	}
+}
+
+// newDiscoveryTransport builds the RoundTripper used for OIDC discovery and,
+// because the constructed provider retains this client, for the JWKS fetches
+// that follow. A discovery document that points its jwks_uri at an internal
+// address is therefore refused on the same terms as the issuer itself.
+func newDiscoveryTransport(allowLoopback bool) http.RoundTripper {
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.DialContext = newRestrictedDialer(allowLoopback).DialContext
+	return httpmetrics.WrapTransport(t)
+}
+
+// Transports are built once and shared so that connection pooling still
+// applies across discovery requests.
+var (
+	strictTransport   = sync.OnceValue(func() http.RoundTripper { return newDiscoveryTransport(false) })
+	loopbackTransport = sync.OnceValue(func() http.RoundTripper { return newDiscoveryTransport(true) })
+)
+
+// discoveryTransport returns the transport to use for the given issuer.
+func discoveryTransport(issuer string) http.RoundTripper {
+	if isLoopbackIssuer(issuer) {
+		return loopbackTransport()
+	}
+	return strictTransport()
+}
+
+// isLoopbackIssuer reports whether the issuer explicitly names a loopback host.
+// This mirrors the carve-out in oidcvalidate.IsValidIssuer, which permits plain
+// HTTP for localhost, 127.0.0.1 and ::1 so that local development and tests can
+// run against a server on the loopback interface.
+//
+// A hostname that merely resolves to loopback is deliberately not covered: only
+// an issuer that says loopback on its face gets the relaxed treatment.
+func isLoopbackIssuer(issuer string) bool {
+	u, err := url.Parse(issuer)
+	if err != nil {
+		return false
+	}
+	host := u.Hostname()
+	if host == "localhost" {
+		return true
+	}
+	addr, err := netip.ParseAddr(host)
+	return err == nil && addr.Unmap().IsLoopback()
+}

--- a/pkg/provider/dial_test.go
+++ b/pkg/provider/dial_test.go
@@ -1,0 +1,158 @@
+// Copyright 2026 Chainguard, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package provider
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"testing"
+)
+
+func TestIsPublicAddress(t *testing.T) {
+	for _, tc := range []struct {
+		addr string
+		want bool
+	}{
+		// Public.
+		{"8.8.8.8", true},
+		{"1.1.1.1", true},
+		{"140.82.121.4", true},
+		{"2606:4700:4700::1111", true},
+
+		// Loopback.
+		{"127.0.0.1", false},
+		{"127.1.2.3", false},
+		{"::1", false},
+
+		// RFC 1918 private.
+		{"10.0.0.1", false},
+		{"172.16.0.1", false},
+		{"172.31.255.255", false},
+		{"192.168.1.1", false},
+
+		// Link-local, including the cloud instance metadata address.
+		{"169.254.169.254", false},
+		{"169.254.0.1", false},
+		{"fe80::1", false},
+
+		// IPv6 unique local.
+		{"fd00::1", false},
+		{"fc00::1", false},
+
+		// Unspecified and other reserved ranges.
+		{"0.0.0.0", false},
+		{"0.1.2.3", false},
+		{"::", false},
+		{"100.64.0.1", false},
+		{"192.0.0.1", false},
+		{"198.18.0.1", false},
+		{"240.0.0.1", false},
+		{"255.255.255.255", false},
+		{"224.0.0.1", false},
+
+		// IPv4-mapped IPv6 must be judged on the embedded IPv4 address.
+		{"::ffff:10.0.0.1", false},
+		{"::ffff:127.0.0.1", false},
+		{"::ffff:8.8.8.8", true},
+	} {
+		t.Run(tc.addr, func(t *testing.T) {
+			addr, err := netip.ParseAddr(tc.addr)
+			if err != nil {
+				t.Fatalf("ParseAddr(%q) = %v", tc.addr, err)
+			}
+			if got := isPublicAddress(addr); got != tc.want {
+				t.Errorf("isPublicAddress(%s) = %v, want %v", tc.addr, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsLoopbackIssuer(t *testing.T) {
+	for _, tc := range []struct {
+		issuer string
+		want   bool
+	}{
+		{"http://localhost:8080", true},
+		{"http://127.0.0.1:8080", true},
+		{"https://127.0.0.1", true},
+		{"http://[::1]:8080", true},
+		{"https://accounts.example.com", false},
+		{"https://token.actions.githubusercontent.com", false},
+		// A public name may still resolve to loopback; it does not get the
+		// carve-out, and the dialer is what ultimately refuses it.
+		{"https://localhost.example.com", false},
+		{"https://10.0.0.1", false},
+		{"", false},
+	} {
+		t.Run(tc.issuer, func(t *testing.T) {
+			if got := isLoopbackIssuer(tc.issuer); got != tc.want {
+				t.Errorf("isLoopbackIssuer(%q) = %v, want %v", tc.issuer, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRestrictedDialerBlocksNonPublic asserts the dialer refuses a real
+// connection to a loopback listener unless loopback has been allowed. The
+// listener stands in for any internal service reachable from the deployment.
+func TestRestrictedDialerBlocksNonPublic(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	addr := server.Listener.Addr().String()
+
+	t.Run("blocked", func(t *testing.T) {
+		_, err := newRestrictedDialer(false).DialContext(context.Background(), "tcp", addr)
+		if err == nil {
+			t.Fatal("DialContext() = nil, want an error for a non-public address")
+		}
+		if !errors.Is(err, errNonPublicAddress) {
+			t.Errorf("DialContext() = %v, want errNonPublicAddress", err)
+		}
+	})
+
+	t.Run("allowed for loopback issuers", func(t *testing.T) {
+		conn, err := newRestrictedDialer(true).DialContext(context.Background(), "tcp", addr)
+		if err != nil {
+			t.Fatalf("DialContext() = %v, want success when loopback is allowed", err)
+		}
+		conn.Close()
+	})
+}
+
+// TestDiscoveryTransportBlocksNonPublicIssuer drives the guard through the
+// transport that discovery actually uses, via a hostname that is not itself
+// loopback but resolves there — the shape a rebinding or attacker-controlled
+// DNS record takes.
+func TestDiscoveryTransportBlocksNonPublicIssuer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	_, port, err := net.SplitHostPort(server.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("SplitHostPort() = %v", err)
+	}
+
+	// "localtest.me" style names are avoided so the test stays hermetic; the
+	// strict transport is instead pointed at the loopback literal directly,
+	// which it must refuse because the issuer carve-out does not apply to it.
+	client := &http.Client{Transport: discoveryTransport("https://accounts.example.com")}
+	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:"+port+"/.well-known/openid-configuration", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() = %v", err)
+	}
+	if _, err := client.Do(req); err == nil {
+		t.Fatal("client.Do() = nil, want an error reaching a non-public address")
+	} else if !errors.Is(err, errNonPublicAddress) {
+		t.Errorf("client.Do() = %v, want errNonPublicAddress", err)
+	}
+}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/cenkalti/backoff/v5"
 	"github.com/chainguard-dev/clog"
-	"github.com/chainguard-dev/terraform-infra-common/pkg/httpmetrics"
 	"github.com/coreos/go-oidc/v3/oidc"
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/octo-sts/app/pkg/maxsize"
@@ -45,7 +44,7 @@ func Get(ctx context.Context, issuer string) (provider VerifierProvider, err err
 	}
 
 	ctx = oidc.ClientContext(ctx, &http.Client{
-		Transport: maxsize.NewRoundTripper(MaximumResponseSize, httpmetrics.Transport),
+		Transport: maxsize.NewRoundTripper(MaximumResponseSize, discoveryTransport(issuer)),
 		CheckRedirect: func(req *http.Request, _ []*http.Request) error {
 			// Validate redirect destination using same rules as original issuer
 			if !oidcvalidate.IsValidIssuer(req.URL.String()) {


### PR DESCRIPTION
## What

Constrains OIDC discovery to destinations that are routable on the public internet, so a discovery request cannot be steered at an address inside the deployment's own network.

## Why

`provider.Get` receives the issuer that `apiauth.ExtractIssuer` read out of the bearer token, and it dials that issuer *before* the token's signature has been checked. The value is therefore chosen by an unauthenticated caller.

`oidcvalidate.IsValidIssuer` already constrains the shape of the issuer — scheme, hostname characters, path, length. What it cannot do is say where the name points. `https://internal-service.example` and a public name whose A record is a private address are both syntactically valid, so discovery will connect to them.

This complements the input sanitisation added in v0.5.3 (CVE-2025-52477) rather than replacing it: that work constrained the string, this constrains the destination.

## How

The HTTP client used for discovery now carries a dialer with a `Control` hook that rejects any address which is not publicly routable — loopback, RFC 1918, RFC 4193 unique local, link-local (where cloud instance metadata services live), carrier-grade NAT, the TEST-NETs, and the other reserved ranges. IPv4-mapped IPv6 addresses are unmapped first so `::ffff:10.0.0.1` is judged as the private address it is.

`Control` is the useful place for this. It runs after name resolution and immediately before `connect(2)`, on the concrete address being dialed, so a name that resolves inward is caught even if it resolved differently a moment earlier when it was validated as a string.

Two consequences worth noting:

- The constructed provider retains this client, so the JWKS fetches that follow are governed by the same rule. A discovery document pointing `jwks_uri` at an internal address is refused on the same terms as the issuer.
- Issuers that explicitly name a loopback host keep the relaxed treatment, preserving the local-development carve-out `IsValidIssuer` already makes for `localhost`, `127.0.0.1` and `::1`. A public hostname that merely *resolves* to loopback does not qualify.

## Testing

- `isPublicAddress` is table-tested across loopback, private, link-local, ULA, CGNAT, reserved, multicast, unspecified, IPv4-mapped and public addresses.
- The dialer is exercised against a real listener, asserting refusal by default and success when the issuer is itself loopback.
- The discovery transport is driven end to end to confirm a strict-mode client cannot reach a non-public address.

The existing `httptest`-based provider tests are unmodified and still pass: they use `127.0.0.1` issuers, which take the loopback carve-out.

`go build ./...`, `go vet ./pkg/provider/` and `go test ./pkg/...` are clean.
