### PR TITLE
fix(deps): pin terraform-infra-common to 1.32.1 to restore prober startup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.19.0
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/chainguard-dev/clog v1.8.1
-	github.com/chainguard-dev/terraform-infra-common v1.35.0
+	github.com/chainguard-dev/terraform-infra-common v1.32.1
 	github.com/cloudevents/sdk-go/v2 v2.16.2
 	github.com/coreos/go-oidc/v3 v3.20.0
 	github.com/go-viper/mapstructure/v2 v2.5.0

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chainguard-dev/clog v1.8.1 h1:Lab3GEDsVm1J9XGlpWEBuzXX7eETRmd0vN5PYoNyT+Y=
 github.com/chainguard-dev/clog v1.8.1/go.mod h1:5MQOZi+Iu7fV7GcJG8ag8rCB5elEOpqRMKEASgnGVdo=
-github.com/chainguard-dev/terraform-infra-common v1.35.0 h1:xGbaoJvuYEVLuHNS/jvNBCe+MTUpFXRx5PsZtUDQRHc=
-github.com/chainguard-dev/terraform-infra-common v1.35.0/go.mod h1:UQnWj4z2p0Lx8y1LYjZzOFLqj/0xAySmlgQDF5Q/bAA=
+github.com/chainguard-dev/terraform-infra-common v1.32.1 h1:M/MFTjj0XzaeXENhKVQlvusCaZVulDUi4wPMxhZd3jI=
+github.com/chainguard-dev/terraform-infra-common v1.32.1/go.mod h1:014V2VRouZ8iem/jZv1T5DeCOb2k0tlsxMRkyEMd/SQ=
 github.com/cloudevents/sdk-go/v2 v2.16.2 h1:ZYDFrYke4FD+jM8TZTJJO6JhKHzOQl2oqpFK1D+NnQM=
 github.com/cloudevents/sdk-go/v2 v2.16.2/go.mod h1:laOcGImm4nVJEU+PHnUrKL56CKmRL65RlQF0kRmW/kg=
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 h1:aBangftG7EVZoUb69Os8IaYg++6uMOdKK83QtkkvJik=


### PR DESCRIPTION
## What/Why

Downgrade `github.com/chainguard-dev/terraform-infra-common` from 1.35.0 back to 1.32.1 (the last version staging deployed healthy on). The 1.33.1 (#1610) and 1.35.0 (#1614) bumps rebuilt the prober image such that its Cloud Run revision fails its startup probe — the container never listens on `PORT=8080` within the startup window and emits no application logs. The prober terraform module is pinned (its service config is unchanged), so the only per-deploy change is the binary rebuilt against this dependency.

## Proof it works

`go build ./cmd/prober ./cmd/app ./cmd/webhook` and `go test ./pkg/webhook/...` pass on 1.32.1. The prober binary starts and binds the port locally on both 1.35.0 and 1.32.1 — the failure only reproduces on Cloud Run (multi-container: prober + OTEL collector sidecar), so the definitive check is the staging deploy on this branch reaching a healthy prober revision.

## Risk + AI role

low -- dependency-version-only change, no first-party code touched; reverts to a version proven healthy two days ago. Affects the app/webhook/prober binaries. AI-assisted diagnosis and authoring; human-directed.

## Review focus

Pin back to 1.32.1 now to unblock versus bisecting 1.33.1 vs 1.35.0 to land the exact upstream change; and whether to add an upper-bound / lockfile discipline so this is not silently re-bumped.