### PR TITLE
chore(deps): revert terraform-infra-common pin back to 1.35.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.19.0
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/chainguard-dev/clog v1.8.1
-	github.com/chainguard-dev/terraform-infra-common v1.32.1
+	github.com/chainguard-dev/terraform-infra-common v1.35.0
 	github.com/cloudevents/sdk-go/v2 v2.16.2
 	github.com/coreos/go-oidc/v3 v3.20.0
 	github.com/go-viper/mapstructure/v2 v2.5.0

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chainguard-dev/clog v1.8.1 h1:Lab3GEDsVm1J9XGlpWEBuzXX7eETRmd0vN5PYoNyT+Y=
 github.com/chainguard-dev/clog v1.8.1/go.mod h1:5MQOZi+Iu7fV7GcJG8ag8rCB5elEOpqRMKEASgnGVdo=
-github.com/chainguard-dev/terraform-infra-common v1.32.1 h1:M/MFTjj0XzaeXENhKVQlvusCaZVulDUi4wPMxhZd3jI=
-github.com/chainguard-dev/terraform-infra-common v1.32.1/go.mod h1:014V2VRouZ8iem/jZv1T5DeCOb2k0tlsxMRkyEMd/SQ=
+github.com/chainguard-dev/terraform-infra-common v1.35.0 h1:xGbaoJvuYEVLuHNS/jvNBCe+MTUpFXRx5PsZtUDQRHc=
+github.com/chainguard-dev/terraform-infra-common v1.35.0/go.mod h1:UQnWj4z2p0Lx8y1LYjZzOFLqj/0xAySmlgQDF5Q/bAA=
 github.com/cloudevents/sdk-go/v2 v2.16.2 h1:ZYDFrYke4FD+jM8TZTJJO6JhKHzOQl2oqpFK1D+NnQM=
 github.com/cloudevents/sdk-go/v2 v2.16.2/go.mod h1:laOcGImm4nVJEU+PHnUrKL56CKmRL65RlQF0kRmW/kg=
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 h1:aBangftG7EVZoUb69Os8IaYg++6uMOdKK83QtkkvJik=


### PR DESCRIPTION
## What/Why

Reverts the 1.32.1 pin from #1619. That pin was made to unblock a staging prober startup failure, but the failure was **transient**, not a dependency regression — re-running the identical 1.35.0 deploy came up healthy (apply + smoke tests green, prober listening on its port). The prober binary links only this module`s `pkg/prober` + `pkg/httpmetrics`, which are effectively unchanged across 1.32.1..1.35.0 (`prober.go`/`transport.go` byte-identical, one sampling-constant refactor in `metrics.go`, and the prober never calls `SetupTracer`), so there was no plausible mechanism. Restoring 1.35.0 so the dependency is not held back on a false premise.

## Proof it works

`go build ./cmd/prober ./cmd/app ./cmd/webhook` passes on 1.35.0. Staging was re-deployed on 1.35.0 and reached green including smoke tests, with a healthy prober revision.

## Risk + AI role

low -- dependency-version-only change back to the version already proven green in staging; reverts an unnecessary pin. AI-assisted; human-directed. The original misdiagnosis behind #1619 was also AI-assisted and is corrected here.

## Review focus

Comfort with dropping the 1.32.1 pin now that 1.35.0 is proven green. The genuinely latent issue that surfaced — the prober `startupProbe.failureThreshold: 1` making transient cold-starts fatal — is called out separately, not addressed here.