### PR TITLE
chore(pre-commit): swap archived go hooks for maintained fork; pin all hooks by SHA

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ exclude: |
   )$
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # frozen: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -20,39 +20,39 @@ repos:
       - id: check-added-large-files
       - id: check-merge-conflict
 
-  - repo: https://github.com/dnephin/pre-commit-golang
-    rev: v0.5.1
+  - repo: https://github.com/TekWizely/pre-commit-golang
+    rev: f298c082154b2cb239fac06a4f452368e66e66dd # frozen: v1.0.0-rc.4
     hooks:
       - id: go-fmt
       - id: go-imports
       - id: go-mod-tidy
 
   - repo: https://github.com/golangci/golangci-lint
-    rev: v2.11.4
+    rev: 8f3b0c7ed018e57905fbd873c697e0b1ede605a5 # frozen: v2.11.4
     hooks:
       - id: golangci-lint-full
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.99.5
+    rev: c0f51014b8ec51c4455a7dac40697be15e285668 # frozen: v1.99.5
     hooks:
       - id: terraform_fmt
         name: terraform-fmt
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # frozen: v6.0.0
     hooks:
       - id: no-commit-to-branch
         name: no-commit-to-main
         args: ['--branch', 'main']
 
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.12
+    rev: 914e7df21a07ef503a81201c76d2b11c789d3fca # frozen: v1.7.12
     hooks:
       - id: actionlint
         name: lint-github-actions
 
   - repo: https://github.com/golangci/misspell
-    rev: v0.6.0
+    rev: 528d713e620bdf4b41849db93cb489c4fef9f5c5 # frozen: v0.6.0
     hooks:
       - id: misspell
         exclude: |


### PR DESCRIPTION
Clears code scanning alert #15 (zizmor `archived-uses`) and hardens the pre-commit supply chain.

## What/Why

Two things, config-only:

1. Replace the **archived** `dnephin/pre-commit-golang` go hooks (`go-fmt`, `go-imports`, `go-mod-tidy`) with the maintained `TekWizely/pre-commit-golang` fork, which exposes the same hook ids. This is what alert #15 flags.
2. Pin **every** third-party pre-commit hook to a full commit SHA, keeping the human-readable tag in a `# frozen:` comment. A mutable tag can be re-pointed by a compromised maintainer; this repo already pins its GitHub Actions by SHA, so this closes the same gap for the pre-commit layer.

No version bumps: each SHA is the exact commit the current tag points to, so hook behavior is unchanged.

## Due diligence: TekWizely/pre-commit-golang

Because we are adopting a new upstream, we vetted it before pinning:

- **Not a GitHub fork of the archived repo.** It is a standalone, from-scratch rewrite and the de-facto maintained successor to `dnephin/pre-commit-golang` (which is archived and read-only). Same hook ids, so the swap is drop-in.
- **Maintained and reputable.** MIT licensed, ~370 stars, active commit history and tagged releases.
- **Scripts read line by line.** The `go-fmt`/`go-imports`/`go-mod-tidy` hooks are thin wrappers around `gofmt -l -d`, `goimports -l -d`, and `go mod tidy`. No curl/wget/network calls, no `eval`, no remote code execution, no writes outside the repo.
- **Pinned to an immutable SHA** (`f298c08…` = `v1.0.0-rc.4`), so even a future upstream compromise cannot alter what we run without a visible PR to bump the pin.

## Proof it works

`pre-commit validate-config` passes. Ran `trailing-whitespace`, `check-yaml`, `go-fmt`, `terraform_fmt`, `actionlint`, and `misspell` across the whole tree at their pinned SHAs, all passed with zero reformatting. (`golangci-lint-full` runs in CI; skipped locally due to an unrelated go1.27-vs-go1.26 toolchain panic.)

## Risk + AI role

low -- config-only, no version bumps, no runtime or CI-behavior change. AI-assisted; human-directed and human-reviewed.

## Review focus

Whether pinning TekWizely at its release-candidate (`v1.0.0-rc.4`) is acceptable versus waiting for a stable tag, and that the frozen tags in comments match the pinned SHAs.
