### PR TITLE
fix(provider): bound the cost of OIDC discovery

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -68,13 +68,36 @@ func Get(ctx context.Context, issuer string) (provider VerifierProvider, err err
 	return provider, nil
 }
 
+// Discovery is driven by an issuer taken from an unverified bearer token, so
+// its cost has to be bounded rather than left to the caller's deadline. A
+// target that stalls — accepting the connection and never responding — would
+// otherwise hold a request open for as long as the client waits, once per
+// attempt, with no ceiling on the number of attempts.
+//
+// These are variables rather than constants only so that tests can shorten
+// them; nothing outside this package changes them.
+var (
+	// discoveryAttemptTimeout bounds a single discovery attempt.
+	discoveryAttemptTimeout = 5 * time.Second
+	// discoveryMaxElapsedTime bounds all attempts together.
+	discoveryMaxElapsedTime = 15 * time.Second
+	// discoveryMaxTries bounds how many attempts are made.
+	discoveryMaxTries uint = 3
+)
+
 // newProviderWithRetry creates a new OIDC provider with exponential backoff retry logic
 func newProviderWithRetry(ctx context.Context, issuer string) (VerifierProvider, error) {
 	attempt := 0
 
 	operation := func() (VerifierProvider, error) {
 		attempt++
-		p, err := oidc.NewProvider(ctx, issuer)
+		// Bound the attempt itself. go-oidc keeps only the HTTP client from
+		// this context, not the context, so cancelling it here does not
+		// affect the returned provider or its later key set fetches.
+		attemptCtx, cancel := context.WithTimeout(ctx, discoveryAttemptTimeout)
+		defer cancel()
+
+		p, err := oidc.NewProvider(attemptCtx, issuer)
 		if err != nil {
 			clog.WarnContext(ctx, "provider creation failed", "attempt", attempt, "issuer", issuer, "error", err)
 			// Check for permanent errors that shouldn't be retried
@@ -97,7 +120,11 @@ func newProviderWithRetry(ctx context.Context, issuer string) (VerifierProvider,
 	expBackoff.Multiplier = 2.0
 	expBackoff.RandomizationFactor = 0.1
 
-	return backoff.Retry(ctx, operation, backoff.WithBackOff(expBackoff))
+	return backoff.Retry(ctx, operation,
+		backoff.WithBackOff(expBackoff),
+		backoff.WithMaxTries(discoveryMaxTries),
+		backoff.WithMaxElapsedTime(discoveryMaxElapsedTime),
+	)
 }
 
 // isPermanentError checks if an error should not be retried based on HTTP status codes

--- a/pkg/provider/retry_bounds_test.go
+++ b/pkg/provider/retry_bounds_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Chainguard, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package provider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestNewProviderWithRetryBoundsAttempts asserts that a failing discovery
+// target is retried a bounded number of times even when the caller's context
+// is generous, so an unauthenticated request cannot drive an open-ended number
+// of outbound requests.
+func TestNewProviderWithRetryBoundsAttempts(t *testing.T) {
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	// Far longer than the retry budget, so any bound observed comes from the
+	// retry configuration rather than from the caller giving up.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	provider, err := newProviderWithRetry(ctx, server.URL)
+	if err == nil {
+		t.Fatal("newProviderWithRetry() = nil error, want failure once the retry budget is spent")
+	}
+	if provider != nil {
+		t.Fatal("newProviderWithRetry() returned a provider, want nil")
+	}
+	if got := uint(atomic.LoadInt32(&attempts)); got != discoveryMaxTries {
+		t.Errorf("attempts = %d, want %d", got, discoveryMaxTries)
+	}
+}
+
+// TestNewProviderWithRetryBoundsStalledTarget asserts that a target which
+// accepts the connection but never replies cannot hold the request for the
+// caller's full deadline.
+func TestNewProviderWithRetryBoundsStalledTarget(t *testing.T) {
+	restore := shortenDiscoveryBudget(t, 200*time.Millisecond, 2*time.Second, 2)
+	defer restore()
+
+	stalled := make(chan struct{})
+	defer close(stalled)
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		// Hold the request until the test finishes or the client gives up.
+		select {
+		case <-stalled:
+		case <-r.Context().Done():
+		}
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	start := time.Now()
+	if _, err := newProviderWithRetry(ctx, server.URL); err == nil {
+		t.Fatal("newProviderWithRetry() = nil error, want failure against a stalled target")
+	}
+	// Each attempt is capped, and the attempts together are capped, so the
+	// call must return long before the caller's own deadline.
+	if elapsed := time.Since(start); elapsed > 30*time.Second {
+		t.Errorf("newProviderWithRetry() took %v, want it bounded by the retry budget", elapsed)
+	}
+}
+
+// shortenDiscoveryBudget lowers the discovery bounds for the duration of a
+// test and returns a function restoring the previous values.
+func shortenDiscoveryBudget(t *testing.T, attempt, elapsed time.Duration, tries uint) func() {
+	t.Helper()
+	oldAttempt, oldElapsed, oldTries := discoveryAttemptTimeout, discoveryMaxElapsedTime, discoveryMaxTries
+	discoveryAttemptTimeout, discoveryMaxElapsedTime, discoveryMaxTries = attempt, elapsed, tries
+	return func() {
+		discoveryAttemptTimeout, discoveryMaxElapsedTime, discoveryMaxTries = oldAttempt, oldElapsed, oldTries
+	}
+}


### PR DESCRIPTION
## What

Gives OIDC discovery its own time and attempt budget instead of letting it run for as long as the caller is willing to wait.

## Why

`newProviderWithRetry` is reached with an issuer taken from a bearer token that has not been verified yet, so the work it performs is chosen by an unauthenticated caller. At present nothing bounds that work:

- each attempt inherits the caller's context, so a single attempt lasts as long as the client waits;
- `backoff.Retry` is given a `BackOff` but no `WithMaxTries` and no `WithMaxElapsedTime`, so it retries until the context is done.

A target that accepts the connection and then never responds therefore holds the request open for the caller's full deadline, issuing a fresh outbound request each round. The retry loop turns one inbound request into several outbound ones and multiplies the time each is held.

## How

- A per-attempt timeout, so one unresponsive target cannot consume the whole request.
- `WithMaxTries`, so the number of outbound requests per inbound request is fixed.
- `WithMaxElapsedTime`, so the attempts together are bounded.

The backoff schedule itself is unchanged, and a caller with a shorter deadline still wins — the per-attempt context derives from the caller's.

Cancelling the per-attempt context once an attempt returns is safe: go-oidc stores the HTTP client taken from the context, not the context itself (`oidc.go`, where the provider builds its `commonRemoteKeySet` from a fresh `context.Background()`), so neither the returned provider nor its later key set fetches depend on the attempt context.

The bounds are package-level variables rather than constants purely so tests can shorten them.

## Testing

- A new test asserts a failing target is retried a bounded number of times even when the caller's context is generous, so the bound demonstrably comes from the retry configuration and not from the caller giving up.
- A second asserts a target that accepts the connection and stalls cannot hold the call for the caller's deadline.

The existing retry tests are unmodified and still pass, including the ones asserting exactly three attempts and a minimum backoff delay.

`go build ./...`, `go vet ./pkg/provider/` and `go test ./pkg/...` are clean.
