### PR TITLE
fix(deploy): pin google provider below v8 to preserve EXTERNAL LB scheme

### DIFF
--- a/env/octo-sts-staging/backend.tf
+++ b/env/octo-sts-staging/backend.tf
@@ -6,5 +6,11 @@ terraform {
   required_providers {
     ko     = { source = "ko-build/ko" }
     cosign = { source = "chainguard-dev/cosign" }
+    # Cap below google v8: v8 changed the default load_balancing_scheme from
+    # EXTERNAL to EXTERNAL_MANAGED, and GCP rejects that scheme change in place
+    # on the existing serverless-gclb backend services. Remove this cap only
+    # alongside a deliberate Classic -> Global external ALB migration.
+    google      = { source = "hashicorp/google", version = ">= 4.79.0, < 8.0.0" }
+    google-beta = { source = "hashicorp/google-beta", version = ">= 4.79.0, < 8.0.0" }
   }
 }

--- a/env/octo-sts/backend.tf
+++ b/env/octo-sts/backend.tf
@@ -6,5 +6,11 @@ terraform {
   required_providers {
     ko     = { source = "ko-build/ko" }
     cosign = { source = "chainguard-dev/cosign" }
+    # Cap below google v8: v8 changed the default load_balancing_scheme from
+    # EXTERNAL to EXTERNAL_MANAGED, and GCP rejects that scheme change in place
+    # on the existing serverless-gclb backend services. Remove this cap only
+    # alongside a deliberate Classic -> Global external ALB migration.
+    google      = { source = "hashicorp/google", version = ">= 4.79.0, < 8.0.0" }
+    google-beta = { source = "hashicorp/google-beta", version = ">= 4.79.0, < 8.0.0" }
   }
 }


### PR DESCRIPTION
## What/Why

Cap the `google`/`google-beta` providers at `< 8.0.0` in the staging and prod env roots. google v8 changed the default `load_balancing_scheme` from `EXTERNAL` to `EXTERNAL_MANAGED` for `google_compute_backend_service` and `google_compute_global_forwarding_rule`. With no upper bound on the constraint (`>= 4.79.0`) and the lockfile gitignored, `terraform init` resolved v8 and the plan tried to flip the live `serverless-gclb` backend services in place, which GCP rejects (`400: cannot change the load balancing scheme until the migration state is set to TEST_ALL_TRAFFIC`). That broke the staging deploy and would break prod on its next run.

## Proof it works

Root cause confirmed against the [google provider v8 upgrade guide](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/version_8_upgrade) (the `load_balancing_scheme` default flip) and the failing runs init log (installed `hashicorp/google v8.0.0`). `terraform fmt` clean. The definitive check is the staging deploy re-run on this branch: it should resolve google 7.x and show no `loadBalancingScheme` change in the plan.

## Risk + AI role

low -- a version-constraint change only, no resource changes; keeps the provider on the 7.x line the last successful deploys used. AI-assisted root-cause and authoring; human-directed.

## Review focus

Pin now (unblocks immediately) versus scheduling the deliberate Classic -> Global external ALB migration to `EXTERNAL_MANAGED` (the eventual forward path, which needs a zero-downtime plan for prod). Also worth deciding whether to commit provider lockfiles so the version is reproducible rather than resolved fresh each run.