### PR TITLE
perf(provider): single-flight concurrent OIDC discovery per issuer

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -28,6 +28,14 @@ import (
 //   - Chainguard: needs around 2KiB
 const MaximumResponseSize = 100 * 1024 // 100KiB
 
+// discoveryTimeout bounds a single shared discovery, independent of any one
+// caller's own context. Discovery is single-flighted across concurrent
+// callers (see discoveryFlight below), so it must not be tied to any single
+// caller's deadline: an unrelated caller's short timeout must not abort
+// discovery for other callers sharing the same issuer, and a genuinely
+// stalled issuer must not hold the shared call open forever either.
+const discoveryTimeout = 20 * time.Second
+
 var (
 	// providers is an LRU cache of recently used providers.
 	providers, _ = lru.New2Q[string, VerifierProvider](100)
@@ -50,25 +58,40 @@ func Get(ctx context.Context, issuer string) (provider VerifierProvider, err err
 		return v, nil
 	}
 
-	ctx = oidc.ClientContext(ctx, &http.Client{
-		Transport: maxsize.NewRoundTripper(MaximumResponseSize, httpmetrics.Transport),
-		CheckRedirect: func(req *http.Request, _ []*http.Request) error {
-			// Validate redirect destination using same rules as original issuer
-			if !oidcvalidate.IsValidIssuer(req.URL.String()) {
-				return fmt.Errorf("redirect destination %q failed issuer validation", req.URL.String())
-			}
-			return nil
-		},
+	// Concurrent Get calls for the same issuer collapse into one discovery,
+	// so the shared discovery runs on its own context bounded only by
+	// discoveryTimeout -- not on any single caller's context. Using DoChan
+	// (rather than Do) means the shared call also keeps running in its own
+	// goroutine even if the caller that happens to trigger it stops
+	// waiting, so other callers sharing the issuer are unaffected either
+	// way.
+	ch := discoveryFlight.DoChan(issuer, func() (any, error) {
+		discoveryCtx, cancel := context.WithTimeout(context.Background(), discoveryTimeout)
+		defer cancel()
+		discoveryCtx = oidc.ClientContext(discoveryCtx, &http.Client{
+			Transport: maxsize.NewRoundTripper(MaximumResponseSize, httpmetrics.Transport),
+			CheckRedirect: func(req *http.Request, _ []*http.Request) error {
+				// Validate redirect destination using same rules as original issuer
+				if !oidcvalidate.IsValidIssuer(req.URL.String()) {
+					return fmt.Errorf("redirect destination %q failed issuer validation", req.URL.String())
+				}
+				return nil
+			},
+		})
+		return newProviderWithRetry(discoveryCtx, issuer)
 	})
 
-	// Concurrent Get calls for the same issuer collapse into one discovery.
-	v, err, _ := discoveryFlight.Do(issuer, func() (any, error) {
-		return newProviderWithRetry(ctx, issuer)
-	})
-	if err != nil {
-		return nil, fmt.Errorf("constructing %q provider: %w", issuer, err)
+	select {
+	case res := <-ch:
+		if res.Err != nil {
+			return nil, fmt.Errorf("constructing %q provider: %w", issuer, res.Err)
+		}
+		provider = res.Val.(VerifierProvider)
+	case <-ctx.Done():
+		// This caller's own context expired while waiting; the shared
+		// discovery keeps running in the background for any other callers.
+		return nil, ctx.Err()
 	}
-	provider = v.(VerifierProvider)
 
 	// Once it is built, memoize the provider so that we hit the fast
 	// path above on subsequent requests for verification.

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -18,6 +18,7 @@ import (
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/octo-sts/app/pkg/maxsize"
 	"github.com/octo-sts/app/pkg/oidcvalidate"
+	"golang.org/x/sync/singleflight"
 )
 
 // MaximumResponseSize is the maximum size of allowed responses from
@@ -30,6 +31,11 @@ const MaximumResponseSize = 100 * 1024 // 100KiB
 var (
 	// providers is an LRU cache of recently used providers.
 	providers, _ = lru.New2Q[string, VerifierProvider](100)
+
+	// discoveryFlight collapses concurrent Get calls for the same issuer
+	// into a single in-flight discovery, so N callers naming a slow or
+	// stalled issuer pay for one discovery instead of N.
+	discoveryFlight singleflight.Group
 )
 
 type VerifierProvider interface {
@@ -55,11 +61,14 @@ func Get(ctx context.Context, issuer string) (provider VerifierProvider, err err
 		},
 	})
 
-	// Verify the token before we trust anything about it.
-	provider, err = newProviderWithRetry(ctx, issuer)
+	// Concurrent Get calls for the same issuer collapse into one discovery.
+	v, err, _ := discoveryFlight.Do(issuer, func() (any, error) {
+		return newProviderWithRetry(ctx, issuer)
+	})
 	if err != nil {
 		return nil, fmt.Errorf("constructing %q provider: %w", issuer, err)
 	}
+	provider = v.(VerifierProvider)
 
 	// Once it is built, memoize the provider so that we hit the fast
 	// path above on subsequent requests for verification.

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -54,6 +54,97 @@ func TestGet_SingleflightCollapsesConcurrentCallers(t *testing.T) {
 	}
 }
 
+func TestGet_FollowerContextIsNotAffectedByLeaderCancellation(t *testing.T) {
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	var requestCount int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		<-release
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		issuerURL := "http://" + r.Host
+		w.Write([]byte(`{"issuer":"` + issuerURL + `","authorization_endpoint":"` + issuerURL + `/auth","token_endpoint":"` + issuerURL + `/token","jwks_uri":"` + issuerURL + `/jwks"}`))
+	}))
+	defer server.Close()
+
+	// Leader has a short deadline that will expire while the server is
+	// deliberately held open. Follower has no deadline at all.
+	leaderCtx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	followerCtx := context.Background()
+
+	leaderDone := make(chan error, 1)
+	followerDone := make(chan error, 1)
+
+	go func() {
+		_, err := Get(leaderCtx, server.URL)
+		leaderDone <- err
+	}()
+	<-started // leader is deterministically in-flight before follower joins
+	go func() {
+		_, err := Get(followerCtx, server.URL)
+		followerDone <- err
+	}()
+
+	leaderErr := <-leaderDone
+	if !errors.Is(leaderErr, context.DeadlineExceeded) {
+		t.Fatalf("expected leader to fail with its own deadline exceeded, got: %v", leaderErr)
+	}
+
+	// Let the shared discovery complete for the follower's benefit.
+	close(release)
+	followerErr := <-followerDone
+
+	if followerErr != nil {
+		t.Fatalf("follower with no deadline of its own must not be affected by the leader's unrelated cancellation, got error: %v", followerErr)
+	}
+}
+
+func TestGet_CallerStillRespectsItsOwnDeadlineWhileWaiting(t *testing.T) {
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		<-release
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		issuerURL := "http://" + r.Host
+		w.Write([]byte(`{"issuer":"` + issuerURL + `","authorization_endpoint":"` + issuerURL + `/auth","token_endpoint":"` + issuerURL + `/token","jwks_uri":"` + issuerURL + `/jwks"}`))
+	}))
+	defer server.Close()
+	defer close(release)
+
+	// Leader has no deadline, so the shared discovery keeps running past
+	// the follower's own short deadline below.
+	leaderCtx := context.Background()
+	followerCtx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	go func() {
+		_, _ = Get(leaderCtx, server.URL)
+	}()
+	<-started // leader is deterministically in-flight before follower joins
+
+	start := time.Now()
+	_, err := Get(followerCtx, server.URL)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected follower to respect its own deadline, got: %v", err)
+	}
+	if elapsed > 200*time.Millisecond {
+		t.Fatalf("follower should have returned promptly at its own ~30ms deadline, took %v", elapsed)
+	}
+}
+
 func TestNewProviderWithRetry_Success(t *testing.T) {
 	// Create a test server that responds successfully
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -8,12 +8,51 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 )
+
+func TestGet_SingleflightCollapsesConcurrentCallers(t *testing.T) {
+	var hits int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		// A small delay widens the race window so concurrent Get calls are
+		// likely to overlap before the first completes.
+		time.Sleep(100 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		issuerURL := "http://" + r.Host
+		w.Write([]byte(`{"issuer":"` + issuerURL + `","authorization_endpoint":"` + issuerURL + `/auth","token_endpoint":"` + issuerURL + `/token","jwks_uri":"` + issuerURL + `/jwks"}`))
+	}))
+	defer server.Close()
+
+	const callers = 20
+	var wg sync.WaitGroup
+	errs := make([]error, callers)
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, err := Get(context.Background(), server.URL)
+			errs[i] = err
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("caller %d: unexpected error: %v", i, err)
+		}
+	}
+
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Fatalf("expected discovery to be single-flighted to 1 request, got %d", got)
+	}
+}
 
 func TestNewProviderWithRetry_Success(t *testing.T) {
 	// Create a test server that responds successfully


### PR DESCRIPTION
Part of #1600; the negative cache half is a separate PR, #1630, so each can be reviewed and reverted independently.

Concurrent Get calls for the same issuer now collapse into one discovery using singleflight, so N callers naming a slow or stalled issuer no longer each pay for a full discovery. An earlier version of this PR tied the shared discovery to whichever caller happened to trigger it, so one caller's short timeout could fail discovery for other callers with a longer or no deadline at all. That is fixed: the shared discovery now runs on its own fixed timeout (20 seconds) independent of any single caller, and each caller still returns promptly if its own context expires while waiting.

One tradeoff is intentional and remains. If every caller waiting on an issuer gives up early, the shared discovery keeps running in the background up to that 20 second cap anyway, since it is no longer tied to any specific caller's cancellation. This cost is bounded per issuer and shared across concurrent callers, so it does not grow with how many callers gave up.

New tests cover the singleflight collapse, the context isolation fix, and a caller still respecting its own deadline while waiting. The full pkg/provider suite passes under race across multiple runs, and golangci-lint, go vet, and gofmt are all clean.