### PR TITLE
feat(octosts): add OCTOSTS_ALLOWED_ISSUERS to confine OIDC discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,38 @@ The URL must use HTTPS. When set, all GitHub API interactions (installation
 lookups, trust policy reads, token exchanges, and token revocations) will target
 the configured endpoint instead of the public GitHub API.
 
+Note that `GITHUB_BASE_URL` does not affect OIDC discovery, which targets the
+issuer named by the presented token. A GHES deployment whose issuer is not
+reachable from the public internet should name it in `OCTOSTS_ALLOWED_ISSUERS`,
+described below.
+
+### Restricting issuers (`OCTOSTS_ALLOWED_ISSUERS`)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OCTOSTS_ALLOWED_ISSUERS` | (empty — any issuer) | Comma-separated issuers this deployment will perform OIDC discovery against. |
+
+A token names its own issuer, and octo-sts must fetch that issuer's discovery
+document to learn the keys that verify the token. The fetch therefore happens
+while the token is still unverified, which means a caller who has presented
+nothing but an unsigned assertion chooses a host this deployment connects to.
+
+Setting `OCTOSTS_ALLOWED_ISSUERS` confines that choice to issuers you name:
+
+```sh
+OCTOSTS_ALLOWED_ISSUERS=https://token.actions.githubusercontent.com
+```
+
+Matching is exact, as it is for the org-level `issuers` list, so a trailing
+slash makes a different issuer. Each entry is validated at startup and the
+process refuses to start if one could never match a valid issuer.
+
+Leave it unset to keep accepting any issuer your trust policies allow. Most
+deployments federate a small, fixed set of identity providers and can name them
+all; a deployment serving organizations that bring their own issuers, or one
+using `issuer_patterns`, will want to leave it unset and rely on the trust
+policy and the org-level allowlist instead.
+
 ### Best Practices
 
 To ensure secure and effective use of octo-sts, follow these recommended practices:

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -111,7 +111,7 @@ func main() {
 		clog.FromContext(ctx).Warn("EVENT_INGRESS_URI unset; exchange events will not be emitted")
 	}
 
-	pboidc.RegisterSecurityTokenServiceServer(d.Server, octosts.NewSecurityTokenServiceServer(router, sticky, ceclient, appCfg.Domain, baseCfg.Metrics, baseCfg.GitHubBaseURL, appCfg.OrgPolicyRepo))
+	pboidc.RegisterSecurityTokenServiceServer(d.Server, octosts.NewSecurityTokenServiceServer(router, sticky, ceclient, appCfg.Domain, baseCfg.Metrics, baseCfg.GitHubBaseURL, appCfg.OrgPolicyRepo, baseCfg.AllowedIssuers))
 	if err := d.RegisterHandler(ctx, pboidc.RegisterSecurityTokenServiceHandlerFromEndpoint); err != nil {
 		log.Panicf("failed to register gateway endpoint: %v", err)
 	}

--- a/pkg/envconfig/envconfig.go
+++ b/pkg/envconfig/envconfig.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
+	"github.com/octo-sts/app/pkg/oidcvalidate"
 )
 
 type EnvConfig struct {
@@ -46,6 +47,17 @@ type EnvConfig struct {
 	// Server deployments (e.g. "https://github.example.com/api/v3").
 	// When empty, the default https://api.github.com is used.
 	GitHubBaseURL string `envconfig:"GITHUB_BASE_URL" required:"false"`
+
+	// AllowedIssuers, when non-empty, is the set of issuers this deployment
+	// will perform OIDC discovery against. Matching is exact, as it is for the
+	// org-level issuers list, so a trailing slash makes a different issuer.
+	//
+	// The bearer token names its own issuer and is unverified at the point
+	// discovery runs, so an unset list lets any caller choose the host this
+	// deployment connects to. Setting it confines that choice to issuers the
+	// operator has named. Leave it unset to keep accepting any issuer the
+	// trust policies allow.
+	AllowedIssuers []string `envconfig:"OCTOSTS_ALLOWED_ISSUERS" required:"false"`
 }
 
 type EnvConfigApp struct {
@@ -155,6 +167,14 @@ func BaseConfig() (*EnvConfig, error) {
 		}
 		if u.Scheme != "https" {
 			return nil, fmt.Errorf("GITHUB_BASE_URL must use https scheme, got %q", u.Scheme)
+		}
+	}
+
+	// Reject an entry that no issuer can ever equal, since it would silently
+	// contribute nothing to a list whose purpose is to be exhaustive.
+	for i, iss := range cfg.AllowedIssuers {
+		if !oidcvalidate.IsValidIssuer(iss) {
+			return nil, fmt.Errorf("OCTOSTS_ALLOWED_ISSUERS[%d] is not a valid issuer: %q", i, iss)
 		}
 	}
 

--- a/pkg/envconfig/envconfig_test.go
+++ b/pkg/envconfig/envconfig_test.go
@@ -276,6 +276,26 @@ func TestBaseConfig(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "OCTOSTS_ALLOWED_ISSUERS accepts a list of issuers",
+			envVars: map[string]string{
+				"PORT":                        "8080",
+				"GITHUB_APP_IDS":              "12345678",
+				"APP_SECRET_CERTIFICATE_FILE": "some-file-path",
+				"OCTOSTS_ALLOWED_ISSUERS":     "https://token.actions.githubusercontent.com,https://accounts.example.com",
+			},
+			wantErr: false,
+		},
+		{
+			name: "OCTOSTS_ALLOWED_ISSUERS rejects an entry no issuer can equal",
+			envVars: map[string]string{
+				"PORT":                        "8080",
+				"GITHUB_APP_IDS":              "12345678",
+				"APP_SECRET_CERTIFICATE_FILE": "some-file-path",
+				"OCTOSTS_ALLOWED_ISSUERS":     "not-a-url",
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/octosts/allowed_issuers_test.go
+++ b/pkg/octosts/allowed_issuers_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 Chainguard, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package octosts
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	v1 "chainguard.dev/sdk/proto/platform/oidc/v1"
+	"github.com/go-jose/go-jose/v4"
+	josejwt "github.com/go-jose/go-jose/v4/jwt"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+func TestIssuerAllowed(t *testing.T) {
+	const gh = "https://token.actions.githubusercontent.com"
+
+	for _, tc := range []struct {
+		name    string
+		allowed []string
+		issuer  string
+		want    bool
+	}{{
+		name:   "empty allowlist permits any issuer",
+		issuer: "https://example.com",
+		want:   true,
+	}, {
+		name:    "listed issuer is permitted",
+		allowed: []string{gh, "https://accounts.example.com"},
+		issuer:  "https://accounts.example.com",
+		want:    true,
+	}, {
+		name:    "unlisted issuer is refused",
+		allowed: []string{gh},
+		issuer:  "https://example.com",
+		want:    false,
+	}, {
+		// Matching is exact, matching the org-level issuers list, where a
+		// trailing slash likewise makes a different issuer.
+		name:    "trailing slash is a different issuer",
+		allowed: []string{gh},
+		issuer:  gh + "/",
+		want:    false,
+	}, {
+		name:    "suffix of a listed issuer is refused",
+		allowed: []string{gh},
+		issuer:  gh + ".example.com",
+		want:    false,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &sts{allowedIssuers: tc.allowed}
+			if got := s.issuerAllowed(tc.issuer); got != tc.want {
+				t.Errorf("issuerAllowed(%q) = %t, wanted %t", tc.issuer, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExchangeChecksAllowlistBeforeDiscovery pins the ordering that gives the
+// allowlist its value: a refused issuer must never be contacted. The issuer
+// here is a server we control, so any request reaching it is a discovery the
+// allowlist was meant to prevent.
+func TestExchangeChecksAllowlistBeforeDiscovery(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.MD{
+		"authorization": []string{"Bearer " + signedTokenForIssuer(t, srv.URL)},
+	})
+
+	s := &sts{allowedIssuers: []string{"https://token.actions.githubusercontent.com"}}
+	_, err := s.Exchange(ctx, &v1.ExchangeRequest{Identity: "foo", Scope: "org/repo"})
+	if err == nil {
+		t.Fatal("Exchange() succeeded, wanted a refusal")
+	}
+	if got := status.Code(err); got != codes.InvalidArgument {
+		t.Errorf("Exchange() code = %v, wanted %v", got, codes.InvalidArgument)
+	}
+	if got := hits.Load(); got != 0 {
+		t.Errorf("issuer received %d requests, wanted 0: discovery ran before the allowlist check", got)
+	}
+}
+
+// TestExchangeWithoutAllowlistPerformsDiscovery is the counterpart: with no
+// allowlist configured the issuer is still contacted, so the new check cannot
+// change what an existing deployment does.
+func TestExchangeWithoutAllowlistPerformsDiscovery(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.MD{
+		"authorization": []string{"Bearer " + signedTokenForIssuer(t, srv.URL)},
+	})
+
+	s := &sts{}
+	if _, err := s.Exchange(ctx, &v1.ExchangeRequest{Identity: "foo", Scope: "org/repo"}); err == nil {
+		t.Fatal("Exchange() succeeded, wanted discovery against the stub to fail")
+	}
+	if hits.Load() == 0 {
+		t.Error("issuer received no requests, wanted discovery to be attempted")
+	}
+}
+
+func signedTokenForIssuer(t *testing.T, issuer string) string {
+	t.Helper()
+
+	pk, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey() = %v", err)
+	}
+	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.RS256, Key: pk}, nil)
+	if err != nil {
+		t.Fatalf("jose.NewSigner() = %v", err)
+	}
+	token, err := josejwt.Signed(signer).Claims(josejwt.Claims{
+		Subject:  "foo",
+		Issuer:   issuer,
+		Audience: josejwt.Audience{"octosts"},
+		Expiry:   josejwt.NewNumericDate(time.Now().Add(10 * time.Minute)),
+	}).Serialize()
+	if err != nil {
+		t.Fatalf("Serialize() = %v", err)
+	}
+	return token
+}

--- a/pkg/octosts/octosts.go
+++ b/pkg/octosts/octosts.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"path"
+	"slices"
 	"strings"
 	"time"
 
@@ -49,15 +50,16 @@ const (
 // GitHub installation tokens. router selects the per-org app pool; sticky (may
 // be nil) persists checks:write routing for check-run ownership across all
 // pools (installation IDs are globally unique within GitHub).
-func NewSecurityTokenServiceServer(router *ghinstall.OrgRouter, sticky stickystore.Store, ceclient cloudevents.Client, domain string, metrics bool, baseURL string, orgPolicyRepo string) pboidc.SecurityTokenServiceServer {
+func NewSecurityTokenServiceServer(router *ghinstall.OrgRouter, sticky stickystore.Store, ceclient cloudevents.Client, domain string, metrics bool, baseURL string, orgPolicyRepo string, allowedIssuers []string) pboidc.SecurityTokenServiceServer {
 	return &sts{
-		router:        router,
-		sticky:        sticky,
-		ceclient:      ceclient,
-		domain:        domain,
-		metrics:       metrics,
-		baseURL:       baseURL,
-		orgPolicyRepo: orgPolicyRepo,
+		router:         router,
+		sticky:         sticky,
+		ceclient:       ceclient,
+		domain:         domain,
+		metrics:        metrics,
+		baseURL:        baseURL,
+		orgPolicyRepo:  orgPolicyRepo,
+		allowedIssuers: allowedIssuers,
 	}
 }
 
@@ -75,9 +77,22 @@ type sts struct {
 	baseURL       string
 	orgPolicyRepo string
 
+	// allowedIssuers, when non-empty, confines OIDC discovery to these
+	// issuers. Empty means any issuer the trust policies allow.
+	allowedIssuers []string
+
 	// orgIssuerFlight collapses concurrent org-allowlist lookups for the same
 	// owner into one enumeration. Its zero value is ready to use.
 	orgIssuerFlight singleflight.Group
+}
+
+// issuerAllowed reports whether issuer may be used for OIDC discovery. An
+// empty allowlist permits any issuer, preserving the behaviour of deployments
+// that have not set one.
+//
+// Matching is exact, as it is for the org-level issuers list.
+func (s *sts) issuerAllowed(issuer string) bool {
+	return len(s.allowedIssuers) == 0 || slices.Contains(s.allowedIssuers, issuer)
 }
 
 func (s *sts) policyRepo() string {
@@ -171,6 +186,14 @@ func (s *sts) Exchange(ctx context.Context, request *pboidc.ExchangeRequest) (_ 
 	// Validate issuer format
 	if !oidcvalidate.IsValidIssuer(issuer) {
 		return nil, status.Error(codes.InvalidArgument, "invalid issuer format")
+	}
+
+	// Confine discovery to issuers the operator named, if any. The bearer
+	// token is still unverified here and names its own issuer, so without
+	// this the caller chooses the host the next line connects to.
+	if !s.issuerAllowed(issuer) {
+		clog.FromContext(ctx).Warnf("issuer not permitted by OCTOSTS_ALLOWED_ISSUERS: %q", issuer)
+		return nil, status.Error(codes.InvalidArgument, "issuer is not allowed")
 	}
 
 	// Fetch the provider from the cache or create a new one and add to the cache


### PR DESCRIPTION
## What

Adds `OCTOSTS_ALLOWED_ISSUERS`, an optional list of issuers a deployment will perform OIDC discovery against. Unset — the default — permits any issuer, so nothing changes for an existing deployment until it is set.

## Why

A token names its own issuer, and that issuer's discovery document is what tells us the keys that verify the token. Discovery therefore has to happen *before* the signature can be checked. `Exchange` reflects that:

```go
issuer, err := apiauth.ExtractIssuer(bearer)   // from an unverified token
if !oidcvalidate.IsValidIssuer(issuer) { ... } // shape only
p, err := provider.Get(ctx, issuer)            // connects to issuer
tok, err := verifier.Verify(ctx, bearer)       // signature checked here
```

So a caller who presents nothing but an unsigned assertion chooses a host the service connects to, and learns from the timing and from its own logs whether the connection was made. The assertion never has to be valid.

The trust policy and the org-level allowlist both settle the issuer question properly, but they are consulted in `lookupInstallAndTrustPolicy`, after the provider has been fetched. The org allowlist additionally permits everything when an organization has not published one, which is the default. Neither constrains the request discovery has already made.

`oidcvalidate.IsValidIssuer` constrains the issuer's shape, which is worth doing, but any well-formed `https` URL satisfies it.

## How

The list is checked immediately after the format check and before `provider.Get`, so an issuer that is not named is never contacted. Matching is exact, as it is for the org-level `issuers` list, so a trailing slash makes a different issuer.

Entries are validated at startup against the same `IsValidIssuer` rule, so an entry no issuer could ever equal is reported rather than silently contributing nothing to a list whose whole purpose is to be exhaustive.

## Scope, and who this is for

This is an operator-level knob, so it protects only deployments that set it. That is a real limitation and I want to be upfront about it: a deployment serving organizations that bring their own issuers, or one relying on `issuer_patterns`, cannot use it and should leave it unset.

I think it still earns its place, because the deployments that *can* use it are the common case — a fixed, known set of identity providers, often just one — and for those it removes the pre-authentication network reach entirely rather than narrowing it. It also gives a GHES deployment a supported way to name an issuer that is not reachable from the public internet.

## Testing

- `issuerAllowed` is table-tested: empty list, listed, unlisted, trailing slash, and a suffix of a listed issuer.
- `TestExchangeChecksAllowlistBeforeDiscovery` points the issuer at a stub server and asserts it receives **zero** requests, pinning the ordering that gives the check its value.
- `TestExchangeWithoutAllowlistPerformsDiscovery` is the counterpart: with no allowlist the issuer is still contacted, so an existing deployment is unaffected.
- Two `BaseConfig` cases cover a valid list and a rejected entry.

`go build ./...`, `go vet` and `go test ./pkg/...` are clean.

## Note

`NewSecurityTokenServiceServer` gains a parameter. Happy to move the options to a struct instead if you would rather not grow the signature again.
